### PR TITLE
Add group cleanup on start

### DIFF
--- a/addons/markers/XEH_postInit.sqf
+++ b/addons/markers/XEH_postInit.sqf
@@ -4,7 +4,7 @@ LOG("Post init start");
 
 [
     {
-        ACEGVAR(common,settingsInitFinished)
+        ACEGVAR(common,settingsInitFinished) && !isNil QEGVAR(miscFixes,groupCleanupRan)
     },
     {
         TRACE_2("ACE Settings initilized",GVAR(groupAndUnitEnabled),GVAR(intraFireteamEnabled));

--- a/addons/miscFixes/CfgEventHandlers.hpp
+++ b/addons/miscFixes/CfgEventHandlers.hpp
@@ -13,6 +13,7 @@ class Extended_PreInit_EventHandlers {
 class Extended_PostInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_kilTracker));
+        serverInit = QUOTE(call COMPILE_FILE(XEH_serverPostInit));
     };
 };
 

--- a/addons/miscFixes/XEH_serverPostInit.sqf
+++ b/addons/miscFixes/XEH_serverPostInit.sqf
@@ -2,7 +2,7 @@
 
 // clean up empty groups
 {
-    if (units _x isEqualTo []) then {
+    if ((units _x) isEqualTo []) then {
         deleteGroup _x;
     };
 } forEach allGroups;

--- a/addons/miscFixes/XEH_serverPostInit.sqf
+++ b/addons/miscFixes/XEH_serverPostInit.sqf
@@ -1,0 +1,10 @@
+#include "script_component.hpp"
+
+// clean up empty groups
+{
+    if (units _x isEqualTo []) then {
+        deleteGroup _x;
+    };
+} forEach allGroups;
+
+GVAR(groupCleanupRan) = true;


### PR DESCRIPTION
Basically this should cleanup the starting empty groups that are created when there are unslotted groups. Should prevent the issue where we get a bunch of markers in the corner of the map, and should help avoid strange group limits in certain conditions. I did some quick testing on the dedicated server, jipped units just re-created the groups with the same markers.

This should also help us edge a bit more performance on PFEHs that use `allGroups`

Things to sanity test:
- [ ] Ensure ACRE configuration isn't lost
- [ ] Ensure callsign isn't lost.