### PR TITLE
Respawn fixes

### DIFF
--- a/addons/respawn/functions/fnc_respawnClient.sqf
+++ b/addons/respawn/functions/fnc_respawnClient.sqf
@@ -82,28 +82,30 @@ if !(isNull _zeusModule) then {
     [_newUnit, _zeusModule] remoteExec [QEFUNC(spectate,transferZeus), SERVER_CLIENT_ID];
 };
 
-// do anything else that needs a delay
-[_newUnit, _group, _rank, _isLeader, _colorTeam] spawn {
-    sleep 10;
-    // validate objects
-    params [
-        ["_newUnit", objNull, [objNull]],
-        ["_group", grpNull, [grpNull]],
-        ["_rank", "private", [""]],
-        ["_isLeader", false, [false]],
-        ["_colorTeam", "MAIN", [""]]
-    ];
-    if (isNull _newUnit || isNull _group) exitWith { WARNING("Group or unit null on delayed execution"); };
+[
+    {
+        params [
+            ["_newUnit", objNull, [objNull]],
+            ["_group", grpNull, [grpNull]],
+            ["_rank", "private", [""]],
+            ["_isLeader", false, [false]],
+            ["_colorTeam", "MAIN", [""]]
+        ];
 
-    // if the unit is the leader, force the selection
-    if (_isLeader) then {
-        _group selectLeader _newUnit;
-    };
+        if (isNull _newUnit || isNull _group) exitWith { WARNING("Group or unit null on delayed execution"); };
 
-    // set new unit rank, fix rating
-    _newUnit setRank _rank; // note setRank will be EG in 1.68
-    _newUnit addRating (25000 - (rating _newUnit));
+        // if the unit is the leader, force the selection
+        if (_isLeader) then {
+            [_group, _newUnit] remoteExecCall ["selectLeader", _group];
+        };
 
-    // assign the unit's color team
-    _newUnit assignTeam _colorTeam;
-};
+        // set new unit rank, fix rating
+        _newUnit setRank _rank;
+        _newUnit addRating (25000 - (rating _newUnit));
+
+        // assign the unit's color team
+        _newUnit assignTeam _colorTeam;
+    },
+    [_newUnit, _group, _rank, _isLeader, _colorTeam],
+    10
+] call CBA_fnc_waitAndExecute;

--- a/addons/respawn/functions/fnc_triggerRespawn.sqf
+++ b/addons/respawn/functions/fnc_triggerRespawn.sqf
@@ -103,25 +103,46 @@ if (_position isEqualTo [-999, -999]) exitWith { ERROR("Invalid position given t
                 private _unit = _x select 3;
 
                 if !(isNull _unit) then {
-                    (_unitsArray select _forEachIndex) params [
-                        "",
-                        "",
-                        ["_unitType", "soldier_f", [""]],
-                        ["_unitRank", "private", [""]],
-                        ["_unitColorTeamIndex", 0, [0]],
-                        ["_isUnitLeader", false, [false]],
-                        ["_isUnitMedic", false, [false]]
-                    ];
-
                     [
-                        _newRespawnGroup,
-                        format ["%1%2", _factionPrefix, _unitType],
-                        _position,
-                        _colorTeamArray select _unitColorTeamIndex,
-                        _unitRank,
-                        _isUnitLeader,
-                        _isUnitMedic
-                    ] remoteExecCall [QFUNC(respawnClient), _unit];
+                        {
+                            params [
+                                "_newRespawnGroup",
+                                "_unit",
+                                "_factionPrefix",
+                                "_colorTeamArray",
+                                "_position",
+                                "_unitArray"
+                            ];
+
+                            _unitArray params [
+                                "",
+                                "",
+                                ["_unitType", "soldier_f", [""]],
+                                ["_unitRank", "private", [""]],
+                                ["_unitColorTeamIndex", 0, [0]],
+                                ["_isUnitLeader", false, [false]],
+                                ["_isUnitMedic", false, [false]]
+                            ];
+
+                            [
+                                _newRespawnGroup,
+                                format ["%1%2", _factionPrefix, _unitType],
+                                _position,
+                                _colorTeamArray select _unitColorTeamIndex,
+                                _unitRank,
+                                _isUnitLeader,
+                                _isUnitMedic
+                            ] remoteExecCall [QFUNC(respawnClient), _unit];
+                        }, [
+                            _newRespawnGroup,
+                            _unit,
+                            _factionPrefix,
+                            _colorTeamArray,
+                            _position,
+                            _unitsArray select _forEachIndex
+                        ],
+                        1
+                    ] call CBA_fnc_waitAndExecute;
 
                     _position set [0, (_position select 0) + UNIT_SPACING];
                 };


### PR DESCRIPTION
- Add delay after group creation to add units to it (should allow time for the group variables to be properly set)

- Change how group leaders are selected, make sure it's executed where the group is local