### PR TITLE
Map marker color

### DIFF
--- a/addons/markers/XEH_PREP.hpp
+++ b/addons/markers/XEH_PREP.hpp
@@ -4,8 +4,10 @@ TRACE_1("",QUOTE(ADDON));
 PREP(drawMarkers);
 PREP(getSideArray);
 PREP(initMarkerHash);
+PREP(setMapMarkerColor);
 PREP(addMarkerInfoToHash);
 PREP(addMarkersToDisplay);
+PREP(checkForMapMarkerColor);
 PREP(handleCheckPlayerForMarkers);
 
 // 3den control functions

--- a/addons/markers/XEH_postInit.sqf
+++ b/addons/markers/XEH_postInit.sqf
@@ -29,6 +29,8 @@ LOG("Post init start");
                 ["unit", {
                     params ["_newPlayer", "_oldPlayer"];
 
+                    [QFUNC(setMapMarkerColor), [_newPlayer]] call CBA_fnc_execNextFrame;
+
                     if (side _newPlayer != side _oldPlayer) then {
                         GVAR(drawHash) = [[],[]];
                         [] call FUNC(initMarkerHash);

--- a/addons/markers/XEH_postInit.sqf
+++ b/addons/markers/XEH_postInit.sqf
@@ -29,7 +29,7 @@ LOG("Post init start");
                 ["unit", {
                     params ["_newPlayer", "_oldPlayer"];
 
-                    [QFUNC(setMapMarkerColor), [_newPlayer]] call CBA_fnc_execNextFrame;
+                    [] call FUNC(checkForMapMarkerColor);
 
                     if (side _newPlayer != side _oldPlayer) then {
                         GVAR(drawHash) = [[],[]];
@@ -40,6 +40,7 @@ LOG("Post init start");
                 }] call CBA_fnc_addPlayerEventHandler;
 
                 [] call FUNC(initMarkerHash);
+                [] call FUNC(checkForMapMarkerColor);
             };
         } else {
             GVAR(skipInstallingEH) = true; // skip installing marker EHs

--- a/addons/markers/functions/fnc_checkForMapMarkerColor.sqf
+++ b/addons/markers/functions/fnc_checkForMapMarkerColor.sqf
@@ -1,0 +1,32 @@
+/*
+ * Author: AACO
+ * Function used to add unit/group marker information into the marker hash
+ *
+ * Arguments:
+ * 0: Unit or Group to add to the marker system <OBJECT/GROUP>
+ *
+ * Return Value:
+ * True if the info was added to the hash, false otherwise <BOOL>
+ *
+ * Examples:
+ * [player] call potato_markers_fnc_addMarkerInfoToHash;
+ * [group player] call potato_markers_fnc_addMarkerInfoToHash;
+ *
+ * Public: Yes
+ */
+
+#include "script_component.hpp"
+TRACE_1("Params",_this);
+
+params [["_newPlayer", objNull, [objNull]]];
+
+if (isNull _newPlayer) exitWith { WARNING("Provided new player is null"); };
+
+if (_newPlayer getVariable [QGVAR(addMarker), false]) then {
+    [_newPlayer getVariable [QGVAR(markerColor), DEFAULT_MARKER_COLOR]] call FUNC(setMapMarkerColor);
+} else {
+    private _group = group _newPlayer;
+    if (_group getVariable [QGVAR(addMarker), false]) then {
+        [_group getVariable [QGVAR(markerColor), DEFAULT_MARKER_COLOR]] call FUNC(setMapMarkerColor);
+    };
+};

--- a/addons/markers/functions/fnc_checkForMapMarkerColor.sqf
+++ b/addons/markers/functions/fnc_checkForMapMarkerColor.sqf
@@ -1,32 +1,27 @@
 /*
  * Author: AACO
- * Function used to add unit/group marker information into the marker hash
+ * Function used to check a unit for a map marker color
  *
  * Arguments:
- * 0: Unit or Group to add to the marker system <OBJECT/GROUP>
+ * None
  *
  * Return Value:
- * True if the info was added to the hash, false otherwise <BOOL>
+ * None
  *
  * Examples:
- * [player] call potato_markers_fnc_addMarkerInfoToHash;
- * [group player] call potato_markers_fnc_addMarkerInfoToHash;
+ * [] call potato_markers_fnc_checkForMapMarkerColor;
  *
- * Public: Yes
+ * Public: No
  */
 
 #include "script_component.hpp"
 TRACE_1("Params",_this);
 
-params [["_newPlayer", objNull, [objNull]]];
-
-if (isNull _newPlayer) exitWith { WARNING("Provided new player is null"); };
-
-if (_newPlayer getVariable [QGVAR(addMarker), false]) then {
-    [_newPlayer getVariable [QGVAR(markerColor), DEFAULT_MARKER_COLOR]] call FUNC(setMapMarkerColor);
+private _group = group player;
+if (_group getVariable [QGVAR(addMarker), false]) then {
+    [_group getVariable [QGVAR(markerColor), DEFAULT_MARKER_COLOR]] call FUNC(setMapMarkerColor);
 } else {
-    private _group = group _newPlayer;
-    if (_group getVariable [QGVAR(addMarker), false]) then {
-        [_group getVariable [QGVAR(markerColor), DEFAULT_MARKER_COLOR]] call FUNC(setMapMarkerColor);
+    if ((leader _group) getVariable [QGVAR(addMarker), false]) then {
+        [(leader _group) getVariable [QGVAR(markerColor), DEFAULT_MARKER_COLOR]] call FUNC(setMapMarkerColor);
     };
 };

--- a/addons/markers/functions/fnc_setMapMarkerColor.sqf
+++ b/addons/markers/functions/fnc_setMapMarkerColor.sqf
@@ -1,18 +1,17 @@
 /*
  * Author: AACO
- * Function used to add unit/group marker information into the marker hash
+ * Function used to set a map marker color on a unit
  *
  * Arguments:
- * 0: Unit or Group to add to the marker system <OBJECT/GROUP>
+ * 0: Marker color <ARRAY>
  *
  * Return Value:
- * True if the info was added to the hash, false otherwise <BOOL>
+ * None
  *
  * Examples:
- * [player] call potato_markers_fnc_addMarkerInfoToHash;
- * [group player] call potato_markers_fnc_addMarkerInfoToHash;
+ * [[0.9,0,0,1]] call potato_markers_fnc_setMapMarkerColor;
  *
- * Public: Yes
+ * Public: No
  */
 
 #include "script_component.hpp"
@@ -31,11 +30,20 @@ private _markerColorString = (COLOR_TO_MARKER_HASH select 1) select _lookup;
 _lookup = -1;
 
 {
+    TRACE_2("loop", _markerColorString, _x select 0);
     if (_markerColorString == (_x select 0)) exitWith {
         _lookup = _forEachIndex;
     };
 } forEach ACEGVAR(markers,MarkerColorsCache);
 
+TRACE_4("vars", str _markerColor, _markerColorString, _lookup, ACEGVAR(markers,MarkerColorsCache));
+
 if (_lookup < 0) exitWith { WARNING("Provided color doesn't have matching ace MarkerColorsCache"); };
+
+// brute force lb selection
+if !(isNull findDisplay 12) then { ((findDisplay 12) displayCtrl 1090) lbSetCurSel _lookup; };
+if !(isNull findDisplay 37) then { ((findDisplay 37) displayCtrl 1090) lbSetCurSel _lookup; };
+if !(isNull findDisplay 52) then { ((findDisplay 52) displayCtrl 1090) lbSetCurSel _lookup; };
+if !(isNull findDisplay 53) then { ((findDisplay 53) displayCtrl 1090) lbSetCurSel _lookup; };
 
 ACEGVAR(markers,curSelMarkerColor) = _lookup;

--- a/addons/markers/functions/fnc_setMapMarkerColor.sqf
+++ b/addons/markers/functions/fnc_setMapMarkerColor.sqf
@@ -40,6 +40,8 @@ TRACE_4("vars", str _markerColor, _markerColorString, _lookup, ACEGVAR(markers,M
 
 if (_lookup < 0) exitWith { WARNING("Provided color doesn't have matching ace MarkerColorsCache"); };
 
+INFO_3("Setting Map Draw Color [Array:%1][Color:%2][Index:%3]",_markerColor,_markerColorString,_lookup);
+
 // brute force lb selection
 if !(isNull findDisplay 12) then { ((findDisplay 12) displayCtrl 1090) lbSetCurSel _lookup; };
 if !(isNull findDisplay 37) then { ((findDisplay 37) displayCtrl 1090) lbSetCurSel _lookup; };

--- a/addons/markers/functions/fnc_setMapMarkerColor.sqf
+++ b/addons/markers/functions/fnc_setMapMarkerColor.sqf
@@ -1,0 +1,41 @@
+/*
+ * Author: AACO
+ * Function used to add unit/group marker information into the marker hash
+ *
+ * Arguments:
+ * 0: Unit or Group to add to the marker system <OBJECT/GROUP>
+ *
+ * Return Value:
+ * True if the info was added to the hash, false otherwise <BOOL>
+ *
+ * Examples:
+ * [player] call potato_markers_fnc_addMarkerInfoToHash;
+ * [group player] call potato_markers_fnc_addMarkerInfoToHash;
+ *
+ * Public: Yes
+ */
+
+#include "script_component.hpp"
+TRACE_1("Params",_this);
+
+params [["_markerColor", [], []]];
+
+if (count _markerColor != 4) exitWith { WARNING("Provided color doesn't have correct arguments"); };
+
+private _lookup = (COLOR_TO_MARKER_HASH select 0) find (str _markerColor);
+
+if (_lookup < 0) exitWith { WARNING("Provided color doesn't have matching cfg marker color"); };
+
+private _markerColorString = (COLOR_TO_MARKER_HASH select 1) select _lookup;
+
+_lookup = -1;
+
+{
+    if (_markerColorString == (_x select 0)) exitWith {
+        _lookup = _forEachIndex;
+    };
+} forEach ACEGVAR(markers,MarkerColorsCache);
+
+if (_lookup < 0) exitWith { WARNING("Provided color doesn't have matching ace MarkerColorsCache"); };
+
+ACEGVAR(markers,curSelMarkerColor) = _lookup;

--- a/addons/markers/functions/fnc_setMarker.sqf
+++ b/addons/markers/functions/fnc_setMarker.sqf
@@ -21,6 +21,8 @@ if (_markerInfo isEqualType true && {_markerInfo}) exitWith { LOG("Marker not se
 
 [{
     params ["_object","_markerInfo"];
+    if (isNull _object) exitWith {}; // probably deleted by miscFixes empty group cleanup
+
     (_markerInfo splitString ",") params [
         ["_markerText", DEFAULT_MARKER_TEXT, [""]],
         ["_markerSize", str DEFAULT_MARKER_SIZE, [""]],

--- a/addons/markers/script_component.hpp
+++ b/addons/markers/script_component.hpp
@@ -31,6 +31,28 @@
 #define BLACK_ARRAY [0,0,0,1]
 #define PINK_ARRAY [1,0.753,0.796,1]
 
+#define COLOR_TO_MARKER_HASH [\
+    [\
+        QUOTE(RED_ARRAY),\
+        QUOTE(YELLOW_ARRAY),\
+        QUOTE(GREEN_ARRAY),\
+        QUOTE(BLUE_ARRAY),\
+        QUOTE(WHITE_ARRAY),\
+        QUOTE(ORANGE_ARRAY),\
+        QUOTE(BLACK_ARRAY),\
+        QUOTE(PINK_ARRAY)\
+    ], [\
+        "ColorRed",\
+        "ColorYellow",\
+        "ColorGreen",\
+        "ColorBlue",\
+        "ColorWhite",\
+        "ColorOrange",\
+        "ColorBlack",\
+        "ColorPink"\
+    ]\
+]
+
 #define DEFAULT_MARKER_TEXT ""
 #define DEFAULT_MARKER_ICON QPATHTOF(data\unknown.paa)
 #define DEFAULT_MARKER_COLOR_TEXT "white"

--- a/addons/markers/script_component.hpp
+++ b/addons/markers/script_component.hpp
@@ -42,14 +42,14 @@
         QUOTE(BLACK_ARRAY),\
         QUOTE(PINK_ARRAY)\
     ], [\
-        "ColorRed",\
-        "ColorYellow",\
-        "ColorGreen",\
-        "ColorBlue",\
-        "ColorWhite",\
-        "ColorOrange",\
-        "ColorBlack",\
-        "ColorPink"\
+        "Red",\
+        "Yellow",\
+        "Green",\
+        "Blue",\
+        "White",\
+        "Yellow",\
+        "Black",\
+        "White"\
     ]\
 ]
 


### PR DESCRIPTION
(based off of #128 )
Preset's a unit's map marking color based on the unit's group or the leader of the group's marker.

@PabstMirror I will admit it's hacky as fuck, but functional.