### PR TITLE
Misc fixes to misc fixes

### DIFF
--- a/addons/miscFixes/CfgMagazines.hpp
+++ b/addons/miscFixes/CfgMagazines.hpp
@@ -1,0 +1,9 @@
+class CfgMagazines {
+    class CA_LauncherMagazine;
+    class rhs_mag_smaw_HEAA: CA_LauncherMagazine {
+        mass = 80;
+    };
+    class rhs_mag_smaw_HEDP: CA_LauncherMagazine {
+        mass = 65;
+    };
+};

--- a/addons/miscFixes/CfgVehicles.hpp
+++ b/addons/miscFixes/CfgVehicles.hpp
@@ -1,0 +1,25 @@
+class CfgVehicles {
+    // Add SMAW box
+    class Box_NATO_Support_F;
+    class GVAR(smawBox): Box_NATO_Support_F {
+        scope = 1;
+        displayName = "SMAW Weapon Box";
+        transportMaxWeapons = 9001;
+        transportMaxMagazines = 9001;
+        transportMaxItems = 9001;
+        maximumload = 1000;
+
+        class TransportWeapons {
+            MACRO_ADDWEAPON(rhs_weap_smaw,1);
+        };
+        class TransportMagazines {
+            MACRO_ADDMAGAZINE(rhs_mag_smaw_HEAA,10);
+            MACRO_ADDMAGAZINE(rhs_mag_smaw_HEDP,10);
+            MACRO_ADDMAGAZINE(rhs_mag_smaw_SR,8);
+        };
+        class TransportItems {
+            MACRO_ADDITEM(rhs_weap_optic_smaw,1);
+        };
+        class TransportBackpacks {};
+    };
+};

--- a/addons/miscFixes/CfgWeapons.hpp
+++ b/addons/miscFixes/CfgWeapons.hpp
@@ -1,0 +1,60 @@
+class CfgWeapons {
+    // Add invisible NVGs for AI purposes
+    class NVGoggles;
+    class potato_fakeNVG: NVGoggles {
+        author = "PabstMirror";
+        modelOptics = QUOTE(PATHTOF(models\plotNVGs));
+        model = "\A3\weapons_f\empty";
+        displayName = "Fake NVGs (AI Only)";
+        descriptionShort = "[Plot Googles] Do not attempt to use as a player, only to allow AI to have better vision";
+        class ItemInfo {
+            type = 616;
+            hmdType = 0;
+            uniformModel = "\A3\weapons_f\empty";
+            modelOff = "\A3\weapons_f\empty";
+            mass = 20;
+        };
+    };
+
+    // create lighter SMAWs for playability
+    class Launcher;
+    class Launcher_Base_F: Launcher {
+        class WeaponSlotsInfo;
+    };
+    class rhs_weap_smaw : Launcher_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 70;
+        };
+    };
+
+    // Manually list all mags for HLC/RHS compat
+    class rhs_weap_ak74m;
+    class rhs_weap_akm : rhs_weap_ak74m {
+        magazines[] = {"rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer", "rhs_30Rnd_762x39mm_89", "rhs_30Rnd_762x39mm_U", "hlc_30Rnd_762x39_b_ak", "hlc_30Rnd_762x39_t_ak", "hlc_45Rnd_762x39_m_rpk", "HLC_45rnd_762x39_T_RPK", "hlc_30rnd_762x39_s_ak"};
+    };
+
+    // shim the bugged uniform
+    class InventoryItem_Base_F;
+    class UniformItem: InventoryItem_Base_F {
+        type = 801;
+    };
+
+    class Uniform_Base;
+    class U_Afghan06: Uniform_Base {
+        author = "EricJ";
+        scope = 2;
+        displayName = "Afghan Clothes 6";
+        picture = "\A3\characters_f\data\ui\icon_U_Citizen_ca.paa";
+        model = "\Taliban_Fighters\Uniforms\Afghan_06NH.p3d";
+        hiddenSelections[] = {"camo"};
+        hiddenSelectionsTextures[] = {"Taliban_Fighters\data\tak_civil06_1_co.paa"};
+        class ItemInfo: UniformItem {
+            uniformModel = "-";
+            uniformClass = "TBan_Fighter6NH";
+            armor = 0;
+            passThrough = 1;
+            containerClass = "Supply30";
+            mass = 30;
+        };
+    };
+};

--- a/addons/miscFixes/config.cpp
+++ b/addons/miscFixes/config.cpp
@@ -7,123 +7,26 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"potato_core", "mbg_celle2", "ace_ui", "rhs_c_weapons", "Taliban_fighters"};
         author = "Potato";
-        authors[] = {"PabstMirror"};
+        authors[] = {"PabstMirror", "AACO"};
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
         VERSION_CONFIG;
     };
 };
 
