### PR TITLE
Fix markers being shown for empty groups

### DIFF
--- a/addons/markers/XEH_postInit.sqf
+++ b/addons/markers/XEH_postInit.sqf
@@ -30,7 +30,7 @@ LOG("Post init start");
                     params ["_newPlayer", "_oldPlayer"];
 
                     if (side _newPlayer != side _oldPlayer) then {
-                        GVAR(markerHash) = [[],[]];
+                        GVAR(drawHash) = [[],[]];
                         [] call FUNC(initMarkerHash);
                     };
 

--- a/addons/markers/functions/fnc_addMarkerInfoToHash.sqf
+++ b/addons/markers/functions/fnc_addMarkerInfoToHash.sqf
@@ -32,6 +32,7 @@ private _texture = _drawObject getVariable [QGVAR(markerTexture), DEFAULT_MARKER
 private _colorArray = _drawObject getVariable [QGVAR(markerColor), DEFAULT_MARKER_COLOR];
 private _size = _drawObject getVariable [QGVAR(markerSize), DEFAULT_MARKER_SIZE];
 private _position = if (_drawObject isEqualType grpNull) then {
+    if ((units _drawObject) isEqualTo []) exitWith {[-10000, -10000, 0]};
     position (leader _drawObject)
 } else {
     position _drawObject

--- a/addons/markers/functions/fnc_drawMarkers.sqf
+++ b/addons/markers/functions/fnc_drawMarkers.sqf
@@ -36,10 +36,11 @@ if (GVAR(groupAndUnitEnabled)) then {
         if (_recalc) then {
             private _drawObject = (GVAR(drawHash) select 0) select _forEachIndex;
             if !(isNull _drawObject) then {
-                _position = if (_drawObject isEqualType grpNull) then {
-                    position (leader _drawObject);
+                if (_drawObject isEqualType grpNull) then {
+                    if (isNull (leader _drawObject)) exitWith {};
+                    _position = position (leader _drawObject);
                 } else {
-                    position _drawObject;
+                    _position = position _drawObject;
                 };
                 _x set [4, _position];
             };


### PR DESCRIPTION
The game seems to still create all groups even if they are not slotted.
So markers is adding markers for all groups and draws icons at [0,0,0]
This just moves them out of the way.

Example, running bwmf with no AI and just me slotted:
![20160902222731_1](https://cloud.githubusercontent.com/assets/9376747/18222460/c907cf80-715d-11e6-9fad-da82e1c76869.jpg)