### PR TITLE
Safestart updates

### DIFF
--- a/addons/safeStart/XEH_postInit.sqf
+++ b/addons/safeStart/XEH_postInit.sqf
@@ -1,5 +1,15 @@
 #include "script_component.hpp"
 
+[
+    {
+        ACEGVAR(common,settingsInitFinished) && {diag_tickTime > (_this select 0)}
+    }, {
+        if (GVAR(enabled)) then {
+            [] call FUNC(makeSafe);
+        };
+    }, [diag_tickTime + 1]
+] call CBA_fnc_waitUntilAndExecute;
+
 [] spawn {
     sleep 1;
 

--- a/addons/safeStart/config.cpp
+++ b/addons/safeStart/config.cpp
@@ -24,4 +24,8 @@ class ACE_Settings {
         value = 1;
         isClientSettable = 1;
     };
+    class GVAR(enabled) {
+        typeName = "BOOL";
+        value = 0;
+    };
 };

--- a/addons/safeStart/gui_safeStart.hpp
+++ b/addons/safeStart/gui_safeStart.hpp
@@ -12,8 +12,8 @@ class RscTitles {
         class controls {
             class safeStartHint: RscStructuredText {
                 idc = 1100;
-                x = 0.4 * safezoneW + safezoneX;
-                y = 0.4 * safezoneH + safezoneY;
+                x = 0 * safezoneW + safezoneX;
+                y = 0.05 * safezoneH + safezoneY;
                 w = 0.2 * safezoneW;
                 h = 0.2 * safezoneH;
             };


### PR DESCRIPTION
Resolves #7 and will allow us to activate safestart using ACE_Settings instead of calling the old pabst function from the init.sqf