-
-//Fix CELLE font error:
+// Fix CELLE font error:
 class CfgLocationTypes {
     class MBG_celle2_icon_A7 {
         font = "PuristaMedium";
     };
 };
 
-//Undo ACE's changes to system messages text brightness
+// Undo ACE's changes to system messages text brightness
 class RscChatListDefault {
     colorMessageProtocol[] = {0.65,0.65,0.65,1};
 };
 
-class CfgVehicles {
-    class LandVehicle;
-    class StaticWeapon: LandVehicle {
-        insideSoundCoef = 0; //ACRE uses this for vehicle sound attenuation (makes it easy to hear mortar gunners)
-    };
-
-    class Box_NATO_Support_F;
-    class GVAR(smawBox): Box_NATO_Support_F {
-        scope = 1;
-        displayName = "SMAW Weapon Box";
-        transportMaxWeapons = 9001;
-        transportMaxMagazines = 9001;
-        transportMaxItems = 9001;
-        maximumload = 1000;
-
-        class TransportWeapons {
-            MACRO_ADDWEAPON(rhs_weap_smaw,1);
-        };
-        class TransportMagazines {
-            MACRO_ADDMAGAZINE(rhs_mag_smaw_HEAA,2);
-            MACRO_ADDMAGAZINE(rhs_mag_smaw_HEDP,2);
-            MACRO_ADDMAGAZINE(rhs_mag_smaw_SR,4);
-        };
-        class TransportItems {};
-        class TransportBackpacks {};
-    };
-};
-
-
-class CfgWeapons {
-    class NVGoggles;
-    class potato_fakeNVG: NVGoggles {
-        author = "pabst";
-        modelOptics = QUOTE(PATHTOF(models\plotNVGs));
-        model = "\A3\weapons_f\empty";
-        displayName = "Fake NVGs (AI Only)";
-        descriptionShort = "[Plot Googles] Do not attempt to use as a player, only to allow AI to have better vision";
-        class ItemInfo {
-            type = 616;
-            hmdType = 0;
-            uniformModel = "\A3\weapons_f\empty";
-            modelOff = "\A3\weapons_f\empty";
-            mass = 20;
-        };
-    };
-
-    // create lighter SMAWs for playability
-    class Launcher;
-    class Launcher_Base_F: Launcher {
-        class WeaponSlotsInfo;
-    };
-    class rhs_weap_smaw : Launcher_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            mass = 70;
-        };
-    };
-
-    // Manually list all mags for HLC/RHS compat
-    class rhs_weap_ak74m;
-    class rhs_weap_akm : rhs_weap_ak74m {
-        magazines[] = {"rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer", "rhs_30Rnd_762x39mm_89", "rhs_30Rnd_762x39mm_U", "hlc_30Rnd_762x39_b_ak", "hlc_30Rnd_762x39_t_ak", "hlc_45Rnd_762x39_m_rpk", "HLC_45rnd_762x39_T_RPK", "hlc_30rnd_762x39_s_ak"};
-    };
-
-    // shim the bugged uniform
-    class InventoryItem_Base_F;
-    class UniformItem: InventoryItem_Base_F {
-        type = 801;
-    };
-
-    class Uniform_Base;
-    class U_Afghan06: Uniform_Base {
-        author = "EricJ";
-        scope = 2;
-        displayName = "Afghan Clothes 6";
-        picture = "\A3\characters_f\data\ui\icon_U_Citizen_ca.paa";
-        model = "\Taliban_Fighters\Uniforms\Afghan_06NH.p3d";
-        hiddenSelections[] = {"camo"};
-        hiddenSelectionsTextures[] = {"Taliban_Fighters\data\tak_civil06_1_co.paa"};
-        class ItemInfo: UniformItem {
-            uniformModel = "-";
-            uniformClass = "TBan_Fighter6NH";
-            armor = 0;
-            passThrough = 1;
-            containerClass = "Supply30";
-            mass = 30;
-        };
-    };
-};
-
-class CfgMagazines {
-    class CA_LauncherMagazine;
-    class rhs_mag_smaw_HEAA: CA_LauncherMagazine {
-        mass = 80;
-    };
-    class rhs_mag_smaw_HEDP: CA_LauncherMagazine {
-        mass = 65;
-    };
-};
-
 #include "CfgEden.hpp"
 #include "CfgEventHandlers.hpp"
+#include "CfgMagazines.hpp"
+#include "CfgVehicles.hpp"
+#include "CfgWeapons.hpp"


### PR DESCRIPTION
- Removes the ACRE emplaced weapon fix (it appears to be no longer valid https://github.com/IDI-Systems/acre2/blob/master/addons/sys_attenuate/fnc_getVehicleAttenuation.sqf https://github.com/IDI-Systems/acre2/blob/master/addons/sys_attenuate/CfgVehicles.hpp )
- Updates the SMAW box to have more ammo + ranging optic.
- Separates most of the configs into their own files.