### PR TITLE
Briefings - Add support for 1.58 multiline input

### DIFF
--- a/addons/briefing/CfgEden.hpp
+++ b/addons/briefing/CfgEden.hpp
@@ -88,7 +88,7 @@ class Cfg3DEN {
 
     class Mission {
         class GVAR(briefings) {// Custom section class, everything inside will be opened in one window
-            displayName = "Side Briefings (<br/> for newLine)"; // Text visible in the window title as "Edit <displayName>"
+            displayName = "Side Briefings (SHIFT + Enter to add a new line)"; // Text visible in the window title as "Edit <displayName>"
             display = "Display3DENEditAttributes"; // Optional - display for attributes window. Must have the same structure and IDCs as the default Display3DENEditAttributes
             class AttributeCategories {
                 class WestBriefing {

--- a/addons/briefing/XEH_PREP.hpp
+++ b/addons/briefing/XEH_PREP.hpp
@@ -3,4 +3,5 @@ TRACE_1("",QUOTE(ADDON));
 PREP(addBriefingToUnit);
 PREP(addCredits);
 PREP(addOrbat);
+PREP(convertNewLineToHTML);
 PREP(setBriefingVar);

--- a/addons/briefing/XEH_postInit.sqf
+++ b/addons/briefing/XEH_postInit.sqf
@@ -6,17 +6,12 @@ if (hasInterface) then {
         systemChat "You have been assigned zeus";
         private _zeusIntent = getMissionConfigValue [QGVAR(zeusIntent), ""];
         if (_zeusIntent == "") exitWith {};
+
+        _zeusIntent = [_zeusIntent] call FUNC(convertNewLineToHTML);
         systemChat "Mission has custom zeus briefing";
         _unit createDiaryRecord ["diary", ["Zeus",_zeusIntent]];
     }] call ACEFUNC(common,addEventHandler);
 
-    if (!isNull player) then {
-        [{
-            ACEGVAR(common,settingsInitFinished) && {diag_tickTime > (_this select 1)}
-        }, {
-            [_this select 0] call FUNC(addBriefingToUnit);
-        }, [player, diag_tickTime + 1]] call CBA_fnc_waitUntilAndExecute;
-    };
     ["playerChanged", {
         TRACE_1("playerChanged eh",ace_player);
         [{

--- a/addons/briefing/functions/fnc_addBriefingToUnit.sqf
+++ b/addons/briefing/functions/fnc_addBriefingToUnit.sqf
@@ -48,6 +48,12 @@ case (civilian):{
 
 TRACE_5("",count _sideBriefAdministration,count _sideBriefMission,count _sideBriefSituation,count _groupBrief,count _playerBrief);
 
+_sideBriefAdministration = [_sideBriefAdministration] call FUNC(convertNewLineToHTML);
+_sideBriefMission = [_sideBriefMission] call FUNC(convertNewLineToHTML);
+_sideBriefSituation = [_sideBriefSituation] call FUNC(convertNewLineToHTML);
+_groupBrief = [_groupBrief] call FUNC(convertNewLineToHTML);
+_playerBrief = [_playerBrief] call FUNC(convertNewLineToHTML);
+
 if (_sideBriefAdministration != "") then {
     _newPlayer createDiaryRecord ["diary", ["Administration",_sideBriefAdministration]];
 };

--- a/addons/briefing/functions/fnc_convertNewLineToHTML.sqf
+++ b/addons/briefing/functions/fnc_convertNewLineToHTML.sqf
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+params ["_input"];
+
+private _out = [];
+
+{
+    if (_x != 10) then {
+        _out pushBack _x;
+    } else {
+        _out append (toArray "<br/>");
+    };
+    nil
+} count (toArray _input);
+
+(toString _out)


### PR DESCRIPTION
Can just hit Shift+Enter to insert new lines in the eden briefing editor