### PR TITLE
Set Vehicle Ammo in 3den

### DIFF
--- a/addons/setVehicleAmmo/$PBOPREFIX$
+++ b/addons/setVehicleAmmo/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\potato\addons\setVehicleAmmo

--- a/addons/setVehicleAmmo/CfgEden.hpp
+++ b/addons/setVehicleAmmo/CfgEden.hpp
@@ -1,0 +1,77 @@
+class ctrlToolbox;
+class ctrlStatic;
+class ctrlListNBox;
+class ctrlTree;
+class ctrlXSliderH;
+
+
+class Cfg3DEN {
+    class Attributes {
+        class Default;
+        class TitleWide: Default {
+            class Controls {
+                class Title;
+            };
+        };
+        class GVAR(vehAmmoAttribute): TitleWide {
+            attributeLoad = QUOTE([ARR_2(_this, _value)] call FUNC(attributeLoad));
+            attributeSave = QUOTE([_this] call FUNC(attributeSave));
+
+            h = "(15 * 	5 + 1) * (pixelH * 	5)";
+            class Controls: Controls {
+                class Type: ctrlToolbox {
+                    idc = 100;
+                    x = "5 * (pixelW * 	5)";
+                    y = "0 * 	5 * (pixelH * 	5)";
+                    w = "(	48 + 	82 - 	5) * (pixelW * 	5)";
+                    h = "1 * 	5 * (pixelH * 	5)";
+                    rows = 1;
+                    columns = 2;
+                    strings[] = {"Default","Custom"};
+                };
+                class ListBackground: ctrlStatic {
+                    x = "5 * (pixelW * 	5)";
+                    y = "1 * 	5 * (pixelH * 	5)";
+                    w = "(	48 + 	82 - 	5) * (pixelW * 	5)";
+                    h = "13 * 	5 * (pixelH * 	5)";
+                    colorBackground[] = {1,1,1,0.1};
+                };
+                class List: ctrlTree {
+                    idc = 101;
+                    x = "5 * (pixelW * 	5)";
+                    y = "1 * 	5 * (pixelH * 	5)";
+                    w = "(	48 + 	82 - 	5) * (pixelW * 	5)";
+                    h = "13 * 	5 * (pixelH * 	5)";
+                };
+                class ammoSlider: ctrlXSliderH {
+                    idc = 102;
+                    x = "5 * (pixelW * 	5)";
+                    y = "14 * 	5 * (pixelH * 	5)";
+                    w = "(	48 + 	82 - 	5) * (pixelW * 	5)";
+                    h = "1 * 	5 * (pixelH * 	5)";
+                };
+            };
+        };
+    };
+
+    class Object {
+        class AttributeCategories {
+            class ADDON {
+                displayName = "POTATO: Set Vehicle Ammo";
+                collapsed = 1;
+                class Attributes {
+                    class ADDON {
+                        displayName = "Set Vehicle Ammo";
+                        tooltip = "";
+                        property = QGVAR(vehAmmoAttribute);
+                        control = QGVAR(vehAmmoAttribute);
+                        defaultValue = "";
+                        typeName = "STRING";
+                        expression = QUOTE([ARR_2(_this,_value)] call FUNC(initVehicle));
+                        condition = "objectVehicle";
+                    };
+                };
+            };
+        };
+    };
+};

--- a/addons/setVehicleAmmo/CfgEventHandlers.hpp
+++ b/addons/setVehicleAmmo/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/setVehicleAmmo/XEH_postInit.sqf
+++ b/addons/setVehicleAmmo/XEH_postInit.sqf
@@ -1,0 +1,1 @@
+#include "script_component.hpp"

--- a/addons/setVehicleAmmo/XEH_preInit.sqf
+++ b/addons/setVehicleAmmo/XEH_preInit.sqf
@@ -1,0 +1,15 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP(attributeLoad);
+PREP(attributeSave);
+PREP(initVehicle);
+
+xx = {
+    PREP(attributeLoad);
+    PREP(attributeSave);
+    PREP(initVehicle);
+};
+
+ADDON = true;

--- a/addons/setVehicleAmmo/XEH_preInit.sqf
+++ b/addons/setVehicleAmmo/XEH_preInit.sqf
@@ -6,10 +6,4 @@ PREP(attributeLoad);
 PREP(attributeSave);
 PREP(initVehicle);
 
-xx = {
-    PREP(attributeLoad);
-    PREP(attributeSave);
-    PREP(initVehicle);
-};
-
 ADDON = true;

