### PR TITLE
Expand max groups, use createGroup array syntax

### DIFF
--- a/addons/respawn/functions/fnc_respawnClient.sqf
+++ b/addons/respawn/functions/fnc_respawnClient.sqf
@@ -51,7 +51,7 @@ if (EGVAR(spectate,running)) then {
 };
 
 // create temp group and new unit
-private _tempGroup = createGroup (side _group);
+private _tempGroup = createGroup [side _group, true]; // explicitly mark for cleanup (even though we delete below)
 private _newUnit = _tempGroup createUnit [_unitType, _position, [], 0, "NONE"];
 
 // if unit is medic add marker attributes

--- a/addons/respawn/functions/fnc_triggerRespawn.sqf
+++ b/addons/respawn/functions/fnc_triggerRespawn.sqf
@@ -81,7 +81,7 @@ if (_position isEqualTo [-999, -999]) exitWith { ERROR("Invalid position given t
                 "_colorTeamArray"
             ];
 
-            private _newRespawnGroup = createGroup _factionSide;
+            private _newRespawnGroup = createGroup [_factionSide, true]; // explicitly mark for cleanup
             TRACE_2("new group", _factionSide, _newRespawnGroup);
 
             if (_markerTexture != "") then {

--- a/addons/spectate/XEH_postServerInit.sqf
+++ b/addons/spectate/XEH_postServerInit.sqf
@@ -11,7 +11,7 @@ if (GVAR(enabled)) then {
             missionNamespace getVariable [QEGVAR(miscFixes,groupCleanupRan), false] || diag_tickTime > (_this select 0)
         },
         {
-            GVAR(group) = createGroup sideLogic;
+            GVAR(group) = createGroup [sideLogic, false]; // explicitly mark for persistence
             publicVariable QGVAR(group);
             GVAR(holderUnit) = GVAR(group) createUnit [QGVAR(holder), ZERO_POS, [], 200, "NONE"];
             GVAR(holderUnit) setVariable [QACEGVAR(zeus,addObject), false, true];

--- a/addons/spectate/functions/fnc_init.sqf
+++ b/addons/spectate/functions/fnc_init.sqf
@@ -71,7 +71,7 @@ _newUnit setPos ZERO_POS;
 [_newUnit, true] remoteExecCall ["hideObjectGlobal", SERVER_CLIENT_ID];
 
 // create spectator unit
-private _tempGroup = createGroup sideLogic;
+private _tempGroup = createGroup [sideLogic, true]; // explicitly mark for cleanup (even though we delete below)
 GVAR(unit) = _tempGroup createUnit [QGVAR(spectator), ZERO_POS, [], 200, "NONE"];
 GVAR(unit) setVariable [QEGVAR(radios,assignedLanguages), GVAR(availableLanguages)];
 selectPlayer GVAR(unit);

--- a/addons/zeusFactory/functions/fnc_createGroup.sqf
+++ b/addons/zeusFactory/functions/fnc_createGroup.sqf
@@ -28,7 +28,7 @@ if (!([_side, count _soldierList, false] call EFUNC(zeusHC,canCreateGroup))) exi
     []
 };
 
-private _group = createGroup _side;
+private _group = createGroup [_side, true]; // explicitly mark for cleanup
 
 private _unitType = _soldierList deleteAt 0; // Create Leader Now
 private _unit = _group createUnit [_unitType, (_factoryLogic getPos [10, random 360]), [], 0, "NONE"];

--- a/addons/zeusFactory/functions/fnc_createTransport.sqf
+++ b/addons/zeusFactory/functions/fnc_createTransport.sqf
@@ -10,7 +10,7 @@ if ((_vehType == "") || {_crewType == ""}) exitWith {ERROR_2("bad data[%1-%2]",_
 
 private _vehicle = _vehType createVehicle ((leader _group) getRelPos [5, 0]);
 
-private _group = createGroup _side;
+private _group = createGroup [_side, true]; // explicitly mark for cleanup
 private _driver = _group createUnit [_crewType, (getPos _vehicle), [], 0, "NONE"];
 
 [{

--- a/addons/zeusHC/ACE_Settings.hpp
+++ b/addons/zeusHC/ACE_Settings.hpp
@@ -5,11 +5,11 @@ class ACE_Settings {
     };
     class GVAR(maxGroupCountPerSide) {
         typeName = "SCALAR";
-        value = 140;
+        value = 280;
     };
     class GVAR(delayBetweenUnitCreation) {
         typeName = "SCALAR";
-        value = 0.25;
+        value = 0.3;
     };
     class GVAR(delayBetweenGroupCreation) {
         typeName = "SCALAR";

--- a/addons/zeusHC/functions/fnc_createCrew.sqf
+++ b/addons/zeusHC/functions/fnc_createCrew.sqf
@@ -47,7 +47,7 @@ private _crewCount = {
 TRACE_1("",_crew);
 
 if ([_side, _crewCount] call FUNC(canCreateGroup)) then {
-    private _group = createGroup _side;
+    private _group = createGroup [_side, true]; // explicitly mark for cleanup
 
     {
         private _unit = _group createUnit [_crewType, [0,0,0], [], 0, "NONE"];

--- a/addons/zeusHC/functions/fnc_createEntityDismounts.sqf
+++ b/addons/zeusHC/functions/fnc_createEntityDismounts.sqf
@@ -23,7 +23,7 @@ if !([_side, count _createUnits] call FUNC(canCreateGroup)) exitWith {
     ["Cannot create a new group at this time", _placerOwner] call FUNC(sendCuratorHint);
 };
 
-private _newGroup = createGroup _side;
+private _newGroup = createGroup [_side, true]; // explicitly mark for cleanup
 
 private _cargoSelection = getText (configFile >> "CfgVehicles" >> (typeOf _attachedVehicle) >> "memoryPointsGetInCargo");
 if (_cargoSelection == "") then {

--- a/addons/zeusHC/functions/fnc_createGroup.sqf
+++ b/addons/zeusHC/functions/fnc_createGroup.sqf
@@ -37,7 +37,7 @@ private _numUnitsToSpawn = count _classNames;
 if !([_side, _numUnitsToSpawn] call FUNC(canCreateGroup)) exitWith { grpNull };
 
 private _unitInitFunction = compile _code;
-private _newGroup = createGroup _side;
+private _newGroup = createGroup [_side, true]; // explicitly mark for cleanup
 
 {
     private _newUnit = _newGroup createUnit [_x, _position, [], 0, _special];

--- a/addons/zeusHC/functions/fnc_fixGroup.sqf
+++ b/addons/zeusHC/functions/fnc_fixGroup.sqf
@@ -28,7 +28,7 @@ _this spawn {
         ["_group", grpNull, [grpNull]]
     ];
 
-    private _newGroup = createGroup (side _group);
+    private _newGroup = createGroup [side _group, true]; // explicitly mark for cleanup
     _newGroup copyWaypoints _group;
 
     private _index = (count (units _group)) - 1;


### PR DESCRIPTION
In 1.68 they expanded the max groups per size to 288, so I updated our limit to 280 (incase someone spawns a lot of 1/2 man groups)

I also used the expanded syntax for explicit cleanup/persistence.