### PR TITLE
Deprecate no radar

### DIFF
--- a/addons/noRadar/config.cpp
+++ b/addons/noRadar/config.cpp
@@ -26,771 +26,925 @@ class CfgVehicles {
     class O_Heli_Light_02_F;
     class O_Heli_Light_02_F_R8: O_Heli_Light_02_F {
         radarType = 8;
+        scope = 1;
         displayName = "Ka-60 Kasatka[R8]";
     };
     class B_Heli_Attack_01_F;
     class B_Heli_Attack_01_F_R8: B_Heli_Attack_01_F {
         radarType = 8;
+        scope = 1;
         displayName = "RAH-66 Comanche[R8]";
     };
     class O_Heli_Attack_02_F;
     class O_Heli_Attack_02_F_R8: O_Heli_Attack_02_F {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-48 Kajman[R8]";
     };
     class O_Heli_Attack_02_black_F;
     class O_Heli_Attack_02_black_F_R8: O_Heli_Attack_02_black_F {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-48 Kajman (Black)[R8]";
     };
     class I_Plane_Fighter_03_CAS_F;
     class I_Plane_Fighter_03_CAS_F_R8: I_Plane_Fighter_03_CAS_F {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 ALCA (CAS)[R8]";
     };
     class I_Plane_Fighter_03_AA_F;
     class I_Plane_Fighter_03_AA_F_R8: I_Plane_Fighter_03_AA_F {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 ALCA (AA)[R8]";
     };
     class B_APC_Tracked_01_AA_F;
     class B_APC_Tracked_01_AA_F_R8: B_APC_Tracked_01_AA_F {
         radarType = 8;
+        scope = 1;
         displayName = "Bardelas[R8]";
     };
     class O_APC_Tracked_02_AA_F;
     class O_APC_Tracked_02_AA_F_R8: O_APC_Tracked_02_AA_F {
         radarType = 8;
+        scope = 1;
         displayName = "ZSU-35 Tigris[R8]";
     };
     class B_Plane_CAS_01_F;
     class B_Plane_CAS_01_F_R8: B_Plane_CAS_01_F {
         radarType = 8;
+        scope = 1;
         displayName = "A-10D Thunderbolt II[R8]";
     };
     class O_Plane_CAS_02_F;
     class O_Plane_CAS_02_F_R8: O_Plane_CAS_02_F {
         radarType = 8;
+        scope = 1;
         displayName = "Yak-130[R8]";
     };
     class B_UAV_02_F;
     class B_UAV_02_F_R8: B_UAV_02_F {
         radarType = 8;
+        scope = 1;
         displayName = "YABHON-R3[R8]";
     };
     class O_UAV_02_F;
     class O_UAV_02_F_R8: O_UAV_02_F {
         radarType = 8;
+        scope = 1;
         displayName = "YABHON-R3[R8]";
     };
     class I_UAV_02_F;
     class I_UAV_02_F_R8: I_UAV_02_F {
         radarType = 8;
+        scope = 1;
         displayName = "YABHON-R3[R8]";
     };
     class B_UAV_02_CAS_F;
     class B_UAV_02_CAS_F_R8: B_UAV_02_CAS_F {
         radarType = 8;
+        scope = 1;
         displayName = "YABHON-R3 (CAS)[R8]";
     };
     class O_UAV_02_CAS_F;
     class O_UAV_02_CAS_F_R8: O_UAV_02_CAS_F {
         radarType = 8;
+        scope = 1;
         displayName = "YABHON-R3 (CAS)[R8]";
     };
     class I_UAV_02_CAS_F;
     class I_UAV_02_CAS_F_R8: I_UAV_02_CAS_F {
         radarType = 8;
+        scope = 1;
         displayName = "YABHON-R3 (CAS)[R8]";
     };
     class rhsusf_f22;
     class rhsusf_f22_R8: rhsusf_f22 {
         radarType = 8;
+        scope = 1;
         displayName = "F-22A[R8]";
     };
     class B_T_UAV_03_F;
     class B_T_UAV_03_F_R8: B_T_UAV_03_F {
         radarType = 8;
+        scope = 1;
         displayName = "MQ-12 Falcon[R8]";
     };
     class O_T_UAV_04_CAS_F;
     class O_T_UAV_04_CAS_F_R8: O_T_UAV_04_CAS_F {
         radarType = 8;
+        scope = 1;
         displayName = "Burraq UCAV[R8]";
     };
     class B_T_VTOL_01_infantry_F;
     class B_T_VTOL_01_infantry_F_R8: B_T_VTOL_01_infantry_F {
         radarType = 8;
+        scope = 1;
         displayName = "V-44 X Blackfish (Infantry Transport)[R8]";
     };
     class B_T_VTOL_01_vehicle_F;
     class B_T_VTOL_01_vehicle_F_R8: B_T_VTOL_01_vehicle_F {
         radarType = 8;
+        scope = 1;
         displayName = "V-44 X Blackfish (Vehicle Transport)[R8]";
     };
     class B_T_VTOL_01_armed_F;
     class B_T_VTOL_01_armed_F_R8: B_T_VTOL_01_armed_F {
         radarType = 8;
+        scope = 1;
         displayName = "V-44 X Blackfish (Armed)[R8]";
     };
     class O_T_VTOL_02_infantry_F;
     class O_T_VTOL_02_infantry_F_R8: O_T_VTOL_02_infantry_F {
         radarType = 8;
+        scope = 1;
         displayName = "Y-32 Xi'an (Infantry Transport)[R8]";
     };
     class O_T_VTOL_02_vehicle_F;
     class O_T_VTOL_02_vehicle_F_R8: O_T_VTOL_02_vehicle_F {
         radarType = 8;
+        scope = 1;
         displayName = "Y-32 Xi'an (Vehicle Transport)[R8]";
     };
     class B_T_APC_Tracked_01_AA_F;
     class B_T_APC_Tracked_01_AA_F_R8: B_T_APC_Tracked_01_AA_F {
         radarType = 8;
+        scope = 1;
         displayName = "Bardelas[R8]";
     };
     class O_T_APC_Tracked_02_AA_ghex_F;
     class O_T_APC_Tracked_02_AA_ghex_F_R8: O_T_APC_Tracked_02_AA_ghex_F {
         radarType = 8;
+        scope = 1;
         displayName = "ZSU-35 Tigris[R8]";
     };
     class RHS_Mi24P_vvs;
     class RHS_Mi24P_vvs_R8: RHS_Mi24P_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24P (FAB)[R8]";
     };
     class RHS_Mi24P_vvsc;
     class RHS_Mi24P_vvsc_R8: RHS_Mi24P_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24P (FAB)[R8]";
     };
     class RHS_Mi24P_CAS_vvs;
     class RHS_Mi24P_CAS_vvs_R8: RHS_Mi24P_CAS_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24P (CAS)[R8]";
     };
     class RHS_Mi24P_CAS_vvsc;
     class RHS_Mi24P_CAS_vvsc_R8: RHS_Mi24P_CAS_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24P (CAS)[R8]";
     };
     class RHS_Mi24P_CAS_vdv;
     class RHS_Mi24P_CAS_vdv_R8: RHS_Mi24P_CAS_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24P (CAS)[R8]";
     };
     class RHS_Mi24P_AT_vvs;
     class RHS_Mi24P_AT_vvs_R8: RHS_Mi24P_AT_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24P (AT)[R8]";
     };
     class RHS_Mi24P_AT_vvsc;
     class RHS_Mi24P_AT_vvsc_R8: RHS_Mi24P_AT_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24P (AT)[R8]";
     };
     class RHS_Mi24P_AT_vdv;
     class RHS_Mi24P_AT_vdv_R8: RHS_Mi24P_AT_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24P (AT)[R8]";
     };
     class RHS_Mi24P_vdv;
     class RHS_Mi24P_vdv_R8: RHS_Mi24P_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24P (FAB)[R8]";
     };
     class RHS_Mi24V_vvs;
     class RHS_Mi24V_vvs_R8: RHS_Mi24V_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (CAS)[R8]";
     };
     class RHS_Mi24V_vvsc;
     class RHS_Mi24V_vvsc_R8: RHS_Mi24V_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (CAS)[R8]";
     };
     class RHS_Mi24V_FAB_vvs;
     class RHS_Mi24V_FAB_vvs_R8: RHS_Mi24V_FAB_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (FAB)[R8]";
     };
     class RHS_Mi24V_FAB_vvsc;
     class RHS_Mi24V_FAB_vvsc_R8: RHS_Mi24V_FAB_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (FAB)[R8]";
     };
     class RHS_Mi24V_FAB_vdv;
     class RHS_Mi24V_FAB_vdv_R8: RHS_Mi24V_FAB_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (FAB)[R8]";
     };
     class RHS_Mi24V_UPK23_vvs;
     class RHS_Mi24V_UPK23_vvs_R8: RHS_Mi24V_UPK23_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (UPK)[R8]";
     };
     class RHS_Mi24V_UPK23_vvsc;
     class RHS_Mi24V_UPK23_vvsc_R8: RHS_Mi24V_UPK23_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (UPK)[R8]";
     };
     class RHS_Mi24V_UPK23_vdv;
     class RHS_Mi24V_UPK23_vdv_R8: RHS_Mi24V_UPK23_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (UPK)[R8]";
     };
     class RHS_Mi24V_AT_vvs;
     class RHS_Mi24V_AT_vvs_R8: RHS_Mi24V_AT_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (AT)[R8]";
     };
     class RHS_Mi24V_AT_vvsc;
     class RHS_Mi24V_AT_vvsc_R8: RHS_Mi24V_AT_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (AT)[R8]";
     };
     class RHS_Mi24V_AT_vdv;
     class RHS_Mi24V_AT_vdv_R8: RHS_Mi24V_AT_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (AT)[R8]";
     };
     class RHS_Mi24Vt_vvs;
     class RHS_Mi24Vt_vvs_R8: RHS_Mi24Vt_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24VT[R8]";
     };
     class RHS_Mi24Vt_vvsc;
     class RHS_Mi24Vt_vvsc_R8: RHS_Mi24Vt_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24VT[R8]";
     };
     class RHS_Mi24V_vdv;
     class RHS_Mi24V_vdv_R8: RHS_Mi24V_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (CAS)[R8]";
     };
     class RHS_Mi8mt_vvs;
     class RHS_Mi8mt_vvs_R8: RHS_Mi8mt_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MT[R8]";
     };
     class RHS_Mi8mt_vvsc;
     class RHS_Mi8mt_vvsc_R8: RHS_Mi8mt_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MT[R8]";
     };
     class RHS_Mi8mt_vdv;
     class RHS_Mi8mt_vdv_R8: RHS_Mi8mt_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MT[R8]";
     };
     class RHS_Mi8mt_vv;
     class RHS_Mi8mt_vv_R8: RHS_Mi8mt_vv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MT[R8]";
     };
     class RHS_Mi8mt_Cargo_vvs;
     class RHS_Mi8mt_Cargo_vvs_R8: RHS_Mi8mt_Cargo_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MT (Cargo)[R8]";
     };
     class RHS_Mi8mt_Cargo_vvsc;
     class RHS_Mi8mt_Cargo_vvsc_R8: RHS_Mi8mt_Cargo_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MT (Cargo)[R8]";
     };
     class RHS_Mi8mt_Cargo_vdv;
     class RHS_Mi8mt_Cargo_vdv_R8: RHS_Mi8mt_Cargo_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MT (Cargo)[R8]";
     };
     class RHS_Mi8mt_Cargo_vv;
     class RHS_Mi8mt_Cargo_vv_R8: RHS_Mi8mt_Cargo_vv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MT (Cargo)[R8]";
     };
     class RHS_Mi8MTV3_vvs;
     class RHS_Mi8MTV3_vvs_R8: RHS_Mi8MTV3_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MTV-3[R8]";
     };
     class RHS_Mi8MTV3_vvsc;
     class RHS_Mi8MTV3_vvsc_R8: RHS_Mi8MTV3_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MTV-3[R8]";
     };
     class RHS_Mi8MTV3_vdv;
     class RHS_Mi8MTV3_vdv_R8: RHS_Mi8MTV3_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MTV-3[R8]";
     };
     class RHS_Mi8MTV3_UPK23_vvs;
     class RHS_Mi8MTV3_UPK23_vvs_R8: RHS_Mi8MTV3_UPK23_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MTV-3 (UPK)[R8]";
     };
     class RHS_Mi8MTV3_UPK23_vvsc;
     class RHS_Mi8MTV3_UPK23_vvsc_R8: RHS_Mi8MTV3_UPK23_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MTV-3 (UPK)[R8]";
     };
     class RHS_Mi8MTV3_UPK23_vdv;
     class RHS_Mi8MTV3_UPK23_vdv_R8: RHS_Mi8MTV3_UPK23_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MTV-3 (UPK)[R8]";
     };
     class RHS_Mi8MTV3_FAB_vvs;
     class RHS_Mi8MTV3_FAB_vvs_R8: RHS_Mi8MTV3_FAB_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MTV-3 (FAB)[R8]";
     };
     class RHS_Mi8MTV3_FAB_vvsc;
     class RHS_Mi8MTV3_FAB_vvsc_R8: RHS_Mi8MTV3_FAB_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MTV-3 (FAB)[R8]";
     };
     class RHS_Mi8MTV3_FAB_vdv;
     class RHS_Mi8MTV3_FAB_vdv_R8: RHS_Mi8MTV3_FAB_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8MTV-3 (FAB)[R8]";
     };
     class RHS_Mi8AMT_vvs;
     class RHS_Mi8AMT_vvs_R8: RHS_Mi8AMT_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMT[R8]";
     };
     class RHS_Mi8AMT_vvsc;
     class RHS_Mi8AMT_vvsc_R8: RHS_Mi8AMT_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMT[R8]";
     };
     class RHS_Mi8AMT_vdv;
     class RHS_Mi8AMT_vdv_R8: RHS_Mi8AMT_vdv {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMT[R8]";
     };
     class RHS_Mi8AMTSh_vvs;
     class RHS_Mi8AMTSh_vvs_R8: RHS_Mi8AMTSh_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMTSh[R8]";
     };
     class RHS_Mi8AMTSh_vvsc;
     class RHS_Mi8AMTSh_vvsc_R8: RHS_Mi8AMTSh_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMTSh[R8]";
     };
     class RHS_Mi8AMTSh_UPK23_vvs;
     class RHS_Mi8AMTSh_UPK23_vvs_R8: RHS_Mi8AMTSh_UPK23_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMTSh (UPK)[R8]";
     };
     class RHS_Mi8AMTSh_UPK23_vvsc;
     class RHS_Mi8AMTSh_UPK23_vvsc_R8: RHS_Mi8AMTSh_UPK23_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMTSh (UPK)[R8]";
     };
     class RHS_Mi8AMTSh_FAB_vvs;
     class RHS_Mi8AMTSh_FAB_vvs_R8: RHS_Mi8AMTSh_FAB_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMTSh (FAB)[R8]";
     };
     class RHS_Mi8AMTSh_FAB_vvsc;
     class RHS_Mi8AMTSh_FAB_vvsc_R8: RHS_Mi8AMTSh_FAB_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMTSh (FAB)[R8]";
     };
     class RHS_Mi8amt_civilian;
     class RHS_Mi8amt_civilian_R8: RHS_Mi8amt_civilian {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMT[R8]";
     };
     class RHS_Su25SM_vvs;
     class RHS_Su25SM_vvs_R8: RHS_Su25SM_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Su-25[R8]";
     };
     class RHS_Su25SM_KH29_vvs;
     class RHS_Su25SM_KH29_vvs_R8: RHS_Su25SM_KH29_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Su-25 (KH29)[R8]";
     };
     class RHS_Su25SM_CAS_vvs;
     class RHS_Su25SM_CAS_vvs_R8: RHS_Su25SM_CAS_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Su-25 (CAS)[R8]";
     };
     class RHS_Su25SM_vvsc;
     class RHS_Su25SM_vvsc_R8: RHS_Su25SM_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Su-25[R8]";
     };
     class RHS_Su25SM_KH29_vvsc;
     class RHS_Su25SM_KH29_vvsc_R8: RHS_Su25SM_KH29_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Su-25 (KH29)[R8]";
     };
     class RHS_Su25SM_CAS_vvsc;
     class RHS_Su25SM_CAS_vvsc_R8: RHS_Su25SM_CAS_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Su-25 (CAS)[R8]";
     };
     class RHS_Ka52_vvsc;
     class RHS_Ka52_vvsc_R8: RHS_Ka52_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Ka-52[R8]";
     };
     class RHS_Ka52_vvs;
     class RHS_Ka52_vvs_R8: RHS_Ka52_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Ka-52[R8]";
     };
     class RHS_Ka52_UPK23_vvs;
     class RHS_Ka52_UPK23_vvs_R8: RHS_Ka52_UPK23_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Ka-52 (UPK)[R8]";
     };
     class RHS_Ka52_UPK23_vvsc;
     class RHS_Ka52_UPK23_vvsc_R8: RHS_Ka52_UPK23_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Ka-52 (UPK)[R8]";
     };
     class rhs_pchela1t_vvs;
     class rhs_pchela1t_vvs_R8: rhs_pchela1t_vvs {
         radarType = 8;
+        scope = 1;
         displayName = "Pchela-1T[R8]";
     };
     class rhs_pchela1t_vvsc;
     class rhs_pchela1t_vvsc_R8: rhs_pchela1t_vvsc {
         radarType = 8;
+        scope = 1;
         displayName = "Pchela-1T[R8]";
     };
     class RHS_T50_vvs_051;
     class RHS_T50_vvs_051_R8: RHS_T50_vvs_051 {
         radarType = 8;
+        scope = 1;
         displayName = "Sukhoi T-50 obr. 2011 (051)[R8]";
     };
     class RHS_T50_vvs_052;
     class RHS_T50_vvs_052_R8: RHS_T50_vvs_052 {
         radarType = 8;
+        scope = 1;
         displayName = "Sukhoi T-50 obr. 2011 (052)[R8]";
     };
     class RHS_T50_vvs_053;
     class RHS_T50_vvs_053_R8: RHS_T50_vvs_053 {
         radarType = 8;
+        scope = 1;
         displayName = "Sukhoi T-50 obr. 2011 (053)[R8]";
     };
     class RHS_T50_vvs_054;
     class RHS_T50_vvs_054_R8: RHS_T50_vvs_054 {
         radarType = 8;
+        scope = 1;
         displayName = "Sukhoi T-50 obr. 2012 (054)[R8]";
     };
     class RHS_T50_vvs_blueonblue;
     class RHS_T50_vvs_blueonblue_R8: RHS_T50_vvs_blueonblue {
         radarType = 8;
+        scope = 1;
         displayName = "Sukhoi T-50 obr. 2013 (055)[R8]";
     };
     class RHS_T50_vvs_generic;
     class RHS_T50_vvs_generic_R8: RHS_T50_vvs_generic {
         radarType = 8;
+        scope = 1;
         displayName = "Sukhoi T-50 obr. 2011[R8]";
     };
     class rhs_l159_CDF;
     class rhs_l159_CDF_R8: rhs_l159_CDF {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 ALCA[R8]";
     };
     class rhs_l159_CDF_plamen;
     class rhs_l159_CDF_plamen_R8: rhs_l159_CDF_plamen {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 (Plamen)[R8]";
     };
     class rhs_l159_CDF_CAP;
     class rhs_l159_CDF_CAP_R8: rhs_l159_CDF_CAP {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 (CAP)[R8]";
     };
     class rhs_l159_CDF_CAS;
     class rhs_l159_CDF_CAS_R8: rhs_l159_CDF_CAS {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 (CAS)[R8]";
     };
     class rhs_l39_cdf;
     class rhs_l39_cdf_R8: rhs_l39_cdf {
         radarType = 8;
+        scope = 1;
         displayName = "L-39C Albatros[R8]";
     };
     class rhs_l159_cdf_b_CDF;
     class rhs_l159_cdf_b_CDF_R8: rhs_l159_cdf_b_CDF {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 ALCA[R8]";
     };
     class rhs_l159_cdf_b_CDF_plamen;
     class rhs_l159_cdf_b_CDF_plamen_R8: rhs_l159_cdf_b_CDF_plamen {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 (Plamen)[R8]";
     };
     class rhs_l159_cdf_b_CDF_CAP;
     class rhs_l159_cdf_b_CDF_CAP_R8: rhs_l159_cdf_b_CDF_CAP {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 (CAP)[R8]";
     };
     class rhs_l159_cdf_b_CDF_CAS;
     class rhs_l159_cdf_b_CDF_CAS_R8: rhs_l159_cdf_b_CDF_CAS {
         radarType = 8;
+        scope = 1;
         displayName = "L-159 (CAS)[R8]";
     };
     class rhs_l39_cdf_b_cdf;
     class rhs_l39_cdf_b_cdf_R8: rhs_l39_cdf_b_cdf {
         radarType = 8;
+        scope = 1;
         displayName = "L-39C Albatros[R8]";
     };
     class RHS_AN2;
     class RHS_AN2_R8: RHS_AN2 {
         radarType = 8;
+        scope = 1;
         displayName = "Antonov An-2[R8]";
     };
     class RHS_AN2_B;
     class RHS_AN2_B_R8: RHS_AN2_B {
         radarType = 8;
+        scope = 1;
         displayName = "Antonov An-2[R8]";
     };
     class rhsgref_cdf_Mi35;
     class rhsgref_cdf_Mi35_R8: rhsgref_cdf_Mi35 {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (CAS)[R8]";
     };
     class rhsgref_mi24g_CAS;
     class rhsgref_mi24g_CAS_R8: rhsgref_mi24g_CAS {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24G[R8]";
     };
     class rhsgref_mi24g_UPK23;
     class rhsgref_mi24g_UPK23_R8: rhsgref_mi24g_UPK23 {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24G (UPK)[R8]";
     };
     class rhsgref_mi24g_FAB;
     class rhsgref_mi24g_FAB_R8: rhsgref_mi24g_FAB {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24G (FAB)[R8]";
     };
     class rhsgref_b_mi24g_CAS;
     class rhsgref_b_mi24g_CAS_R8: rhsgref_b_mi24g_CAS {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24G[R8]";
     };
     class rhsgref_b_mi24g_UPK23;
     class rhsgref_b_mi24g_UPK23_R8: rhsgref_b_mi24g_UPK23 {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24G (UPK)[R8]";
     };
     class rhsgref_b_mi24g_FAB;
     class rhsgref_b_mi24g_FAB_R8: rhsgref_b_mi24g_FAB {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24G (FAB)[R8]";
     };
     class rhs_zsu234_aa;
     class rhs_zsu234_aa_R8: rhs_zsu234_aa {
         radarType = 8;
+        scope = 1;
         displayName = "ZSU-23-4V[R8]";
     };
     class RHS_AH64D;
     class RHS_AH64D_R8: RHS_AH64D {
         radarType = 8;
+        scope = 1;
         displayName = "AH-64D (Multi-Role)[R8]";
     };
     class RHS_AH64D_GS;
     class RHS_AH64D_GS_R8: RHS_AH64D_GS {
         radarType = 8;
+        scope = 1;
         displayName = "AH-64D (Ground-Suppression)[R8]";
     };
     class RHS_AH64D_CS;
     class RHS_AH64D_CS_R8: RHS_AH64D_CS {
         radarType = 8;
+        scope = 1;
         displayName = "AH-64D (Close-Support)[R8]";
     };
     class RHS_AH64D_wd;
     class RHS_AH64D_wd_R8: RHS_AH64D_wd {
         radarType = 8;
+        scope = 1;
         displayName = "AH-64D (Multi-Role)[R8]";
     };
     class RHS_AH64D_wd_GS;
     class RHS_AH64D_wd_GS_R8: RHS_AH64D_wd_GS {
         radarType = 8;
+        scope = 1;
         displayName = "AH-64D (Ground-Suppression)[R8]";
     };
     class RHS_AH64D_wd_CS;
     class RHS_AH64D_wd_CS_R8: RHS_AH64D_wd_CS {
         radarType = 8;
+        scope = 1;
         displayName = "AH-64D (Close-Support)[R8]";
     };
     class RHS_AH64D_AA;
     class RHS_AH64D_AA_R8: RHS_AH64D_AA {
         radarType = 8;
+        scope = 1;
         displayName = "AH-64D (AA)[R8]";
     };
     class RHS_AH64D_wd_AA;
     class RHS_AH64D_wd_AA_R8: RHS_AH64D_wd_AA {
         radarType = 8;
+        scope = 1;
         displayName = "AH-64D (AA)[R8]";
     };
     class RHS_AH64DGrey;
     class RHS_AH64DGrey_R8: RHS_AH64DGrey {
         radarType = 8;
+        scope = 1;
         displayName = "AH-64D (OIF Grey)[R8]";
     };
     class RHS_C130J;
     class RHS_C130J_R8: RHS_C130J {
         radarType = 8;
+        scope = 1;
         displayName = "C-130J[R8]";
     };
     class RHS_A10;
     class RHS_A10_R8: RHS_A10 {
         radarType = 8;
+        scope = 1;
         displayName = "A-10A (CAS)[R8]";
     };
     class RHS_A10_AT;
     class RHS_A10_AT_R8: RHS_A10_AT {
         radarType = 8;
+        scope = 1;
         displayName = "A-10A (AT)[R8]";
     };
     class rhsusf_CH53E_USMC;
     class rhsusf_CH53E_USMC_R8: rhsusf_CH53E_USMC {
         radarType = 8;
+        scope = 1;
         displayName = "CH-53E[R8]";
     };
     class rhsusf_CH53E_USMC_D;
     class rhsusf_CH53E_USMC_D_R8: rhsusf_CH53E_USMC_D {
         radarType = 8;
+        scope = 1;
         displayName = "CH-53E[R8]";
     };
     class rhsusf_mkvsoc;
     class rhsusf_mkvsoc_R8: rhsusf_mkvsoc {
         radarType = 8;
+        scope = 1;
         displayName = "Mk.V SOC[R8]";
     };
     class rhsgref_cdf_zsu234;
     class rhsgref_cdf_zsu234_R8: rhsgref_cdf_zsu234 {
         radarType = 8;
+        scope = 1;
         displayName = "ZSU-23-4V[R8]";
     };
     class rhsgref_cdf_reg_Mi8amt;
     class rhsgref_cdf_reg_Mi8amt_R8: rhsgref_cdf_reg_Mi8amt {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMT[R8]";
     };
     class rhsgref_cdf_reg_Mi17Sh;
     class rhsgref_cdf_reg_Mi17Sh_R8: rhsgref_cdf_reg_Mi17Sh {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMTSh[R8]";
     };
     class rhsgref_cdf_Mi35_UPK;
     class rhsgref_cdf_Mi35_UPK_R8: rhsgref_cdf_Mi35_UPK {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (UPK)[R8]";
     };
     class rhsgref_cdf_su25;
     class rhsgref_cdf_su25_R8: rhsgref_cdf_su25 {
         radarType = 8;
+        scope = 1;
         displayName = "Su-25[R8]";
     };
     class rhsgref_cdf_b_zsu234;
     class rhsgref_cdf_b_zsu234_R8: rhsgref_cdf_b_zsu234 {
         radarType = 8;
+        scope = 1;
         displayName = "ZSU-23-4V[R8]";
     };
     class rhsgref_cdf_b_reg_Mi8amt;
     class rhsgref_cdf_b_reg_Mi8amt_R8: rhsgref_cdf_b_reg_Mi8amt {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMT[R8]";
     };
     class rhsgref_cdf_b_reg_Mi17Sh;
     class rhsgref_cdf_b_reg_Mi17Sh_R8: rhsgref_cdf_b_reg_Mi17Sh {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMTSh[R8]";
     };
     class rhsgref_cdf_b_Mi35;
     class rhsgref_cdf_b_Mi35_R8: rhsgref_cdf_b_Mi35 {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (CAS)[R8]";
     };
     class rhsgref_cdf_b_Mi35_UPK;
     class rhsgref_cdf_b_Mi35_UPK_R8: rhsgref_cdf_b_Mi35_UPK {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (UPK)[R8]";
     };
     class rhsgref_cdf_b_su25;
     class rhsgref_cdf_b_su25_R8: rhsgref_cdf_b_su25 {
         radarType = 8;
+        scope = 1;
         displayName = "Su-25[R8]";
     };
     class rhsgref_ins_zsu234;
     class rhsgref_ins_zsu234_R8: rhsgref_ins_zsu234 {
         radarType = 8;
+        scope = 1;
         displayName = "ZSU-23-4V[R8]";
     };
     class rhsgref_ins_Mi8amt;
     class rhsgref_ins_Mi8amt_R8: rhsgref_ins_Mi8amt {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMT[R8]";
     };
     class rhsgref_ins_g_zsu234;
     class rhsgref_ins_g_zsu234_R8: rhsgref_ins_g_zsu234 {
         radarType = 8;
+        scope = 1;
         displayName = "ZSU-23-4V[R8]";
     };
     class rhsgref_ins_g_Mi8amt;
     class rhsgref_ins_g_Mi8amt_R8: rhsgref_ins_g_Mi8amt {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMT[R8]";
     };
     class rhsgref_un_Mi8amt;
     class rhsgref_un_Mi8amt_R8: rhsgref_un_Mi8amt {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-8AMT[R8]";
     };
     class rhsgref_un_Mi24V;
     class rhsgref_un_Mi24V_R8: rhsgref_un_Mi24V {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (CAS)[R8]";
     };
     class rhsgref_un_Mi24V_UPK;
     class rhsgref_un_Mi24V_UPK_R8: rhsgref_un_Mi24V_UPK {
         radarType = 8;
+        scope = 1;
         displayName = "Mi-24V (UPK)[R8]";
     };
     class BWA3_Tiger_RMK_PARS;
     class BWA3_Tiger_RMK_PARS_R8: BWA3_Tiger_RMK_PARS {
         radarType = 8;
+        scope = 1;
         displayName = "UH Tiger RMK (PARS)[R8]";
     };
     class BWA3_Tiger_RMK_Universal;
     class BWA3_Tiger_RMK_Universal_R8: BWA3_Tiger_RMK_Universal {
         radarType = 8;
+        scope = 1;
         displayName = "UH Tiger RMK (Universal)[R8]";
     };
     class BWA3_Tiger_RMK_FZ;
     class BWA3_Tiger_RMK_FZ_R8: BWA3_Tiger_RMK_FZ {
         radarType = 8;
+        scope = 1;
         displayName = "UH Tiger RMK (FZ Rockets)[R8]";
     };
     class BWA3_Tiger_RMK_Heavy;
     class BWA3_Tiger_RMK_Heavy_R8: BWA3_Tiger_RMK_Heavy {
         radarType = 8;
+        scope = 1;
         displayName = "UH Tiger RMK (Heavy)[R8]";
     };
     class BWA3_Tiger_Gunpod_PARS;
     class BWA3_Tiger_Gunpod_PARS_R8: BWA3_Tiger_Gunpod_PARS {
         radarType = 8;
+        scope = 1;
         displayName = "UH Tiger Gunpod (PARS)[R8]";
     };
     class BWA3_Tiger_Gunpod_FZ;
     class BWA3_Tiger_Gunpod_FZ_R8: BWA3_Tiger_Gunpod_FZ {
         radarType = 8;
+        scope = 1;
         displayName = "UH Tiger Gunpod (FZ Rockets)[R8]";
     };
     class BWA3_Tiger_Gunpod_Heavy;
     class BWA3_Tiger_Gunpod_Heavy_R8: BWA3_Tiger_Gunpod_Heavy {
         radarType = 8;
+        scope = 1;
         displayName = "UH Tiger Gunpod (Heavy)[R8]";
     };
 };


### PR DESCRIPTION
After 1.70 changes this isn't really needed as much
Changes to a vehicle's radar will have to be done differently.

This still leaves the vehicles as available, so shouldn't break anything.
Can remove later.