### PR TITLE
Use config values instead of string type compare

### DIFF
--- a/addons/missionTest/functions/fnc_onMissionSave.sqf
+++ b/addons/missionTest/functions/fnc_onMissionSave.sqf
@@ -126,7 +126,8 @@ private _checkMedical = [];
                 } forEach (magazinesAmmoFull _unit);
                 if (_ammoCount == 0) then {
                     // Ignore launchers that auto load ammo via script
-                    if (((toLower _weapon) in ["rhs_weap_rpg26", "rhs_weap_m136"]) || {getText (configFile >> "CfgWeapons" >> _weapon >> "ACE_UsedTube") != ""}) then {
+                    if (([configFile >> "CfgWeapons" >> _weapon >> "ACE_UsedTube"] call CFUNC(getText)) != ""
+                            || {[configFile >> "CfgWeapons" >> _weapon >> "rhs_disposable"] call CFUNC(getBool)}) then {
                         TRACE_1("ignoring special AT reloads",_weapon);
                     } else {
                         TRACE_2("has zero ammo",_typeOf,_weapon);


### PR DESCRIPTION
Use CFUNCs for config lookups
Changes how RHS disposables are checked, can duplicate for BAF if they ever update to autoload their launchers.