### PR TITLE
Assign Gear refactor/update

### DIFF
--- a/addons/assignGear/CfgEventHandlers.hpp
+++ b/addons/assignGear/CfgEventHandlers.hpp
@@ -12,21 +12,21 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_Init_EventHandlers {
     class CAManBase {
-        class ADDON { serverInit = QUOTE(_this call FUNC(assignGearMan)); };
+        class ADDON { serverInit = QUOTE([ARR_2(FUNC(assignGearMan),_this)] call CBA_fnc_execNextFrame); };
     };
     class Car {
-        class ADDON { serverInit  = QUOTE([ARR_2((_this select 0), 'Car')] call FUNC(assignGearVehicle);); };
+        class ADDON { serverInit = QUOTE([ARR_2(FUNC(assignGearVehicle),[ARR_2(_this select 0, 'Car')])] call CBA_fnc_execNextFrame); };
     };
     class Tank {
-        class ADDON { serverInit  = QUOTE([ARR_2((_this select 0), 'Tank')] call FUNC(assignGearVehicle);); };
+        class ADDON { serverInit = QUOTE([ARR_2(FUNC(assignGearVehicle),[ARR_2(_this select 0, 'Tank')])] call CBA_fnc_execNextFrame); };
     };
     class Helicopter {
-        class ADDON { serverInit  = QUOTE([ARR_2((_this select 0), 'Helicopter')] call FUNC(assignGearVehicle);); };
+        class ADDON { serverInit = QUOTE([ARR_2(FUNC(assignGearVehicle),[ARR_2(_this select 0, 'Helicopter')])] call CBA_fnc_execNextFrame); };
     };
     class Plane {
-        class ADDON { serverInit  = QUOTE([ARR_2((_this select 0), 'Plane')] call FUNC(assignGearVehicle);); };
+        class ADDON { serverInit = QUOTE([ARR_2(FUNC(assignGearVehicle),[ARR_2(_this select 0, 'Plane')])] call CBA_fnc_execNextFrame); };
     };
     class Ship_F {
-        class ADDON { serverInit  = QUOTE([ARR_2((_this select 0), 'Ship_F')] call FUNC(assignGearVehicle);); };
+        class ADDON { serverInit = QUOTE([ARR_2(FUNC(assignGearVehicle),[ARR_2(_this select 0, 'Ship_F')])] call CBA_fnc_execNextFrame); };
     };
 };

--- a/addons/assignGear/XEH_PREP.hpp
+++ b/addons/assignGear/XEH_PREP.hpp
@@ -1,5 +1,11 @@
 TRACE_1("",QUOTE(ADDON));
 
+PREP(addItemsToContainer);
 PREP(assignGearMan);
 PREP(assignGearVehicle);
+PREP(cleanPrefix);
+PREP(getContainerInfo);
+PREP(getLinkedIndex);
 PREP(getLoadoutFromConfig);
+PREP(getWeaponArray);
+PREP(setWeaponAttachment);

--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -8,13 +8,16 @@ GVAR(usePotato) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "usePotato"
 
 if (GVAR(usePotato)) then {
     GVAR(loadoutCache) = call CBA_fnc_createNamespace;
+    GVAR(classnameCache) = call CBA_fnc_createNamespace;
+    GVAR(weaponAttachmentCache) = call CBA_fnc_createNamespace;
 
     GVAR(allowMagnifiedOptics) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "allowMagnifiedOptics")) == 1);
     GVAR(useFallback) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "useFallback")) == 1);
-    GVAR(maxRandomization) = if (isNumber (missionConfigFile >> "CfgLoadouts" >> "maxRandomization")) then { getNumber (missionConfigFile >> "CfgLoadouts" >> "maxRandomization") } else {5};
-    GVAR(setVehicleLoadouts) = if (isNumber (missionConfigFile >> "CfgLoadouts" >> "setVehicleLoadouts")) then {getNumber (missionConfigFile >> "CfgLoadouts" >> "setVehicleLoadouts")} else {1};
+    GVAR(maxRandomization) = if (isNumber (missionConfigFile >> "CfgLoadouts" >> "maxRandomization")) then { getNumber (missionConfigFile >> "CfgLoadouts" >> "maxRandomization") } else { 5 };
+    GVAR(setVehicleLoadouts) = if (isNumber (missionConfigFile >> "CfgLoadouts" >> "setVehicleLoadouts")) then {getNumber (missionConfigFile >> "CfgLoadouts" >> "setVehicleLoadouts")} else { 1 };
+    GVAR(prefixes) = if (isArray (missionConfigFile >> "CfgLoadouts" >> "prefixes")) then { getArray (missionConfigFile >> "CfgLoadouts" >> "prefixes") } else { [] };
 
-    diag_log text format ["[POTATO-assignGear] Enabled [useFallback:%1 allowMagnifiedOptics:%2 maxRandomization:%3 setVehicleLoadouts:%4]", GVAR(useFallback), GVAR(allowMagnifiedOptics), GVAR(maxRandomization), GVAR(setVehicleLoadouts)];
+    diag_log text format ["[POTATO-assignGear] Enabled [useFallback:%1 allowMagnifiedOptics:%2 maxRandomization:%3 setVehicleLoadouts:%4, prefixes: %5]", GVAR(useFallback), GVAR(allowMagnifiedOptics), GVAR(maxRandomization), GVAR(setVehicleLoadouts), GVAR(prefixes)];
 } else {
     diag_log text format ["[POTATO-assignGear] Disabled"];
 };

