### PR TITLE
Reflow assign gear for JIPs

### DIFF
--- a/addons/adminMenu/XEH_postInit.sqf
+++ b/addons/adminMenu/XEH_postInit.sqf
@@ -14,14 +14,8 @@
 
     [{
         if (missionNamespace getVariable [QEGVAR(assignGear,usePotato), false]) then {
-            // set unit loadout overrides our sick shades :(
-            private _goggles = goggles _this;
-            removeGoggles _this;
-
-            diag_log text format ["[POTATO] Calling %1", QEFUNC(assignGear,assignGearMan)];
-            [_this] call EFUNC(assignGear,assignGearMan);
-
-            _this addGoggles _goggles;
+            diag_log text format ["[POTATO] Calling %1", QEFUNC(assignGear,requestPlayerGear)];
+            [_this] call EFUNC(assignGear,requestPlayerGear);
         } else {
             diag_log text format ["[POTATO] Calling F_fnc_assignGearMan"];
             [_this] call F_fnc_assignGearMan;

--- a/addons/assignGear/XEH_PREP.hpp
+++ b/addons/assignGear/XEH_PREP.hpp
@@ -9,5 +9,6 @@ PREP(getContainerInfo);
 PREP(getLinkedIndex);
 PREP(getLoadoutFromConfig);
 PREP(getWeaponArray);
+PREP(requestPlayerGear);
 PREP(setOptic);
 PREP(setWeaponAttachment);

--- a/addons/assignGear/XEH_clientPostInit.sqf
+++ b/addons/assignGear/XEH_clientPostInit.sqf
@@ -1,78 +1,84 @@
 #include "script_component.hpp"
 
-if (GVAR(allowChangeableOptics) && hasInterface) then {
-    private _path = (
-        missionConfigFile >>
-        "CfgLoadouts" >>
-        (toLower faction player) >>
-        (player getVariable ["F_Gear", [typeOf player] call FUNC(cleanPrefix)])
-    );
+if (GVAR(usePotato) && hasInterface) then {
+    if (didJIP) then {
+        [FUNC(requestPlayerGear), [player]] call CBA_fnc_execNextFrame;
+    };
 
-    private _opticOptions = [];
-    {
-        if (isNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "optics")) then {
-            if (!GVAR(allowMagnifiedOptics)) then {
-                private _minZoom = 999; //FOV, so smaller is more zoomed in
-                {
-                    if (isNumber (_x >> "opticsZoomMin")) then { _minZoom = _minZoom min (getNumber (_x >> "opticsZoomMin")); };
-                    if (isText (_x >> "opticsZoomMin")) then { _minZoom = _minZoom min (call compile getText (_x >> "opticsZoomMin")); };
-                    nil
-                } count configProperties [configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"]; // count used here for speed, make sure nil is above this line
+    if (GVAR(allowChangeableOptics)) then {
+        private _path = (
+            missionConfigFile >>
+            "CfgLoadouts" >>
+            (toLower faction player) >>
+            (player getVariable ["F_Gear", [typeOf player] call FUNC(cleanPrefix)])
+        );
 
-                if (_minZoom >= 0.25) then {
+        private _opticOptions = [];
+        {
+            if (isNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "optics")) then {
+                if (!GVAR(allowMagnifiedOptics)) then {
+                    private _minZoom = 999; //FOV, so smaller is more zoomed in
+                    {
+                        if (isNumber (_x >> "opticsZoomMin")) then { _minZoom = _minZoom min (getNumber (_x >> "opticsZoomMin")); };
+                        if (isText (_x >> "opticsZoomMin")) then { _minZoom = _minZoom min (call compile getText (_x >> "opticsZoomMin")); };
+                        nil
+                    } count configProperties [configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"]; // count used here for speed, make sure nil is above this line
+
+                    if (_minZoom >= 0.25) then {
+                        _opticOptions pushBackUnique (toLower _x);
+                    };
+                } else {
                     _opticOptions pushBackUnique (toLower _x);
                 };
+            };
+        } forEach ((getArray (_path >> "opticChoices")) + (getArray (_path >> "attachments")));
+
+        if (_opticOptions isEqualTo []) exitWith { LOG("No optic options found"); };
+
+        private _baseAction = [
+            "BaseOpticChoice",
+            "Choose Optic",
+            QPATHTOF(data\scope.paa),
+            {},
+            {missionNamespace getVariable [QEGVAR(safeStart,startTime_PV), -1] != -1}
+        ] call ACEFUNC(interact_menu,createAction);
+
+        [
+            typeOf player, 1,
+            ["ACE_SelfActions", "ACE_Equipment"],
+            _baseAction
+        ] call  ACEFUNC(interact_menu,addActionToClass);
+
+        {
+            if (isClass (configFile >> "CfgWeapons" >> _x)) then {
+                private _picture = QPATHTOF(data\scope.paa);
+                if (isText (configFile >> "CfgWeapons" >> _x >> "picture")) then {
+                    _picture = getText (configFile >> "CfgWeapons" >> _x >> "picture");
+                };
+
+                private _name = _x;
+                if (isText (configFile >> "CfgWeapons" >> _x >> "displayName")) then {
+                    _name = getText (configFile >> "CfgWeapons" >> _x >> "displayName");
+                };
+
+                private _action = [
+                    format ["OpticChoice%1",_forEachIndex],
+                    _name,
+                    _picture,
+                    FUNC(setOptic),
+                    FUNC(canSetOptic),
+                    {},
+                    [_x, _opticOptions]
+                ] call ACEFUNC(interact_menu,createAction);
+
+                [
+                    typeOf player, 1,
+                    ["ACE_SelfActions", "ACE_Equipment", "BaseOpticChoice"],
+                    _action
+                ] call ACEFUNC(interact_menu,addActionToClass);
             } else {
-                _opticOptions pushBackUnique (toLower _x);
+                WARNING_1("Optic option not a valid class", _x);
             };
-        };
-    } forEach ((getArray (_path >> "opticChoices")) + (getArray (_path >> "attachments")));
-
-    if (_opticOptions isEqualTo []) exitWith { LOG("No optic options found"); };
-
-    private _baseAction = [
-        "BaseOpticChoice",
-        "Choose Optic",
-        QPATHTOF(data\scope.paa),
-        {},
-        {missionNamespace getVariable [QEGVAR(safeStart,startTime_PV), -1] != -1}
-    ] call ACEFUNC(interact_menu,createAction);
-
-    [
-        typeOf player, 1,
-        ["ACE_SelfActions", "ACE_Equipment"],
-        _baseAction
-    ] call  ACEFUNC(interact_menu,addActionToClass);
-
-    {
-        if (isClass (configFile >> "CfgWeapons" >> _x)) then {
-            private _picture = QPATHTOF(data\scope.paa);
-            if (isText (configFile >> "CfgWeapons" >> _x >> "picture")) then {
-                _picture = getText (configFile >> "CfgWeapons" >> _x >> "picture");
-            };
-
-            private _name = _x;
-            if (isText (configFile >> "CfgWeapons" >> _x >> "displayName")) then {
-                _name = getText (configFile >> "CfgWeapons" >> _x >> "displayName");
-            };
-
-            private _action = [
-                format ["OpticChoice%1",_forEachIndex],
-                _name,
-                _picture,
-                FUNC(setOptic),
-                FUNC(canSetOptic),
-                {},
-                [_x, _opticOptions]
-            ] call ACEFUNC(interact_menu,createAction);
-
-            [
-                typeOf player, 1,
-                ["ACE_SelfActions", "ACE_Equipment", "BaseOpticChoice"],
-                _action
-            ] call ACEFUNC(interact_menu,addActionToClass);
-        } else {
-            WARNING_1("Optic option not a valid class", _x);
-        };
-    } forEach _opticOptions;
+        } forEach _opticOptions;
+    };
 };

--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -22,7 +22,7 @@ if (GVAR(usePotato)) then {
     if (isServer) then {
         [ // assign gear to man
             "CAManBase",
-            "init",
+            "initPost",
             FUNC(assignGearMan),
             true, // allow inheritence
             [], // don't exclude classes

--- a/addons/assignGear/functions/fnc_assignGearMan.sqf
+++ b/addons/assignGear/functions/fnc_assignGearMan.sqf
@@ -18,8 +18,8 @@
 
 TRACE_1("params",_this);
 
-params ["_unit"];
-TRACE_2("",_unit,local _unit);
+params ["_unit", ["_request", false, [false]]];
+TRACE_3("",_unit, local _unit,_request);
 
 BEGIN_COUNTER(assignGearMan);
 
@@ -51,7 +51,10 @@ if (isNil "_loadoutArray") then {
     GVAR(loadoutCache) setVariable [_loadoutKey, _loadoutArray];
 };
 
+// set unit loadout overrides our sick shades :(
+private _goggles = goggles _unit;
 _unit setUnitLoadout _loadoutArray;
+_unit addGoggles _goggles;
 
 if (isText (_path >> "init")) then {
     TRACE_1("calling init code",getText (_path >> "init"));
@@ -62,6 +65,7 @@ _unit setVariable [QGVAR(gearSetup), true, true];
 
 END_COUNTER(assignGearMan);
 
+if (_request) exitWith {}; // don't run hack on requests
 // Stupid hack to fix gear automaticly until we can sort out why setUnitLoadout ocasionly fails on JIPs
 [{
     params ["_unit", "_loadoutArray"];
@@ -74,7 +78,9 @@ END_COUNTER(assignGearMan);
 
     if ((_arrayUniform != (uniform _unit)) || {_arrayVest != (vest _unit)} || {_arrayBackpack != (backpack _unit)}) then {
         ERROR_2("Mismatch [%1] [%2]", name _unit, typeOf _unit);
+        private _goggles = goggles _unit;
         _unit setUnitLoadout _loadoutArray;
+        _unit addGoggles _goggles;
         ["potato_adminMsg", [(format ["Auto-reset gear on %1", name _unit]), "Server"]] call CBA_fnc_globalEvent;
     };
 }, [_unit, _loadoutArray], 15] call CBA_fnc_waitAndExecute;

--- a/addons/assignGear/functions/fnc_requestPlayerGear.sqf
+++ b/addons/assignGear/functions/fnc_requestPlayerGear.sqf
@@ -1,0 +1,24 @@
+/*
+ * Author: AACO
+ * Simple passthrough function that will request gear from the server
+ *
+ * Arguments:
+ * 0: Player who is requesting the gear <OBJECT>
+ *
+ * Example:
+ * [player] call potato_assignGear_fnc_requestPlayerGear;
+ *
+ * Public: Yes
+ */
+
+#include "script_component.hpp"
+
+TRACE_1("params",_this);
+
+// if not executed on server, pass to server
+if !(isServer) exitWith { _this remoteExecCall [QFUNC(requestPlayerGear), SERVER_CLIENT_ID]; };
+
+params [["_unit", objNull, [objNull]]];
+
+if (isNull _unit) exitWith { WARNING("Provided unit is null"); };
+[_unit, true] call FUNC(assignGearMan);


### PR DESCRIPTION
Resolves #94 

This PR will:
- Move assignGearMan to initPost
- Add actual JIP handling (tested on local dedicated, should be interesting in large scale dedicated)
- Move google handling to assignGearMan
- Refactor the reset gear menu tool to use the new function
- Ensure assign gear is only run on the server to better leverage caching

If this works reliably in session, we should be able to remove the watch dog (might need to keep it for AI?)

Potential downsides: 
- If the server initPost actually works on JIPs (which is historically has not) assign gear could run twice per JIP (with no benefit)
- Moving the googles stuff to assign gear might lead to strange stuff for AI?