### PR TITLE
Change some default ace settings

### DIFF
--- a/addons/aceSettings/$PBOPREFIX$
+++ b/addons/aceSettings/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\potato\addons\aceSettings

--- a/addons/aceSettings/config.cpp
+++ b/addons/aceSettings/config.cpp
@@ -1,0 +1,43 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"potato_core", "ace_laserPointer", "ace_map", "ace_zeus", "ace_hearing", "ace_overheating"};
+        author[] = {"PabstMirror"};
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+
+// ACE Settings: (see http://forums.bourbonwarfare.site.nfoservers.com/viewtopic.php?f=8&t=2026)
+class ACE_Settings {
+    //Daylight laser pointer:
+    class ace_laserPointer_enabled {
+        typeName = "BOOL";
+        value = 0;
+    };
+    class ace_map_DefaultChannel {//ACE 3.4.0 - https://github.com/acemod/ACE3/pull/2650
+        typeName = "NUMBER";
+        value = 1; //SIDE
+    };
+    class ace_zeus_autoAddObjects {
+        typeName = "BOOL";
+        value = 1;
+    };
+    class ace_hearing_autoAddEarplugsToUnits {
+        typeName = "BOOL";
+        value = 0;
+    };
+    class ace_overheating_unJamOnreload { //Normal (R key) reload will fix jams
+        typeName = "BOOL";
+        value = 1;
+    };
+    class ace_overheating_unJamFailChance {
+        typeName = "SCALAR";
+        value = 0;
+    };
+};

--- a/addons/aceSettings/config.cpp
+++ b/addons/aceSettings/config.cpp
@@ -13,7 +13,7 @@ class CfgPatches {
 };
 
 
-// ACE Settings: (see http://forums.bourbonwarfare.site.nfoservers.com/viewtopic.php?f=8&t=2026)
+// ACE Settings: (see http://forums.bourbonwarfare.com/viewtopic.php?f=8&t=2026)
 class ACE_Settings {
     //Daylight laser pointer:
     class ace_laserPointer_enabled {

--- a/addons/aceSettings/script_component.hpp
+++ b/addons/aceSettings/script_component.hpp
@@ -1,0 +1,16 @@
+#define COMPONENT aceSettings
+#include "\z\potato\addons\core\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define CBA_DEBUG_SYNCHRONOUS
+
+#ifdef DEBUG_ENABLED_ACESETTINGS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_ACESETTINGS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_ACESETTINGS
+#endif
+
+#include "\z\potato\addons\core\script_macros.hpp"


### PR DESCRIPTION
#12

These just change the defaults but do not force (lock) the settings, so mission makers can still set to whatever they want.

If we want we can remove these from the description.ext in BWMF

Ref http://ace3mod.com/wiki/framework/settings-framework.html#load-order