--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -9,7 +9,6 @@ GVAR(usePotato) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "usePotato"
 if (GVAR(usePotato)) then {
     GVAR(loadoutCache) = call CBA_fnc_createNamespace;
     GVAR(classnameCache) = call CBA_fnc_createNamespace;
-    GVAR(weaponAttachmentCache) = call CBA_fnc_createNamespace;
 
     GVAR(allowMagnifiedOptics) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "allowMagnifiedOptics")) == 1);
     GVAR(useFallback) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "useFallback")) == 1);

--- a/addons/assignGear/functions/fnc_addItemsToContainer.sqf
+++ b/addons/assignGear/functions/fnc_addItemsToContainer.sqf
@@ -1,0 +1,94 @@
+/*
+ * Author: PabstMirror, AACO
+ * Add items to a container array (only if they have space)
+ *
+ * Arguments:
+ * 0: Array of items to add to the given container <ARRAY>
+ * 1: Array of all containers and their free space <ARRAY>
+ * 2: Index of the given container <NUMBER>
+ *
+ * Return Value:
+ * Array of items that couldn't be added to the given container <ARRAY>
+ *
+ * Example:
+ * [_configItems, _containersArray, UNIFORM_INDEX] call potato_assignGear_addItemsToContainer;
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+#define VEST_ALLOWED_SLOTS 701
+#define UNIFORM_ALLOWED_SLOTS 801
+#define BACKPACK_ALLOWED_SLOTS 901
+
+TRACE_1("params",_this);
+params ["_itemsToAddArray", "_containersArray", "_containerIndex"];
+
+// if there's no work do be done, quit early
+if (_itemsToAddArray isEqualTo []) exitWith { _itemsToAddArray };
+
+private _indexSlotNum = [UNIFORM_ALLOWED_SLOTS, VEST_ALLOWED_SLOTS, BACKPACK_ALLOWED_SLOTS] select _containerIndex; // for the "allowedSlots" check
+(_containersArray select _containerIndex) params ["_sizeLeft", ["_array", []]];
+TRACE_4("Adding Items To Container",_itemsToAddArray,_containerIndex,_sizeLeft,_array);
+
+private _returnArray = [];
+{
+    private _itemToAdd = _x;
+    private _itemLeft = [] call {
+        // exit if there's no room left in the container
+        if (_sizeLeft <= 0) exitWith { TRACE_1("no room",_itemToAdd); _itemToAdd };
+
+        (_itemToAdd splitString ":") params ["_classname", ["_amountToAdd", "1", [""]]];
+        _amountToAdd = parseNumber _amountToAdd;
+
+        if (isClass (configFile >> "CfgMagazines" >> _classname)) then {
+            [
+                getNumber (configFile >> "CfgMagazines" >> _classname >> "mass"),
+                getNumber (configFile >> "CfgMagazines" >> _classname >> "count"),
+                getArray (configFile >> "CfgMagazines" >> _classname >> "allowedSlots")
+            ]
+        } else {
+            if (isClass (configFile >> "CfgWeapons" >> _classname)) then {
+                [
+                    getNumber (configFile >> "CfgWeapons" >> _classname >> "ItemInfo" >> "mass"),
+                    -1,
+                    getArray (configFile >> "CfgWeapons" >> _classname >> "ItemInfo" >> "allowedSlots")
+                ]
+            } else {
+                [-1, -1, []]
+            }
+        } params ["_mass", "_count", "_allowedSlots"];
+
+        if (_mass < 0) exitWith {
+            diag_log text format ["[POTATO-assignGear] Item Not Found [%1]", _itemToAdd];
+            ""
+        };
+
+        if (!((_allowedSlots isEqualTo []) || {_indexSlotNum in _allowedSlots})) exitWith {
+            TRACE_3("not allowed in slot",_classname,_allowedSlots,_indexSlotNum);
+            _itemToAdd
+        };
+
+        private _ammountThatWillFit = if (_mass == 0) then { 9999 } else { floor (_sizeLeft / _mass) };
+        private _ammountAdded = _ammountThatWillFit min _amountToAdd;
+        TRACE_6("",_classname,_mass,_count,_amountToAdd,_ammountThatWillFit,_ammountAdded);
+
+        if (_ammountAdded == 0) exitWith { _itemToAdd };
+        if (_count > 0) then {
+            (_array select 1) pushBack [_classname, _ammountAdded, _count];
+        } else {
+            (_array select 1) pushBack [_classname, _ammountAdded];
+        };
+
+        _sizeLeft = _sizeLeft - (_ammountAdded * _mass);
+        (_containersArray select _index) set [0, _sizeLeft];
+
+        if (_ammountAdded == _amountToAdd) exitWith { "" };
+        (format ["%1:%2",_classname, (_amountToAdd - _ammountAdded)])
+    };
+
+    if (_itemLeft != "") then { _returnArray pushBack _itemLeft };
+    nil
+} count _itemsToAddArray; // count used here for speed, make sure nil is above this line
+
+_returnArray

--- a/addons/assignGear/functions/fnc_assignGearVehicle.sqf
+++ b/addons/assignGear/functions/fnc_assignGearVehicle.sqf
@@ -11,14 +11,16 @@
  *
  * Example:
  * [cursorTarget] call potato_assignGear_fnc_assignGearVehicle;
+ *
+ * Public: Yes
  */
 // #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
+TRACE_1("params",_this);
 params ["_theVehicle", "_defaultLoadout"];
