### PR TITLE
Add group cleanup and setup markers and spectate to wait for cleanup

### DIFF
--- a/addons/briefing/functions/fnc_addCredits.sqf
+++ b/addons/briefing/functions/fnc_addCredits.sqf
@@ -30,7 +30,6 @@ _unit createDiaryRecord ["diary", ["Credits", format ["
 <br/>
 Bourbon Warfare Mission Framework<br/>
 BWMF Version: %4<br/>
-Based on F3 (http://www.ferstaberinde.com/f3/en/)<br/>
 <br/>
 <br/>
 POTATO Version: %5

--- a/addons/markers/XEH_postInit.sqf
+++ b/addons/markers/XEH_postInit.sqf
@@ -4,10 +4,11 @@ LOG("Post init start");
 
 [
     {
-        (ACEGVAR(common,settingsInitFinished) && missionNamespace getVariable [QEGVAR(miscFixes,groupCleanupRan), false]) || diag_tickTime > (_this select 0)
+        ACEGVAR(common,settingsInitFinished) && {(missionNamespace getVariable [QEGVAR(miscFixes,groupCleanupRan), false]) || {diag_tickTime > (_this select 0)}}
     },
     {
         TRACE_2("ACE Settings initilized",GVAR(groupAndUnitEnabled),GVAR(intraFireteamEnabled));
+        if (isNil QEGVAR(miscFixes,groupCleanupRan)) then {ERROR_1("Server never set %1", QEGVAR(miscFixes,groupCleanupRan));};
         if (hasInterface && {GVAR(groupAndUnitEnabled) || {GVAR(intraFireteamEnabled)}}) then {
             GVAR(skipInstallingEH) = false;
 

--- a/addons/markers/XEH_postInit.sqf
+++ b/addons/markers/XEH_postInit.sqf
@@ -4,7 +4,7 @@ LOG("Post init start");
 
 [
     {
-        ACEGVAR(common,settingsInitFinished)
+        (ACEGVAR(common,settingsInitFinished) && missionNamespace getVariable [QEGVAR(miscFixes,groupCleanupRan), false]) || diag_tickTime > (_this select 0)
     },
     {
         TRACE_2("ACE Settings initilized",GVAR(groupAndUnitEnabled),GVAR(intraFireteamEnabled));
@@ -49,5 +49,6 @@ LOG("Post init start");
         {
             (_x select 1) call (_x select 0);
         } forEach GVAR(settingsDelayedFunctions);
-    }
+    },
+    [diag_tickTime + 5]
 ] call CBA_fnc_waitUntilAndExecute;

--- a/addons/miscFixes/CfgEventHandlers.hpp
+++ b/addons/miscFixes/CfgEventHandlers.hpp
@@ -13,6 +13,7 @@ class Extended_PreInit_EventHandlers {
 class Extended_PostInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_kilTracker));
+        serverInit = QUOTE(call COMPILE_FILE(XEH_serverPostInit));
     };
 };
 

--- a/addons/miscFixes/XEH_serverPostInit.sqf
+++ b/addons/miscFixes/XEH_serverPostInit.sqf
@@ -1,8 +1,11 @@
+// Can eventually remove if this shows no problems
+#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
 // clean up empty groups
 {
     if ((units _x) isEqualTo []) then {
+        TRACE_2("Deleting Empty Group",_x,groupID _x);
         deleteGroup _x;
     };
 } forEach allGroups;

--- a/addons/miscFixes/XEH_serverPostInit.sqf
+++ b/addons/miscFixes/XEH_serverPostInit.sqf
@@ -1,0 +1,10 @@
+#include "script_component.hpp"
+
+// clean up empty groups
+{
+    if ((units _x) isEqualTo []) then {
+        deleteGroup _x;
+    };
+} forEach allGroups;
+
+missionNamespace setVariable [QGVAR(groupCleanupRan), true, true];

--- a/addons/spectate/XEH_postServerInit.sqf
+++ b/addons/spectate/XEH_postServerInit.sqf
@@ -1,14 +1,22 @@
 #include "script_component.hpp"
 
 if (GVAR(enabled)) then {
-    GVAR(group) = createGroup sideLogic;
-    publicVariable QGVAR(group);
-    GVAR(holderUnit) = GVAR(group) createUnit [QGVAR(holder), ZERO_POS, [], 200, "NONE"];
-    GVAR(holderUnit) setVariable [QACEGVAR(zeus,addObject), false, true];
-    diag_log format ["[POTATO-spectate] Spectate group: %1, spectate unit: %2", GVAR(group), GVAR(holderUnit)];
-
     // delete old spectator units
     addMissionEventHandler ["HandleDisconnect", {
         if ((_this select 0) isKindOf QGVAR(spectator)) then { deleteVehicle (_this select 0); };
     }];
+
+    [
+        {
+            missionNamespace getVariable [QEGVAR(miscFixes,groupCleanupRan), false] || diag_tickTime > (_this select 0)
+        },
+        {
+            GVAR(group) = createGroup sideLogic;
+            publicVariable QGVAR(group);
+            GVAR(holderUnit) = GVAR(group) createUnit [QGVAR(holder), ZERO_POS, [], 200, "NONE"];
+            GVAR(holderUnit) setVariable [QACEGVAR(zeus,addObject), false, true];
+            diag_log format ["[POTATO-spectate] Spectate group: %1, spectate unit: %2", GVAR(group), GVAR(holderUnit)];
+        },
+        [diag_tickTime + 5]
+    ] call CBA_fnc_waitUntilAndExecute;
 };


### PR DESCRIPTION
Tested with a single client on dedicated (as well as JIP tests), no ill side effects noticed. Markers and spectate group created before timeout.

@PabstMirror can you take a quick sanity check?