--- a/addons/setVehicleAmmo/config.cpp
+++ b/addons/setVehicleAmmo/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"potato_core", "3den"};
+        author[] = {"PabstMirror"};
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEden.hpp"
+#include "CfgEventHandlers.hpp"

--- a/addons/setVehicleAmmo/functions/fnc_attributeLoad.sqf
+++ b/addons/setVehicleAmmo/functions/fnc_attributeLoad.sqf
@@ -1,0 +1,220 @@
+#include "script_component.hpp"
+
+params ["_control", "_loadoutValue"];
+TRACE_2("params",_control ,_loadoutValue);
+
+GVAR(turretMagsArray) = [];
+GVAR(defaultLoad) = [];
+GVAR(deltaLoad) = [];
+GVAR(selectedTurretPath) = [];
+GVAR(selectedTreePath) = [];
+GVAR(selectedMagazine) = "";
+
+
+//Parse string into a delta loadout array:
+if (_loadoutValue isEqualTo true) then {_loadoutValue = ""}; //why?
+if (_loadoutValue != "") then {
+    _loadoutValue = call compile _loadoutValue;
+    if (_loadoutValue isEqualType []) then {
+        GVAR(deltaLoad) = _loadoutValue;
+    };
+};
+
+private _entity = (get3DENSelected "object") select 0;
+TRACE_2("",_entity,typeOf _entity);
+
+private _enableLBChangedEH = {
+    params ["_control", "_selection"];
+    TRACE_2("lbChanged eh",_control,_selection);
+    if (_selection == 0) then {
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) ctrlEnable false;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) ctrlSetFade 0.5;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) ctrlCommit 0;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlEnable false;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlSetFade 0.5;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlCommit 0;
+    } else {
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) ctrlEnable true;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) ctrlSetFade 0;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) ctrlCommit 0;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlEnable true;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlSetFade 0;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlCommit 0;
+    };
+};
+(_control controlsGroupCtrl 100) ctrlAddEventHandler ["ToolboxSelChanged", _enableLBChangedEH];
+
+if (GVAR(deltaLoad) isEqualTo []) then {
+    (_control controlsGroupCtrl 100) lbSetCurSel 0;
+    ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) ctrlEnable false;
+    ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) ctrlSetFade 0.5;
+    ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) ctrlCommit 0;
+    ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlEnable false;
+    ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlSetFade 0.5;
+    ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlCommit 0;
+
+} else {
+    (_control controlsGroupCtrl 100) lbSetCurSel 1;
+};
+
+private _treeSelChangedEH = {
+    params ["_control", "_newPath"];
+    TRACE_2("lbChanged eh",_control,_newPath);
+
+    private _mag = GVAR(turretMagsArray);
+    private _path = [];
+    {
+        _mag = _mag select _x;
+        if (_forEachIndex == 0) then {
+            _path = _mag select 0;
+            _mag = _mag select 1;
+        };
+    } forEach _newPath;
+    TRACE_1("",_mag);
+
+    if (_mag isEqualType "") then {
+        GVAR(selectedTurretPath) = _path;
+        GVAR(selectedMagazine) = _mag;
+        GVAR(selectedTreePath) = _newPath;
+        private _magCount = 0;
+        {
+            _x params ["_xPath", "_xMag", "_xCount"];
+            if ((_xPath isEqualTo GVAR(selectedTurretPath)) && {_xMag == GVAR(selectedMagazine)}) exitwith {
+                _magCount = _xCount;
+            };
+        } forEach GVAR(defaultLoad);
+        {
+            _x params ["_xPath", "_xMag", "_xCount"];
+            if ((_xPath isEqualTo GVAR(selectedTurretPath)) && {_xMag == GVAR(selectedMagazine)}) exitwith {
+                _magCount = _magCount + _xCount;
+            };
+        } forEach GVAR(deltaLoad);
+
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) sliderSetRange [0, 10];
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) sliderSetPosition _magCount;
+
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlEnable true;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlSetFade 0;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlCommit 0;
+    } else {
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlEnable false;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlSetFade 1;
+        ((ctrlParentControlsGroup _control) controlsGroupCtrl 102) ctrlCommit 0;
+    };
+};
+(_control controlsGroupCtrl 101) ctrlAddEventHandler ["TreeSelChanged", _treeSelChangedEH];
+
+private _sliderChangedEH = {
+    params ["_control", "_sliderValue"];
+    TRACE_2("lbChanged eh",_control,_sliderValue);
+
+    _sliderValue = (round (_sliderValue * 10)) / 10;
+
+    private _defaultCount = 0;
+    {
+        _x params ["_xPath", "_xMag", "_xCount"];
+        if ((_xPath isEqualTo GVAR(selectedTurretPath)) && {_xMag == GVAR(selectedMagazine)}) exitwith {
+            _defaultCount = _xCount;
+        };
+    } forEach GVAR(defaultLoad);
+
+    private _delta = _sliderValue - _defaultCount;
+    private _found = false;
+    {
+        _x params ["_xPath", "_xMag", "_xCount"];
+        if ((_xPath isEqualTo GVAR(selectedTurretPath)) && {_xMag == GVAR(selectedMagazine)}) exitwith {
+            _found = true;
+            _x set [2, _delta];
+        };
+    } forEach GVAR(deltaLoad);
+    if (!_found) then {
+        GVAR(deltaLoad) pushBack [GVAR(selectedTurretPath), GVAR(selectedMagazine), _delta];
+    };
+
+    TRACE_3("",_delta,GVAR(selectedMagazine),GVAR(selectedTreePath));
+
+    private _rounds = round (_sliderValue * getNumber (configFile >> "CfgMagazines" >> GVAR(selectedMagazine) >> "count"));
+    private _text = format ["%1 [%2x = %3rnds]", GVAR(selectedMagazine), _sliderValue, _rounds];
+    ((ctrlParentControlsGroup _control) controlsGroupCtrl 101) tvSetText [GVAR(selectedTreePath), _text];
+};
+(_control controlsGroupCtrl 102) ctrlAddEventHandler ["SliderPosChanged", _sliderChangedEH];
+
+
+private _config = configFile >> "CfgVehicles" >> (typeOf _entity);
+private _turrets = allTurrets _entity;
+TRACE_1("",_turrets);
+
+
+private _addWeaponSystem = {
+    params ["_config", "_path", "_name"];
+    private _weapons = getArray (_config >> "weapons");
+    private _magazines = getArray (_config >> "magazines");
+    TRACE_3("",_weapons,_magazines,_config);
+    if (_weapons isEqualTo []) exitWith {};
+
+    {
+        _magToAdd = _x;
+        _found = false;
+        {
+            _x params ["_xPath", "_xMag", "_xCount"];
+            if ((_xPath isEqualTo _path) && {_xMag == _magToAdd}) exitwith {
+                _found = true;
+                _x set [2, (_xCount + 1)];
+            };
+        } forEach GVAR(defaultLoad);
+        if (!_found) then {
+            GVAR(defaultLoad) pushBack [_path, _magToAdd, 1];
+        };
+    } forEach _magazines;
+
+    private _tvIndexTurret = (_control controlsGroupCtrl 101) tvAdd [ [], _name];
+    (_control controlsGroupCtrl 101) tvExpand [_tvIndexTurret];
+
+    private _index = GVAR(turretMagsArray) pushBack [_path, []];
+
+    {
+        private _weapon = _x;
+        private _muzzles = getArray (configFile >> "CfgWeapons" >> _weapon >> "muzzles");
+        private _weaponMagazines = getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines");
+
+        ((GVAR(turretMagsArray) select _index) select 1) pushBack _weaponMagazines;
+
+        {
+            if (_x != "this") then {
+                _weaponMagazines append (getArray (configFile >> "CfgWeapons" >> _weapon >> _x >> "magazines"));
+            };
+            false
+        } count _muzzles;
+
+        private _tvIndexWeapon = (_control controlsGroupCtrl 101) tvAdd [[_tvIndexTurret], _x];
+        (_control controlsGroupCtrl 101) tvExpand [_tvIndexTurret, _tvIndexWeapon];
+        {
+            _magToAdd = _x;
+            private _magCount = 0;
+            {
+                _x params ["_xPath", "_xMag", "_xCount"];
+                if ((_xPath isEqualTo _path) && {_xMag == _magToAdd}) exitwith {
+                    _magCount = _xCount;
+                };
+            } forEach GVAR(defaultLoad);
+            {
+                _x params ["_xPath", "_xMag", "_xCount"];
+                if ((_xPath isEqualTo _path) && {_xMag == _magToAdd}) exitwith {
+                    _magCount = _xCount;
+                };
+            } forEach GVAR(deltaLoad);
+
+            private _rounds = round (_magCount * getNumber (configFile >> "CfgMagazines" >> _magToAdd >> "count"));
+            private _text = format ["%1 [%2x = %3rnds]", _magToAdd, _magCount, _rounds];
+            (_control controlsGroupCtrl 101) tvAdd [[_tvIndexTurret, _tvIndexWeapon], _text];
+        } forEach _weaponMagazines;
+    } forEach _weapons;
+};
+
+[_config, [-1], "Pilot"] call _addWeaponSystem;
+
+{
+    _turretConfig = [_config, _x] call ace_common_fnc_getTurretConfigPath;
+    TRACE_2("",_x,_turretConfig);
+    [_turretConfig, _x, (format ["Turret %1", _x])] call _addWeaponSystem;
+} forEach _turrets;