-TRACE_2("params",_theVehicle,_defaultLoadout);
 
-if (!GVAR(usePotato)) exitWith {TRACE_1("disabled",GVAR(usePotato))};
+if (!GVAR(usePotato)) exitWith { LOG("asignGearVehicle disabled"); };
 
 private _typeOf = typeOf _theVehicle;
 private _loadout = _theVehicle getVariable ["F_Gear", _typeOf];
@@ -77,25 +79,25 @@ private _transportBackpacks = getArray(_path >> "TransportBackpacks");
     (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
     _theVehicle addMagazineCargoGlobal [_classname, parseNumber _amount];
     nil
-} count _transportMagazines;
+} count _transportMagazines; // count used here for speed, make sure nil is above this line
 
 // transportItems
 {
     (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
     _theVehicle addItemCargoGlobal [_classname, parseNumber _amount];
     nil
-} count _transportItems;
+} count _transportItems; // count used here for speed, make sure nil is above this line
 
 // transportWeapons
 {
     (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
     _theVehicle addWeaponCargoGlobal [_classname, parseNumber _amount];
     nil
-} count _transportWeapons;
+} count _transportWeapons; // count used here for speed, make sure nil is above this line
 
 // transportBackpacks
 {
     (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
     _theVehicle addBackpackCargoGlobal [_classname, parseNumber _amount];
     nil
-} count _transportBackpacks;
+} count _transportBackpacks; // count used here for speed, make sure nil is above this line

--- a/addons/assignGear/functions/fnc_cleanPrefix.sqf
+++ b/addons/assignGear/functions/fnc_cleanPrefix.sqf
@@ -1,0 +1,39 @@
+/*
+ * Author: AACO
+ * Gets container information from an array of classnames
+ *
+ * Arguments:
+ * 0: Array of containers to select <ARRAY>
+ * 1: The array containing the container specific loadout array information <ARRAY>
+ * 2: The array containing all the containers and their available space <ARRAY>
+ * 3: Does the container class needed to be looked up in CfgWeapons (optional, default: true) <BOOL>
+ *
+ * Return Value:
+ * NONE
+ *
+ * Example:
+ * [_configUniform, _uniformArray, _containersArray] call potato_assignGear_getContainerInfo;
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+TRACE_1("params",_this);
+
+params ["_unitClassname"];
+
+private _cleanedClassname = GVAR(classnameCache) getVariable _unitClassname;
+if (isNil "_cleanedClassname") then { // cache classname lookups
+    _cleanedClassname = _unitClassname;
+    {
+        private _prefixLength = count _x;
+        if ((toLower (_unitClassname select [0, _prefixLength])) == _x) exitWith {
+            _cleanedClassname = _unitClassname select [_prefixLength];
+        };
+        nil
+    } count GVAR(prefixes);  // count used here for speed, make sure nil is above this line
+
+    GVAR(classnameCache) setVariable [_unitClassname, _cleanedClassname];
+};
+
+_cleanedClassname

--- a/addons/assignGear/functions/fnc_getContainerInfo.sqf
+++ b/addons/assignGear/functions/fnc_getContainerInfo.sqf
@@ -4,15 +4,14 @@
  *
  * Arguments:
  * 0: Array of containers to select <ARRAY>
- * 1: The array containing the container specific loadout array information <ARRAY>
- * 2: The array containing all the containers and their available space <ARRAY>
- * 3: Does the container class needed to be looked up in CfgWeapons (optional, default: true) <BOOL>
+ * 1: The array containing all the containers and their available space <ARRAY>
+ * 2: Does the container class needed to be looked up in CfgWeapons (optional, default: true) <BOOL>
  *
  * Return Value:
  * NONE
  *
  * Example:
- * [_configUniform, _uniformArray, _containersArray] call potato_assignGear_getContainerInfo;
+ * [_configUniform, _containersArray] call potato_assignGear_getContainerInfo;
  *
  * Public: No
  */

