### PR TITLE
Force STHUD to be configured through ACE settings instead of the built in UI

### DIFF
--- a/addons/sthud/ACE_Settings.hpp
+++ b/addons/sthud/ACE_Settings.hpp
@@ -1,0 +1,17 @@
+class ACE_Settings {
+    class GVAR(stHudMode) {
+        category = "ST HUD";
+        displayName = "ST HUD Mode";
+        typeName = "SCALAR";
+        value = 3;
+        values[] = {"OFF", "HUD Only", "Names Only", "Normal"};
+        isClientSettable = 1;
+    };
+    class GVAR(stHudCompass) {
+        category = "ST HUD";
+        displayName = "ST HUD Compass";
+        typeName = "BOOL";
+        value = 1;
+        isClientSettable = 1;
+    };
+};

--- a/addons/sthud/CfgEventHandlers.hpp
+++ b/addons/sthud/CfgEventHandlers.hpp
@@ -1,0 +1,5 @@
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        clientInit = QUOTE(call COMPILE_FILE(XEH_clientPostInit));
+    };
+};

--- a/addons/sthud/XEH_clientPostInit.sqf
+++ b/addons/sthud/XEH_clientPostInit.sqf
@@ -1,0 +1,45 @@
+#include "script_component.hpp"
+
+LOG("In Post init");
+
+if (!hasInterface) exitWith {};
+
+// disable STHUD menu, if it exists
+if (isClass (configFile >> "CfgPatches" >> "ST_STHud_Usermenu")) then {
+    LOG("ST Options mod found, waiting on function def");
+    [
+        {!(isNil "fn_sthud_usermenu_changeMode")},
+        {
+            LOG("ST Options function found, stubbing");
+            fn_sthud_usermenu_changeMode = { WARNING("fn_sthud_usermenu_changeMode called, but ignored"); };
+        }
+    ] call CBA_fnc_waitUntilAndExecute
+};
+
+// wait for settings
+["ace_settingsInitialized", {
+    // set original value
+    [
+        {!isNil "STUI_Save_SupervisorH"},
+        {
+            ST_STHud_ShownUI = GVAR(stHudMode);
+            ST_STHud_ShowCompass = GVAR(stHudCompass);
+            [] call ST_STHud_UpdateUI;
+        }
+    ] call CBA_fnc_waitUntilAndExecute;
+
+
+    // On changing settings, update the view
+    ["ace_settingChanged", {
+        TRACE_1("params", _this);
+        params ["_name","_value"];
+
+        if (_name == QGVAR(stHudMode)) exitWith {
+            ST_STHud_ShownUI = _value;
+            [] call ST_STHud_UpdateUI;
+        };
+        if (_name == QGVAR(stHudCompass)) exitWith {
+            ST_STHud_ShowCompass = _value;
+        };
+    }] call CBA_fnc_addEventHandler;
+}] call CBA_fnc_addEventHandler;

--- a/addons/sthud/config.cpp
+++ b/addons/sthud/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"potato_core","ST_STHud"};
+        author = "Potato";
+        authors[] = {"AACO"};
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "ACE_Settings.hpp"
+#include "CfgEventHandlers.hpp"

--- a/addons/sthud/script_component.hpp
+++ b/addons/sthud/script_component.hpp
@@ -1,0 +1,16 @@
+#define COMPONENT sthud
+#include "\z\potato\addons\core\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define CBA_DEBUG_SYNCHRONOUS
+
+#ifdef DEBUG_ENABLED_STHUD
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_STHUD
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_STHUD
+#endif
+
+#include "\z\potato\addons\core\script_macros.hpp"


### PR DESCRIPTION
Disable STHUD menu
Move settings to client settable ACE Settings (allows mission makers to force HUD modes)
Resolves #61

Note to @PabstMirror , if you want to build this as an ACE Compat PBO, you should just need to localize the setting strings. I wanted to entirely disable the STHUD menu's keybinding but the way they have it set up doesn't provide a good way to go that route. We could always just drop the STHUD menu PBO if this gets added.

More general note: I should probably set something up similarly for Apex HUD, but I still got some time there.

Assigned to @zerithsmash and @PabstMirror to discuss if this is something we even want to do.