### PR TITLE
Assign gear tweaks

### DIFF
--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -9,8 +9,6 @@ PREP_RECOMPILE_END;
 GVAR(usePotato) = [missionConfigFile >> "CfgLoadouts" >> "usePotato"] call CFUNC(getBool);
 
 if (GVAR(usePotato)) then {
-    GVAR(preInitRan) = true;
-
     GVAR(loadoutCache) = call CBA_fnc_createNamespace;
     GVAR(classnameCache) = call CBA_fnc_createNamespace;
 

--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -24,7 +24,7 @@ if (GVAR(usePotato)) then {
     if (isServer) then {
         [ // assign gear to man
             "CAManBase",
-            "init",
+            "initPost",
             FUNC(assignGearMan),
             true, // allow inheritence
             [], // don't exclude classes

--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -6,18 +6,20 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
-GVAR(usePotato) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "usePotato")) == 1);
+GVAR(usePotato) = [missionConfigFile >> "CfgLoadouts" >> "usePotato"] call CFUNC(getBool);
 
 if (GVAR(usePotato)) then {
+    GVAR(preInitRan) = true;
+
     GVAR(loadoutCache) = call CBA_fnc_createNamespace;
     GVAR(classnameCache) = call CBA_fnc_createNamespace;
 
-    GVAR(allowMagnifiedOptics) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "allowMagnifiedOptics")) == 1);
-    GVAR(allowChangeableOptics) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "allowChangeableOptics")) == 1);
-    GVAR(useFallback) = ((getNumber (missionConfigFile >> "CfgLoadouts" >> "useFallback")) == 1);
-    GVAR(maxRandomization) = if (isNumber (missionConfigFile >> "CfgLoadouts" >> "maxRandomization")) then { getNumber (missionConfigFile >> "CfgLoadouts" >> "maxRandomization") } else { 5 };
-    GVAR(setVehicleLoadouts) = if (isNumber (missionConfigFile >> "CfgLoadouts" >> "setVehicleLoadouts")) then {getNumber (missionConfigFile >> "CfgLoadouts" >> "setVehicleLoadouts")} else { 1 };
-    GVAR(prefixes) = if (isArray (missionConfigFile >> "CfgLoadouts" >> "prefixes")) then { getArray (missionConfigFile >> "CfgLoadouts" >> "prefixes") } else { [] };
+    GVAR(allowMagnifiedOptics) = [missionConfigFile >> "CfgLoadouts" >> "allowMagnifiedOptics"] call CFUNC(getBool);
+    GVAR(allowChangeableOptics) = [missionConfigFile >> "CfgLoadouts" >> "allowChangeableOptics"] call CFUNC(getBool);
+    GVAR(useFallback) = [missionConfigFile >> "CfgLoadouts" >> "useFallback"] call CFUNC(getBool);
+    GVAR(maxRandomization) = [missionConfigFile >> "CfgLoadouts" >> "maxRandomization", 5] call CFUNC(getNumber);
+    GVAR(setVehicleLoadouts) = [missionConfigFile >> "CfgLoadouts" >> "setVehicleLoadouts", 1] call CFUNC(getNumber);
+    GVAR(prefixes) = [missionConfigFile >> "CfgLoadouts" >> "prefixes"] call CFUNC(getArray);
 
     if (isServer) then {
         [ // assign gear to man
@@ -31,8 +33,8 @@ if (GVAR(usePotato)) then {
 
         [ // assign gear to car
             "Car",
-            "init",
-            { [FUNC(assignGearVehicle), [_this select 0, "Car"]] call CBA_fnc_execNextFrame; },
+            "initPost",
+            { [_this select 0, "Car"] call FUNC(assignGearVehicle); },
             true,
             [],
             true
@@ -40,8 +42,8 @@ if (GVAR(usePotato)) then {
 
         [ // assign gear to tank
             "Tank",
-            "init",
-            { [FUNC(assignGearVehicle), [_this select 0, "Tank"]] call CBA_fnc_execNextFrame; },
+            "initPost",
+            { [_this select 0, "Tank"] call FUNC(assignGearVehicle); },
             true,
             [],
             true
@@ -49,8 +51,8 @@ if (GVAR(usePotato)) then {
 
         [ // assign gear to helicopter
             "Helicopter",
-            "init",
-            { [FUNC(assignGearVehicle), [_this select 0, "Helicopter"]] call CBA_fnc_execNextFrame; },
+            "initPost",
+            { [_this select 0, "Helicopter"] call FUNC(assignGearVehicle); },
             true,
             ["ace_fastroping_helper", "ACE_friesBase"],
             true
@@ -58,8 +60,8 @@ if (GVAR(usePotato)) then {
 
         [ // assign gear to plane
             "Plane",
-            "init",
-            { [FUNC(assignGearVehicle), [_this select 0, "Plane"]] call CBA_fnc_execNextFrame; },
+            "initPost",
+            { [_this select 0, "Plane"] call FUNC(assignGearVehicle); },
             true,
             [],
             true
@@ -67,16 +69,27 @@ if (GVAR(usePotato)) then {
 
         [ // assign gear to ship
             "Ship_F",
-            "init",
-            { [FUNC(assignGearVehicle), [_this select 0, "Ship_F"]] call CBA_fnc_execNextFrame; },
+            "initPost",
+            { [_this select 0, "Ship_F"] call FUNC(assignGearVehicle); },
             true,
             [],
             true
         ] call CBA_fnc_addClassEventHandler;
+
+        if (is3DEN) then {
+            diag_log text format ["[POTATO-assignGear] Running assign gear for the 3den entities at load"];
+
+            {
+                if (_x isKindOf "CAManBase") then {
+                    [_x] call FUNC(assignGearMan);
+                };
+            } forEach (all3DENEntities select 0);
+        };
     };
 
     diag_log text format ["[POTATO-assignGear] Enabled [useFallback: %1, allowMagnifiedOptics: %2, allowChangeableOptics: %3, maxRandomization: %4, setVehicleLoadouts: %5, prefixes: %6]", GVAR(useFallback), GVAR(allowMagnifiedOptics), GVAR(allowChangeableOptics), GVAR(maxRandomization), GVAR(setVehicleLoadouts), GVAR(prefixes)];
 } else {
+    GVAR(allowChangeableOptics) = false;
     diag_log text format ["[POTATO-assignGear] Disabled"];
 };
 

--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -22,7 +22,7 @@ if (GVAR(usePotato)) then {
     if (isServer) then {
         [ // assign gear to man
             "CAManBase",
-            "initPost",
+            "init",
             FUNC(assignGearMan),
             true, // allow inheritence
             [], // don't exclude classes

--- a/addons/assignGear/functions/fnc_assignGearMan.sqf
+++ b/addons/assignGear/functions/fnc_assignGearMan.sqf
@@ -62,19 +62,19 @@ _unit setVariable [QGVAR(gearSetup), true, true];
 
 END_COUNTER(assignGearMan);
 
-
 // Stupid hack to fix gear automaticly until we can sort out why setUnitLoadout ocasionly fails on JIPs
 [{
     params ["_unit", "_loadoutArray"];
     if (isNull _unit) exitWith {};
-    
+
     private _arrayUniform = (_loadoutArray select 3) param [0, ""];
     private _arrayVest = (_loadoutArray select 4) param [0, ""];
-    TRACE_4("Checking loadout: Uniform [%1-%2] Vest [%3-%4]",_arrayUniform,uniform _unit,_arrayVest,vest _unit);
+    private _arrayBackpack = (_loadoutArray select 5) param [0, ""];
+    TRACE_6("Checking loadout: Uniform [%1-%2] Vest [%3-%4] Backpack [%5-%6]",_arrayUniform, uniform _unit, _arrayVest, vest _unit, _arrayBackpack, backpack _unit);
 
-    if ((_arrayUniform != (uniform _unit)) || {_arrayVest != (vest _unit)}) then {
-        ERROR_2("Mismatch [%1] [%2]",name _unit, typeOf _unit);
+    if ((_arrayUniform != (uniform _unit)) || {_arrayVest != (vest _unit)} || {_arrayBackpack != (backpack _unit)}) then {
+        ERROR_2("Mismatch [%1] [%2]", name _unit, typeOf _unit);
         _unit setUnitLoadout _loadoutArray;
         ["potato_adminMsg", [(format ["Auto-reset gear on %1", name _unit]), "Server"]] call CBA_fnc_globalEvent;
     };
-}, [_unit, _loadoutArray], 15] call CBA_fnc_waitAndExecute
+}, [_unit, _loadoutArray], 15] call CBA_fnc_waitAndExecute;

--- a/addons/assignGear/functions/fnc_assignGearVehicle.sqf
+++ b/addons/assignGear/functions/fnc_assignGearVehicle.sqf
@@ -42,27 +42,28 @@ private _path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
 if (!isClass _path) then {
     //No CfgLoadouts for exact loadout, try default
     private _vehConfigSide = [_theVehicle, true] call BIS_fnc_objectSide;
-    private _vehConfigFaction = switch (_vehConfigSide) do {
-        case (west): { "blu_f" };
-        case (east): { "opf_f" };
-        case (independent): { "ind_f" };
-        default { "civ_f" };
+    private _vehConfigFactions = switch (_vehConfigSide) do {
+        case (west): { ["blu_f", "potato_usmc"] };
+        case (east): { ["opf_f", "potato_msv"] };
+        case (independent): { ["ind_f", "potato_airborne"] };
+        default { ["civ_f"] };
     };
-    _path = missionConfigFile >> "CfgLoadouts" >> _vehConfigFaction >> _defaultLoadout;
 
-    if (!isClass _path) then {
-        _vehConfigFaction = switch (_vehConfigSide) do { // note: will recheck civ_f here
-            case (west): { "potato_usmc" };
-            case (east): { "potato_msv" };
-            case (independent): { "potato_airborne" };
-            default { "civ_f" };
-        };
-        _path = missionConfigFile >> "CfgLoadouts" >> _vehConfigFaction >> _defaultLoadout;
-    };
+    {
+        private _break = false;
+        private _loadoutToCheck = _x;
+
+        {
+            _path = missionConfigFile >> "CfgLoadouts" >> _x >> _loadoutToCheck;
+            if (isClass _path) exitWith { _break = true; };
+        } forEach _vehConfigFactions;
+
+        if (_break) exitWith {};
+    } forEach [_loadout, _defaultLoadout];
 };
 
 if (!isClass _path) exitWith {
-    diag_log text format ["[POTATO-AssignGear] - No loadout found for %1 (typeOf %2) (kindOf %3) (defaultLoadout: %4)", _theVehicle, typeof _theVehicle, _loadout, _defaultLoadout];
+    diag_log text format ["[POTATO-assignGear] - No loadout found for %1 (typeOf %2) (kindOf %3) (defaultLoadout: %4)", _theVehicle, typeof _theVehicle, _loadout, _defaultLoadout];
 };
 
 //Clean out starting inventory (even if there is no class)


### PR DESCRIPTION
Changes:
- Use core funcs when pulling information from the configs
- Move the XEHs from init to initPost (should have the frame delay built in now)
- Make gear apply to units on 3DEN load
- Make sure allowChangeableOptics is defined even if potato is off
- Add backpack validation to the gear watchdog
- Change the vehicle gear class lookup to scan through available faction/loadout combos before looking at the default loadout.

Questions:
Do we want to look at ALL factions under a side, instead of the limited scope (add some caching once found)? Would increase initial lookup time, but would not need to update this code if we expand our set of default factions?