--- a/addons/assignGear/functions/fnc_getContainerInfo.sqf
+++ b/addons/assignGear/functions/fnc_getContainerInfo.sqf
@@ -1,0 +1,43 @@
+/*
+ * Author: AACO
+ * Gets container information from an array of classnames
+ *
+ * Arguments:
+ * 0: Array of containers to select <ARRAY>
+ * 1: The array containing the container specific loadout array information <ARRAY>
+ * 2: The array containing all the containers and their available space <ARRAY>
+ * 3: Does the container class needed to be looked up in CfgWeapons (optional, default: true) <BOOL>
+ *
+ * Return Value:
+ * NONE
+ *
+ * Example:
+ * [_configUniform, _uniformArray, _containersArray] call potato_assignGear_getContainerInfo;
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+TRACE_1("params",_this);
+
+params [
+    ["_containers", [], [[]]],
+    ["_allContainersArray", [], [[]]],
+    ["_lookupContainer", true, [true]]
+];
+
+if (_containers isEqualTo []) then {
+    WARNING("No classnames provided for container");
+    _allContainersArray pushBack [0];
+} else {
+    private _container = selectRandom _containers;
+    private _containerClass = if (_lookupContainer) then {
+        getText (configFile >> "CfgWeapons" >> _container >> "ItemInfo" >> "containerClass")
+    } else {
+        _container
+    };
+    private _containerSpace = getNumber (configFile >> "CfgVehicles" >> _containerClass >> "maximumLoad");
+    TRACE_3("container info: ",_container,_containerClass,_containerSpace);
+
+    _allContainersArray pushBack [_containerSpace, [_container, []]];
+};

--- a/addons/assignGear/functions/fnc_getLinkedIndex.sqf
+++ b/addons/assignGear/functions/fnc_getLinkedIndex.sqf
@@ -1,0 +1,69 @@
+/*
+ * Author: PabstMirror, AACO
+ * Gets the index of the linked item, or sets the binocular weapons array if needed
+ *
+ * Arguments:
+ * 0: Linked item classname <STRING>
+ * 1: Binocular weapon array (only used for binocular items) <ARRAY>
+ * 2: List of provided magazines (only used for binocular items) <ARRAY>
+ *
+ * Return Value:
+ * Index of the linked item <NUMBER>
+ *
+ * Example:
+ * [_linkedItem, _binocularArray, _configMagazines] call potato_assignGear_getLinkedIndex;
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+#define BINO_INDEX -2
+#define UNK_INDEX -1
+#define MAP_INDEX 0
+#define GPS_INDEX 1
+#define RADIO_INDEX 2
+#define COMPASS_INDEX 3
+#define WATCH_INDEX 4
+#define NVG_INDEX 5
+
+TRACE_1("params",_this);
+params ["_linkedItem", "_binocularArray", "_configMagazines"];
+
+// Maps
+if (_x isKindOf ["ItemMap", configFile >> "CfgWeapons"]) exitWith {
+    MAP_INDEX
+};
+
+// GPS/UAV terminals
+if (_x isKindOf ["ItemGPS", configFile >> "CfgWeapons"] || {_x isKindOf ["UavTerminal_base", configFile >> "CfgWeapons"]}) exitWith {
+    GPS_INDEX
+};
+
+// Radios (non TFAR/ACRE)
+if (_x isKindOf ["ItemRadio", configFile >> "CfgWeapons"]) exitWith {
+    RADIO_INDEX
+};
+
+// Compasses
+if (_x isKindOf ["ItemCompass", configFile >> "CfgWeapons"]) exitWith {
+    COMPASS_INDEX
+};
+
+// Watches
+if (_x isKindOf ["ItemWatch", configFile >> "CfgWeapons"]) exitWith {
+    WATCH_INDEX
+};
+
+// Night vision/thermal goggles
+if (_x isKindOf ["NVGoggles", configFile >> "CfgWeapons"]) exitWith {
+    NVG_INDEX
+};
+
+// Binoculars (not actually treated as a linked item)
+if (_x isKindOf ["Binocular", configFile >> "CfgWeapons"]) exitWith {
+    _binocularArray = [_x, [], _configMagazines] call FUNC(getWeaponArray);
+    BINO_INDEX
+};
+
+diag_log text format ["[POTATO-assignGear] - linkedItems [%1] unknown type", _linkedItem];
+UNK_INDEX

--- a/addons/assignGear/functions/fnc_getLoadoutFromConfig.sqf
+++ b/addons/assignGear/functions/fnc_getLoadoutFromConfig.sqf
@@ -6,15 +6,21 @@
  * 0: Config Path <CONFIG>
  *
  * Return Value:
- * <ARRAY>
+ * Loadout array (https://community.bistudio.com/wiki/Talk:getUnitLoadout) <ARRAY>
  *
  * Example:
  * [missionConfigFile >> "CfgLoadouts" >> (faction player) >> (typeOf player)] call potato_assignGear_fnc_getLoadoutFromConfig
+ *
+ * Public: No
  */
-#include "script_component.hpp"
 
+#include "script_component.hpp"
+#define UNIFORM_INDEX 0
+#define VEST_INDEX 1
+#define BACKPACK_INDEX 2
+
+TRACE_1("params",_this);
 params ["_path"];
-TRACE_1("params",_path);
 
 private _configUniform = getArray (_path >> "uniform");
 private _configVest = getArray (_path >> "vest");
@@ -29,202 +35,54 @@ private _configItems = getArray (_path >> "items");
 private _configLinkedItems = getArray (_path >> "linkedItems");
 private _configAttachments = getArray (_path >> "attachments");
 private _configSecondaryAttachments = getArray (_path >> "secondaryAttachments");
+private _configHandgunAttachments = getArray (_path >> "handgunAttachments");
 
-private _uniformArray = [];
-private _vestArray = [];
-private _backpackArray = [];
-private _containersArray = [[0],[0],[0]];
+private _containersArray = [];
 
-if (!(_configUniform isEqualTo [])) then {
-    private _uniform = selectRandom _configUniform;
-    private _container = getText (configFile >> "CfgWeapons" >> _uniform >> "ItemInfo" >> "containerClass");
-    private _uniformSpace = getNumber (configFile >> "CfgVehicles" >> _container >> "maximumLoad");
-    TRACE_3("",_uniform,_container,_uniformSpace);
-    _uniformArray = [_uniform, []];
-    _containersArray set [0, [_uniformSpace, _uniformArray]];
-};
-if (!(_configVest isEqualTo [])) then {
-    private _vest = selectRandom _configVest;
-    private _container = getText (configFile >> "CfgWeapons" >> _vest >> "ItemInfo" >> "containerClass");
-    private _vestSpace = getNumber (configFile >> "CfgVehicles" >> _container >> "maximumLoad");
-    TRACE_3("",_vest,_container,_vestSpace);
-    _vestArray = [_vest, []];
-    _containersArray set [1, [_vestSpace, _vestArray]];
-};
-if (!(_configBackpack isEqualTo [])) then {
-    private _backpack = selectRandom _configBackpack;
-    private _backpackSpace = getNumber (configFile >> "CfgVehicles" >> _backpack >> "maximumLoad");
-    TRACE_2("",_backpack,_backpackSpace);
-    _backpackArray = [_backpack, []];
-    _containersArray set [2, [_backpackSpace, _backpackArray]];
-};
+// NOTE: order of the three calls below matter!
+[_configUniform, _containersArray] call FUNC(getContainerInfo);
+[_configVest, _containersArray] call FUNC(getContainerInfo);
+[_configBackpack, _containersArray, false] call FUNC(getContainerInfo);
 
 TRACE_1("containers",_containersArray);
 
