### PR TITLE
Assign Gear - Handle empty string warnings

### DIFF
--- a/addons/assignGear/functions/fnc_addItemsToContainer.sqf
+++ b/addons/assignGear/functions/fnc_addItemsToContainer.sqf
@@ -41,9 +41,12 @@ private _returnArray = [];
     private _itemLeft = [] call {
         // exit if there's no room left in the container
         if (_sizeLeft <= 0) exitWith { TRACE_1("no room",_itemToAdd); _itemToAdd };
+        if (_itemToAdd == "") exitWith {TRACE_1("empty string - ignoring",_itemToAdd); ""};
 
         (_itemToAdd splitString ":") params ["_classname", ["_amountToAdd", "1", [""]]];
         _amountToAdd = parseNumber _amountToAdd;
+
+        if (_amountToAdd < 1) exitWith {TRACE_1("item count is zero - ignoring",_itemToAdd); ""};
 
         if (isClass (configFile >> "CfgMagazines" >> _classname)) then {
             [

--- a/addons/assignGear/functions/fnc_getWeaponArray.sqf
+++ b/addons/assignGear/functions/fnc_getWeaponArray.sqf
@@ -29,13 +29,16 @@ private _weaponArray = [_weapon, "", "", "", [], [], ""];
 private _attachables = [_weapon] call CBA_fnc_compatibleItems;
 
 {
-    (_x splitString ":") params [["_classname", ""]]; // count makes no sense for attachments, ignore
-    private _config = configFile >> "CfgWeapons" >> _classname;
-    if ({_x == _classname} count _attachables > 0) then {
-        [_weaponArray, _config, _classname, _doOpticCheck] call FUNC(setWeaponAttachment);
+    if (_x != "") then {
+        (_x splitString ":") params [["_classname", ""]]; // count makes no sense for attachments, ignore
+        private _config = configFile >> "CfgWeapons" >> _classname;
+        if ({_x == _classname} count _attachables > 0) then {
+            [_weaponArray, _config, _classname, _doOpticCheck] call FUNC(setWeaponAttachment);
+        } else {
+            diag_log text format ["[POTATO-assignGear] - Attachment [%1] not compatible with [%2]", _classname, _weapon];
+        };
     } else {
-        if (_x == "") exitWith {TRACE_1("empty string - ignoring",_x);};
-        diag_log text format ["[POTATO-assignGear] - Attachment [%1] not compatible with [%2]", _classname, _weapon];
+        TRACE_1("Empty string for weapon attachment - ignoring",_weapon);
     };
     nil
 } count _attachments; // count used here for speed, make sure nil is above this line

--- a/addons/assignGear/functions/fnc_getWeaponArray.sqf
+++ b/addons/assignGear/functions/fnc_getWeaponArray.sqf
@@ -34,6 +34,7 @@ private _attachables = [_weapon] call CBA_fnc_compatibleItems;
     if ({_x == _classname} count _attachables > 0) then {
         [_weaponArray, _config, _classname, _doOpticCheck] call FUNC(setWeaponAttachment);
     } else {
+        if (_x == "") exitWith {TRACE_1("empty string - ignoring",_itemToAdd);};
         diag_log text format ["[POTATO-assignGear] - Attachment [%1] not compatible with [%2]", _classname, _weapon];
     };
     nil

--- a/addons/assignGear/functions/fnc_getWeaponArray.sqf
+++ b/addons/assignGear/functions/fnc_getWeaponArray.sqf
@@ -34,7 +34,7 @@ private _attachables = [_weapon] call CBA_fnc_compatibleItems;
     if ({_x == _classname} count _attachables > 0) then {
         [_weaponArray, _config, _classname, _doOpticCheck] call FUNC(setWeaponAttachment);
     } else {
-        if (_x == "") exitWith {TRACE_1("empty string - ignoring",_itemToAdd);};
+        if (_x == "") exitWith {TRACE_1("empty string - ignoring",_x);};
         diag_log text format ["[POTATO-assignGear] - Attachment [%1] not compatible with [%2]", _classname, _weapon];
     };
     nil


### PR DESCRIPTION
Cleans up a couple of non-problem warnings, mainly from us using empty strings in macros.

`#define RIFLE_ATTACHMENTS ""`
```
[POTATO-assignGear] - Attachment [] not compatible with [rhs_weap_mk18_wd]
```

`#define AT_MAG ""` // Because: ("" splitString ":") = []
```
[POTATO-assignGear] Item Not Found [any:scalar NaN]
[POTATO] (assignGear) ERROR:  z\potato\addons\assignGear\functions\fnc_addItemsToContainer.sqf:72
    [any:scalar NaN] Bad Item Classname
```

`#define FAC_MAGAZINES "Laserbatteries"` // Because getWeaponArray takes out a magazine, so it becomes "Laserbatteries:0"
```
[POTATO] (assignGear) WARNING: ~~~~~~~~~ Items not added for: Soldier_unarmed_F ~~~~~~~~~~~ z\potato\addons\assignGear\functions\fnc_getLoadoutFromConfig.sqf:86
[POTATO] (assignGear) WARNING: Items: [] z\potato\addons\assignGear\functions\fnc_getLoadoutFromConfig.sqf:87
[POTATO] (assignGear) WARNING: BackpackItems: [] z\potato\addons\assignGear\functions\fnc_getLoadoutFromConfig.sqf:88
[POTATO] (assignGear) WARNING: Magazines: ["Laserbatteries:0"] z\potato\addons\assignGear\functions\fnc_getLoadoutFromConfig.sqf:89
```