--- a/addons/setVehicleAmmo/functions/fnc_attributeSave.sqf
+++ b/addons/setVehicleAmmo/functions/fnc_attributeSave.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+
+params ["_control"];
+TRACE_1("params",_control);
+
+_return = "";
+
+if ((lbCurSel(_control controlsGroupCtrl 100)) == 0) exitWith {
+    TRACE_1("lb set to default",_return);
+    _return
+};
+
+
+private _output = [];
+{
+    TRACE_1("x:",_x);
+    _x params ["_xPath", "_xMag", "_xCount"];
+    if (_xCount != 0) then {
+        _output pushBack _x;
+    };
+} forEach GVAR(deltaLoad);
+
+private _return = (str _output);
+TRACE_2("",count _output,_return);
+_return

--- a/addons/setVehicleAmmo/functions/fnc_initVehicle.sqf
+++ b/addons/setVehicleAmmo/functions/fnc_initVehicle.sqf
@@ -1,0 +1,35 @@
+#include "script_component.hpp"
+
+params ["_vehicle", "_loadoutValue"];
+TRACE_2("params",_vehicle,_loadoutValue);
+
+if (!(_loadoutValue isEqualType "")) exitWith {TRACE_1("not string",_loadoutValue)};
+if (_loadoutValue == "") exitWith {TRACE_1("default",_loadoutValue);};
+_loadoutValue = call compile _loadoutValue;
+if (!(_loadoutValue isEqualType [])) exitWith {TRACE_1("not array",_loadoutValue)};
+
+TRACE_1("",_loadoutValue);
+TRACE_3("veh",typeOf _vehicle,local _vehicle,magazines _vehicle);
+
+{
+    _x params ["_xPath", "_xMag", "_xCount"];
+    while {_xCount < 0} do {
+        _vehicle removeMagazineTurret [_xMag, _xPath];
+        TRACE_2("removing",_xMag,_xPath);
+        _xCount = _xCount + 1;
+    };
+    while {_xCount > 0} do {
+        if (_xCount >= 1) then {
+            _vehicle addMagazineTurret [_xMag, _xPath];
+            TRACE_2("adding full",_xMag,_xPath);
+            _xCount = _xCount - 1;
+        } else {
+            private _rounds = floor (_xCount * getNumber (configFile >> "CfgMagazines" >> _xMag >> "count"));
+            _vehicle addMagazineTurret [_xMag, _xPath, _rounds];
+            TRACE_3("adding partial",_xMag,_xPath,_rounds);
+            _xCount = 0;
+        };
+    };
+} forEach _loadoutValue;
+
+TRACE_1("veh",magazines _vehicle);

--- a/addons/setVehicleAmmo/functions/script_component.hpp
+++ b/addons/setVehicleAmmo/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\potato\addons\setVehicleAmmo\script_component.hpp"

--- a/addons/setVehicleAmmo/script_component.hpp
+++ b/addons/setVehicleAmmo/script_component.hpp
@@ -1,0 +1,16 @@
+#define COMPONENT setVehicleAmmo
+#include "\z\potato\addons\core\script_mod.hpp"
+
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
+#define CBA_DEBUG_SYNCHRONOUS
+
+#ifdef DEBUG_ENABLED_SETVEHICLEAMMO
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_SETVEHICLEAMMO
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_SETVEHICLEAMMO
+#endif
+
+#include "\z\potato\addons\core\script_macros.hpp"


### PR DESCRIPTION
Close #2

Allows changing vehicle magazine counts via 3den interface.
So not it's easy to do stuff like limit the mortar to just flares.

It can be a little cluttered because it shows all magazines the weapon is capable of firing (3 different tracer colors for each ammo type), we could limit it to just default magazines.

![image](https://cloud.githubusercontent.com/assets/9376747/14405469/4510aac4-fe55-11e5-9a52-e94a27328221.png)