-private _headgear = if (_configHeadgear isEqualTo []) then {""} else {selectRandom _configHeadgear};
+private _headgear = if (_configHeadgear isEqualTo []) then { "" } else { selectRandom _configHeadgear };
 private _binocularArray = [];
 private _assignedItems = ["", "", "", "", "", ""];
 
-private _fnc_addItemsToContainer = {
-    params ["_itemsToAddArray", "_index"];
-    TRACE_2("params",_itemsToAddArray,_index);
-    if (_itemsToAddArray isEqualTo []) exitWith {_itemsToAddArray};
-    private _indexSlotNum = [801, 701, 901] select _index; //for the "allowedSlots" check
-    (_containersArray select _index) params ["_sizeLeft", ["_array", []]];
-    TRACE_4("Adding Items To Container",_itemsToAddArray,_index,_sizeLeft,_array);
-    private _returnArray = [];
-    {
-        _itemToAdd = _x;
-        _xReturn = [] call {
-            if (_sizeLeft <= 0) exitWith {TRACE_1("no room",_itemToAdd); _itemToAdd};
-            (_itemToAdd splitString ":") params ["_classname", ["_amountToAdd", "1", [""]]];
-            _amountToAdd = parseNumber _amountToAdd;
-            private _mass = -1;
-            private _count = -1;
-            private _allowedSlots = [];
-            if (isClass (configFile >> "CfgMagazines" >> _classname)) then {
-                _mass = getNumber (configFile >> "CfgMagazines" >> _classname >> "mass");
-                _count = getNumber (configFile >> "CfgMagazines" >> _classname >> "count");
-                _allowedSlots = getArray (configFile >> "CfgMagazines" >> _classname >> "allowedSlots");
-            } else {
-                if (isClass (configFile >> "CfgWeapons" >> _classname)) exitWith {
-                    _mass = getNumber (configFile >> "CfgWeapons" >> _classname >> "ItemInfo" >> "mass");
-                    _allowedSlots = getArray (configFile >> "CfgWeapons" >> _classname >> "ItemInfo" >> "allowedSlots");
-                };
-            };
-            if (_mass < 0) exitWith {
-                diag_log text format ["[POTATO-assignGear] Item Not Found [%1]", _itemToAdd];
-                "";
-            };
-            if (!((_allowedSlots isEqualTo []) || {_indexSlotNum in _allowedSlots})) exitWith {
-                TRACE_3("not allowed in slot",_classname,_allowedSlots,_indexSlotNum);
-                _itemToAdd
-            };
+// Process Weapons
+private _primaryWeaponArray = if (_configWeapons isEqualTo []) then { [] } else { [selectRandom _configWeapons, _configAttachments, _configMagazines] call FUNC(getWeaponArray) };
+private _launcherWeaponArray = if (_configLaunchers isEqualTo []) then { [] } else { [selectRandom _configLaunchers, _configSecondaryAttachments, _configMagazines, false] call FUNC(getWeaponArray) }; // skip optic check on launchers
+private _handgunWeaponArray = if (_configHandguns isEqualTo []) then { [] } else { [selectRandom _configHandguns, _configHandgunAttachments, _configMagazines] call FUNC(getWeaponArray) };
 
-
-            private _ammountThatWillFit = if (_mass == 0) then {9999} else {floor (_sizeLeft / _mass)};
-            private _ammountAdded = _ammountThatWillFit min _amountToAdd;
-            TRACE_6("",_classname,_mass,_count,_amountToAdd,_ammountThatWillFit,_ammountAdded);
-            
-            if (_ammountAdded == 0) exitWith {_itemToAdd};
-            if (_count > 0) then {
-                (_array select 1) pushBack [_classname, _ammountAdded, _count];
-            } else {
-                (_array select 1) pushBack [_classname, _ammountAdded];
-            };
-
-            _sizeLeft = _sizeLeft - (_ammountAdded * _mass);
-            (_containersArray select _index) set [0, _sizeLeft];
-
-            if (_ammountAdded == _amountToAdd) exitWith {""};
-            (format ["%1:%2",_classname, (_amountToAdd - _ammountAdded)])
-        };
-        if (_xReturn != "") then {_returnArray pushBack _xReturn};
-    } forEach _itemsToAddArray;
-    _returnArray
-};
-
-
-private _fnc_getWeaponArray = {
-    params ["_weapon", "_attachments"];
-
-    private _weaponArray = [_weapon, "", "", "", [], [], ""];
-    private _attachables = [_weapon] call CBA_fnc_compatibleItems;
-
-    {
-        (_x splitString ":") params [["_classname", ""]]; //count makes no sense for attachments, ignore
-        private _config = configFile >> "CfgWeapons" >> _classname;
-        if (({_x == _classname} count _attachables) > 0) then {
-            switch (getNumber(_config >> "itemInfo" >> "type")) do {
-            case (101): {_weaponArray set [1, _classname]}; //muzzle
-            case (301): {_weaponArray set [2, _classname]}; //pointer
-            case (201): {
-                    if (!GVAR(allowMagnifiedOptics)) then {
-                        private _minZoom = 999; //FOV, so smaller is more zoomed in
-                        {
-                            if (isNumber (_x >> "opticsZoomMin")) then {_minZoom = _minZoom min (getNumber (_x >> "opticsZoomMin"));};
-                            if (isText (_x >> "opticsZoomMin")) then {_minZoom = _minZoom min (call compile getText (_x >> "opticsZoomMin"));};
-                            nil
-                        } count configProperties [_config >> "ItemInfo" >> "OpticsModes"];
-                        if (_minZoom < 0.25) then {
-                            diag_log text format ["[POTATO-assignGear] allowMagnifiedOptics is false, not adding %1 (opticsZoomMin %2)", _classname, _minZoom];
-                            _classname = "";
-                        };
-                    };
-                    _weaponArray set [3, _classname]}; //optic
-            case (302): {_weaponArray set [6, _classname]}; //bipod
-                default {diag_log text format ["[POTATO-assignGear] - Attachment [%1] has unknown type", _classname];};
-            };
-        } else {
-            diag_log text format ["[POTATO-assignGear] - Attachment [%1] not compatible with [%2]", _classname, _weapon];
-        };
-    } forEach _attachments;
-
-    private _muzzles = getArray (configFile >> "CfgWeapons" >> _weapon >> "muzzles");
-    {
-        private _magazines = getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines");
-        private _arrayIndex = 4;
-        if (_x != "this") then {
-            _magazines = getArray (configFile >> "CfgWeapons" >> _weapon >> _x >> "magazines");
-            _arrayIndex = 5;
-        };
-        {
-            (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
-            if (({_x == _classname} count _magazines) > 0) exitWith {
-                private _count = getNumber (configFile >> "CfgMagazines" >> _classname >> "count");
-                _weaponArray set [_arrayIndex, [_classname, _count]];
-                _configMagazines set [_forEachIndex, format ["%1:%2", _classname, ((parseNumber _amount) - 1)]];
-            };
-        } forEach _configMagazines;
-    } forEach _muzzles;
-    _weaponArray
-};
-
-
-//Process Weapons:
-private _primaryWeaponArray = if (_configWeapons isEqualTo []) then {[]} else {[selectRandom _configWeapons, _configAttachments] call _fnc_getWeaponArray};
-private _launcherWeaponArray = if (_configLaunchers isEqualTo []) then {[]} else {[selectRandom _configLaunchers, _configSecondaryAttachments] call _fnc_getWeaponArray};
-private _handgunWeaponArray = if (_configHandguns isEqualTo []) then {[]} else {[selectRandom _configHandguns, []] call _fnc_getWeaponArray};
-
-//Process linkedItems (includes binocular)
+// Process linkedItems (includes binoculars)
 {
-    private _type = [] call {
-        if (_x isKindOf ["ItemMap", configFile >> "CfgWeapons"]) exitWith {0};
-        if (_x isKindOf ["ItemGPS", configFile >> "CfgWeapons"]) exitWith {1};
-        if (_x isKindOf ["UavTerminal_base", configFile >> "CfgWeapons"]) exitWith {1};
-        if (_x isKindOf ["ItemRadio", configFile >> "CfgWeapons"]) exitWith {2};
-        if (_x isKindOf ["ItemCompass", configFile >> "CfgWeapons"]) exitWith {3};
-        if (_x isKindOf ["ItemWatch", configFile >> "CfgWeapons"]) exitWith {4};
-        if (_x isKindOf ["NVGoggles", configFile >> "CfgWeapons"]) exitWith {5};
-        if (_x isKindOf ["Binocular", configFile >> "CfgWeapons"]) exitWith {
-            _binocularArray = [_x, []] call _fnc_getWeaponArray;
-            -2
-        };
-        -1
+    private _linkedItemIndex = [_x, _binocularArray, _configMagazines] call FUNC(getLinkedIndex);
+
+    if (_linkedItemIndex >= 0) then {
+        _assignedItems set [_linkedItemIndex, _x];
     };
-    if (_type >= 0) then {
-        _assignedItems set [_type, _x];
-    } else {
-        if (_type == -1) then { diag_log text format ["[POTATO-assignGear] - linkedItems [%1] unknown type", _x]; };
-    };
-} forEach _configLinkedItems;
+    nil
+} count _configLinkedItems; // count used here for speed, make sure nil is above this line
 
-TRACE_1("Adding Items Start x",_containersArray);
+TRACE_1("Adding Items Start: ",_containersArray);
 
-_configItems = [_configItems, 0] call _fnc_addItemsToContainer;
-_configItems = [_configItems, 1] call _fnc_addItemsToContainer;
-_configItems = [_configItems, 2] call _fnc_addItemsToContainer;
+_configItems = [_configItems, _containersArray, UNIFORM_INDEX] call FUNC(addItemsToContainer);
+_configItems = [_configItems, _containersArray, VEST_INDEX] call FUNC(addItemsToContainer);
+_configItems = [_configItems, _containersArray, BACKPACK_INDEX] call FUNC(addItemsToContainer);
+TRACE_1("Remaining items: ", _configItems);
 
-_configBackpackItems = [_configBackpackItems, 2] call _fnc_addItemsToContainer;
-_configBackpackItems = [_configBackpackItems, 1] call _fnc_addItemsToContainer;
-_configBackpackItems = [_configBackpackItems, 0] call _fnc_addItemsToContainer;
+_configBackpackItems = [_configBackpackItems, _containersArray, BACKPACK_INDEX] call FUNC(addItemsToContainer);
+_configBackpackItems = [_configBackpackItems, _containersArray, VEST_INDEX] call FUNC(addItemsToContainer);
+_configBackpackItems = [_configBackpackItems, _containersArray, UNIFORM_INDEX] call FUNC(addItemsToContainer);
+TRACE_1("Remaining backpack items: ", _configBackpackItems);
 
-_configMagazines = [_configMagazines, 1] call _fnc_addItemsToContainer;
-_configMagazines = [_configMagazines, 2] call _fnc_addItemsToContainer;
-_configMagazines = [_configMagazines, 0] call _fnc_addItemsToContainer;
+_configMagazines = [_configMagazines, _containersArray, VEST_INDEX] call FUNC(addItemsToContainer);
+_configMagazines = [_configMagazines, _containersArray, BACKPACK_INDEX] call FUNC(addItemsToContainer);
+_configMagazines = [_configMagazines, _containersArray, UNIFORM_INDEX] call FUNC(addItemsToContainer);
+TRACE_1("Remaining magazines: ", _configBackpackItems);
 
-TRACE_1("Adding Items End",_containersArray);
+TRACE_1("Adding Items End: ",_containersArray);
 
-private _return = [_primaryWeaponArray, _launcherWeaponArray, _handgunWeaponArray, _uniformArray, _vestArray, _backpackArray, _headgear, "", _binocularArray, _assignedItems];
-
-_return;
+// return array, to spec of https://community.bistudio.com/wiki/Talk:getUnitLoadout
+[_primaryWeaponArray, _launcherWeaponArray, _handgunWeaponArray, (_containersArray select UNIFORM_INDEX) select 1, (_containersArray select VEST_INDEX) select 1, (_containersArray select BACKPACK_INDEX) select 1, _headgear, "", _binocularArray, _assignedItems]

--- a/addons/assignGear/functions/fnc_getWeaponArray.sqf
+++ b/addons/assignGear/functions/fnc_getWeaponArray.sqf
@@ -1,0 +1,64 @@
+/*
+ * Author: PabstMirror, AACO
+ * Gets a weapon array from a weapon classname, an array of attachement classnames,
+ * and an array of magazines
+ *
+ * Arguments:
+ * 0: Weapon classname <STRING>
+ * 1: Array of attachements to add to the weapon <ARRAY>
+ * 2: Array of magazines to preload the weapon with <ARRAY>
+ * 3: Should we check the optic (optional, default: true) <BOOL>
+ *
+ * Return Value:
+ * Weapon array <ARRAY>
+ *
+ * Example:
+ * [_configWeapon, _configAttachments, _configMagazines] call potato_assignGear_getWeaponArray;
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+#define GUN_INDEX 4
+#define UNDERSLUNG_INDEX 5
+
+TRACE_1("params",_this);
+params ["_weapon", "_attachments", "_configMagazines", ["_doOpticCheck", true, [true]]];
+
+private _weaponArray = [_weapon, "", "", "", [], [], ""];
+private _attachables = GVAR(weaponAttachmentCache) getVariable _weapon;
+if (isNil "_attachables") then { // cache attachement lookups
+    _attachables = [_weapon] call CBA_fnc_compatibleItems;
+    GVAR(weaponAttachmentCache) setVariable [_weapon, _attachables];
+};
+
+{
+    (_x splitString ":") params [["_classname", ""]]; // count makes no sense for attachments, ignore
+    private _config = configFile >> "CfgWeapons" >> _classname;
+    if (_classname in _attachables) then {
+        [_weaponArray, _config, _classname, _doOpticCheck] call FUNC(setWeaponAttachment);
+    } else {
+        diag_log text format ["[POTATO-assignGear] - Attachment [%1] not compatible with [%2]", _classname, _weapon];
+    };
+    nil
+} count _attachments; // count used here for speed, make sure nil is above this line
+
+{
+    if (_x == "this") then { // main gun magazines
+        [GUN_INDEX, getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines")]
+    } else { // underslung weapon magazines
+        [UNDERSLUNG_INDEX, getArray (configFile >> "CfgWeapons" >> _weapon >> _x >> "magazines")]
+    } params ["_arrayIndex", "_magazines"];
+
+    {
+        (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
+        if (_classname in _magazines) exitWith {
+            private _count = getNumber (configFile >> "CfgMagazines" >> _classname >> "count");
+            _weaponArray set [_arrayIndex, [_classname, _count]];
+            _configMagazines set [_forEachIndex, format ["%1:%2", _classname, ((parseNumber _amount) - 1)]];
+        };
+    } forEach _configMagazines; // for each used here, since we need the index
+    nil
+} count getArray (configFile >> "CfgWeapons" >> _weapon >> "muzzles");  // count used here for speed, make sure nil is above this line
+
+_weaponArray

--- a/addons/assignGear/functions/fnc_getWeaponArray.sqf
+++ b/addons/assignGear/functions/fnc_getWeaponArray.sqf
@@ -26,11 +26,7 @@ TRACE_1("params",_this);
 params ["_weapon", "_attachments", "_configMagazines", ["_doOpticCheck", true, [true]]];
 
 private _weaponArray = [_weapon, "", "", "", [], [], ""];
-private _attachables = GVAR(weaponAttachmentCache) getVariable _weapon;
-if (isNil "_attachables") then { // cache attachement lookups
-    _attachables = [_weapon] call CBA_fnc_compatibleItems;
-    GVAR(weaponAttachmentCache) setVariable [_weapon, _attachables];
-};
+private _attachables = [_weapon] call CBA_fnc_compatibleItems;
 
 {
     (_x splitString ":") params [["_classname", ""]]; // count makes no sense for attachments, ignore

--- a/addons/assignGear/functions/fnc_setWeaponAttachment.sqf
+++ b/addons/assignGear/functions/fnc_setWeaponAttachment.sqf
@@ -1,0 +1,69 @@
+/*
+ * Author: PabstMirror, AACO
+ * Adds attachements to a weapon array
+ *
+ * Arguments:
+ * 0: Weapon array to add the attachement to <ARRAY>
+ * 1: Config path of the attachement <CONFIG>
+ * 2: Attachement classname <STRING>
+ * 3: Should we check the optic (optional, default: true) <BOOL>
+ *
+ * Return Value:
+ * NONE
+ *
+ * Example:
+ * [_weaponArray, _config, _classname, _doOpticCheck] call potato_assignGear_setWeaponAttachement;
+ *
+ * Public: No
+ */
+
+#include "script_component.hpp"
+#define MUZZLE_NUMBER 101
+#define MUZZLE_INDEX 1
+#define OPTIC_NUMBER 201
+#define OPTIC_INDEX 3
+#define POINTER_NUMBER 301
+#define POINTER_INDEX 2
+#define BIPOD_NUMBER 302
+#define BIPOD_INDEX 6
+
+TRACE_1("params",_this);
+params ["_weaponArray", "_config", "_classname", ["_doOpticCheck", true, [true]]];
+
+private _typeNumber = getNumber (_config >> "itemInfo" >> "type");
+
+// muzzle
+if (_typeNumber == MUZZLE_NUMBER) exitWith {
+    _weaponArray set [MUZZLE_INDEX, _classname];
+};
+
+// optic
+if (_typeNumber == OPTIC_NUMBER) exitWith {
+    if (!GVAR(allowMagnifiedOptics) && {_doOpticCheck}) then {
+        private _minZoom = 999; //FOV, so smaller is more zoomed in
+        {
+            if (isNumber (_x >> "opticsZoomMin")) then {_minZoom = _minZoom min (getNumber (_x >> "opticsZoomMin"));};
+            if (isText (_x >> "opticsZoomMin")) then {_minZoom = _minZoom min (call compile getText (_x >> "opticsZoomMin"));};
+            nil
+        } count configProperties [_config >> "ItemInfo" >> "OpticsModes"]; // count used here for speed, make sure nil is above this line
+
+        if (_minZoom < 0.25) then {
+            diag_log text format ["[POTATO-assignGear] allowMagnifiedOptics is false, not adding %1 (opticsZoomMin %2)", _classname, _minZoom];
+            _classname = "";
+        };
+    };
+
+    _weaponArray set [OPTIC_INDEX, _classname];
+};
+
+// pointer
+if (_typeNumber == POINTER_NUMBER) exitWith {
+    _weaponArray set [POINTER_INDEX, _classname];
+};
+
+// bipod
+if (_typeNumber == BIPOD_NUMBER) exitWith {
+    _weaponArray set [BIPOD_INDEX, _classname];
+};
+
+diag_log text format ["[POTATO-assignGear] - Attachment [%1] has unknown type", _classname];

--- a/addons/assignGear/script_component.hpp
+++ b/addons/assignGear/script_component.hpp
@@ -1,7 +1,7 @@
 #define COMPONENT assignGear
 #include "\z\potato\addons\core\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
+// #define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS
 

--- a/addons/assignGear/script_component.hpp
+++ b/addons/assignGear/script_component.hpp
@@ -1,7 +1,7 @@
 #define COMPONENT assignGear
 #include "\z\potato\addons\core\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
+#define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS
 


### PR DESCRIPTION
hooo boy, major update to assign gear.
- Added a frame delay to the assign gear (man and vehicle) scripts to help with the `F_Gear` and JIP issues (ref #94 ).  `F_Gear` seems to work much better, JIPing remains to be seen.
- Add `handgunAttachments` to the available loadout fields (mainly for competitionist sake, since we have the launcher attachments as well)
- Break `getLoadoutFromConfig` into a few helper functions to A. reduce SQF calls (define functions once, instead of each run) and B. to hopefully helpfully break down some of the 'mega code' into more readable parcels.
- Add more debugging around assignGearMan to hopefully give better benchmarking.
- Add ability to have ambiguous loadouts. The TL;DR of this feature is to have one loadout (german, british, whatever) usable for all sides/factions.
- Don't run the magnified optic check on launchers (prevents a lot of MAT issues honestly).
- Set the class event handlers through scripting, instead of through configuration

Running on my computer (local dedicated server, local client, value in seconds):
`1:16:10 "[POTATO-assignGear] - assignGearMan ran 588 times, with an average run time of 0.00462764"`
4ms be call ain't bad.

@PabstMirror can you take a read through? I did local/dedicated testing and it seemed fine.
@zerithsmash tagging you just because.
