### PR TITLE
Some cleanup for assign gear

### DIFF
--- a/addons/assignGear/XEH_PREP.hpp
+++ b/addons/assignGear/XEH_PREP.hpp
@@ -9,6 +9,7 @@ PREP(getContainerInfo);
 PREP(getLinkedIndex);
 PREP(getLoadoutFromConfig);
 PREP(getWeaponArray);
+PREP(isOpticMagnified);
 PREP(requestPlayerGear);
 PREP(setOptic);
 PREP(setWeaponAttachment);

--- a/addons/assignGear/XEH_clientPostInit.sqf
+++ b/addons/assignGear/XEH_clientPostInit.sqf
@@ -15,21 +15,9 @@ if (GVAR(usePotato) && hasInterface) then {
 
         private _opticOptions = [];
         {
-            if (isNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "optics")) then {
-                if (!GVAR(allowMagnifiedOptics)) then {
-                    private _minZoom = 999; //FOV, so smaller is more zoomed in
-                    {
-                        if (isNumber (_x >> "opticsZoomMin")) then { _minZoom = _minZoom min (getNumber (_x >> "opticsZoomMin")); };
-                        if (isText (_x >> "opticsZoomMin")) then { _minZoom = _minZoom min (call compile getText (_x >> "opticsZoomMin")); };
-                        nil
-                    } count configProperties [configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"]; // count used here for speed, make sure nil is above this line
-
-                    if (_minZoom >= 0.25) then {
-                        _opticOptions pushBackUnique (toLower _x);
-                    };
-                } else {
-                    _opticOptions pushBackUnique (toLower _x);
-                };
+            if (isNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "optics")
+                    && (GVAR(allowMagnifiedOptics) || {!([_x] call FUNC(isOpticMagnified))})) then {
+                _opticOptions pushBackUnique (toLower _x);
             };
         } forEach ((getArray (_path >> "opticChoices")) + (getArray (_path >> "attachments")));
 

--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -11,6 +11,7 @@ GVAR(usePotato) = [missionConfigFile >> "CfgLoadouts" >> "usePotato"] call CFUNC
 if (GVAR(usePotato)) then {
     GVAR(loadoutCache) = call CBA_fnc_createNamespace;
     GVAR(classnameCache) = call CBA_fnc_createNamespace;
+    GVAR(magnifiedOpticCache) = call CBA_fnc_createNamespace;
 
     GVAR(allowMagnifiedOptics) = [missionConfigFile >> "CfgLoadouts" >> "allowMagnifiedOptics"] call CFUNC(getBool);
     GVAR(allowChangeableOptics) = [missionConfigFile >> "CfgLoadouts" >> "allowChangeableOptics"] call CFUNC(getBool);

--- a/addons/assignGear/functions/fnc_addItemsToContainer.sqf
+++ b/addons/assignGear/functions/fnc_addItemsToContainer.sqf
@@ -17,13 +17,6 @@
  */
 
 #include "script_component.hpp"
-#define VEST_ALLOWED_SLOTS 701
-#define UNIFORM_ALLOWED_SLOTS 801
-#define BACKPACK_ALLOWED_SLOTS 901
-#define PRIMARY_TYPE 1
-#define HANDGUN_TYPE 2
-#define LAUNCHER_TYPE 4
-#define BINO_TYPE 4096
 
 TRACE_1("params",_this);
 params ["_itemsToAddArray", "_containersArray", "_containerIndex"];

--- a/addons/assignGear/functions/fnc_assignGearMan.sqf
+++ b/addons/assignGear/functions/fnc_assignGearMan.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: PabstMirror
- * Applies a loadout to a unit
+ * Applies a loadout to a unit (cached)
  *
  * Arguments:
  * 0: Unit <OBJECT>
@@ -52,12 +52,11 @@ if (isNil "_loadoutArray") then {
 };
 
 // set unit loadout overrides our sick shades :(
-private _goggles = goggles _unit;
+_loadoutArray set [LA_FACEWARE_INDEX, goggles _unit];
 _unit setUnitLoadout _loadoutArray;
-_unit addGoggles _goggles;
 
 if (isText (_path >> "init")) then {
-    TRACE_1("calling init code",getText (_path >> "init"));
+    TRACE_1("calling init code", getText (_path >> "init"));
     _unit call compile ("this = _this;"+ getText (_path >> "init"));
 };
 
@@ -71,16 +70,14 @@ if (_request) exitWith {}; // don't run hack on requests
     params ["_unit", "_loadoutArray"];
     if (isNull _unit) exitWith {};
 
-    private _arrayUniform = (_loadoutArray select 3) param [0, ""];
-    private _arrayVest = (_loadoutArray select 4) param [0, ""];
-    private _arrayBackpack = (_loadoutArray select 5) param [0, ""];
-    TRACE_6("Checking loadout: Uniform [%1-%2] Vest [%3-%4] Backpack [%5-%6]",_arrayUniform, uniform _unit, _arrayVest, vest _unit, _arrayBackpack, backpack _unit);
+    private _arrayUniform = (_loadoutArray select LA_UNIFORM_INDEX) param [0, ""];
+    private _arrayVest = (_loadoutArray select LA_VEST_INDEX) param [0, ""];
+    private _arrayBackpack = (_loadoutArray select LA_BACKPACK_INDEX) param [0, ""];
+    TRACE_6("Checking loadout: Uniform [%1-%2] Vest [%3-%4] Backpack [%5-%6]", _arrayUniform, uniform _unit, _arrayVest, vest _unit, _arrayBackpack, backpack _unit);
 
     if ((_arrayUniform != (uniform _unit)) || {_arrayVest != (vest _unit)} || {_arrayBackpack != (backpack _unit)}) then {
         ERROR_2("Mismatch [%1] [%2]", name _unit, typeOf _unit);
-        private _goggles = goggles _unit;
         _unit setUnitLoadout _loadoutArray;
-        _unit addGoggles _goggles;
         ["potato_adminMsg", [(format ["Auto-reset gear on %1", name _unit]), "Server"]] call CBA_fnc_globalEvent;
     };
 }, [_unit, _loadoutArray], 15] call CBA_fnc_waitAndExecute;

--- a/addons/assignGear/functions/fnc_cleanPrefix.sqf
+++ b/addons/assignGear/functions/fnc_cleanPrefix.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: AACO
- * Gets container information from an array of classnames
+ * Gets container information from an array of classnames (cached)
  *
  * Arguments:
  * 0: Unit classname <STRING>
@@ -16,8 +16,10 @@
 
 #include "script_component.hpp"
 
-params ["_unitClassname"];
+params [["_unitClassname", "", [""]]];
 TRACE_1("cleanPrefix",_unitClassname);
+
+if (_unitClassname == "") exitWith {ERROR("_unitClassname is empty string"); _unitClassname };
 
 private _cleanedClassname = GVAR(classnameCache) getVariable _unitClassname;
 if (isNil "_cleanedClassname") then { // cache classname lookups
@@ -30,7 +32,6 @@ if (isNil "_cleanedClassname") then { // cache classname lookups
         nil
     } count GVAR(prefixes);  // count used here for speed, make sure nil is above this line
 
-    if (_unitClassname == "") exitWith {ERROR("_unitClassname is empty string");};
     GVAR(classnameCache) setVariable [_unitClassname, _cleanedClassname];
 };
 

--- a/addons/assignGear/functions/fnc_getLoadoutFromConfig.sqf
+++ b/addons/assignGear/functions/fnc_getLoadoutFromConfig.sqf
@@ -92,4 +92,15 @@ if (((count _configItems) + (count _configBackpackItems) + (count _configMagazin
 TRACE_1("Adding Items End: ",_containersArray);
 
 // return array, to spec of https://community.bistudio.com/wiki/Talk:getUnitLoadout
-[_primaryWeaponArray, _launcherWeaponArray, _handgunWeaponArray, (_containersArray select UNIFORM_INDEX) select 1, (_containersArray select VEST_INDEX) select 1, (_containersArray select BACKPACK_INDEX) select 1, _headgear, "", _binocularArray, _assignedItems]
+[
+    _primaryWeaponArray,
+    _launcherWeaponArray,
+    _handgunWeaponArray,
+    (_containersArray select UNIFORM_INDEX) select 1,
+    (_containersArray select VEST_INDEX) select 1,
+    (_containersArray select BACKPACK_INDEX) select 1,
+    _headgear,
+    "",
+    _binocularArray,
+    _assignedItems
+]

--- a/addons/assignGear/functions/fnc_getWeaponArray.sqf
+++ b/addons/assignGear/functions/fnc_getWeaponArray.sqf
@@ -19,8 +19,6 @@
  */
 
 #include "script_component.hpp"
-#define GUN_INDEX 4
-#define UNDERSLUNG_INDEX 5
 
 TRACE_1("params",_this);
 params ["_weapon", "_attachments", "_configMagazines", ["_doOpticCheck", true, [true]]];
@@ -38,16 +36,16 @@ private _attachables = [_weapon] call CBA_fnc_compatibleItems;
             diag_log text format ["[POTATO-assignGear] - Attachment [%1] not compatible with [%2]", _classname, _weapon];
         };
     } else {
-        TRACE_1("Empty string for weapon attachment - ignoring",_weapon);
+        TRACE_1("Empty string for weapon attachment - ignoring", _weapon);
     };
     nil
 } count _attachments; // count used here for speed, make sure nil is above this line
 
 {
     if (_x == "this") then { // main gun magazines
-        [GUN_INDEX, getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines")]
+        [LAW_PRIMARY_MUZZLE_MAG_INDEX, getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines")]
     } else { // underslung weapon magazines
-        [UNDERSLUNG_INDEX, getArray (configFile >> "CfgWeapons" >> _weapon >> _x >> "magazines")]
+        [LAW_SECONDARY_MUZZLE_MAG_INDEX, getArray (configFile >> "CfgWeapons" >> _weapon >> _x >> "magazines")]
     } params ["_arrayIndex", "_magazines"];
 
     {

--- a/addons/assignGear/functions/fnc_isOpticMagnified.sqf
+++ b/addons/assignGear/functions/fnc_isOpticMagnified.sqf
@@ -1,0 +1,39 @@
+/*
+ * Author: AACO
+ * Checks if the given optic classname is considered magnified (cached)
+ *
+ * Arguments:
+ * 0: Optic classname to check <STRING>
+ *
+ * Example:
+ * ["optic_Aco"] call potato_assignGear_fnc_isOpticMagnified;
+ *
+ * Public: Yes
+ */
+
+#include "script_component.hpp"
+
+TRACE_1("params",_this);
+params [["_opticClassname", "", [""]]];
+
+if (_opticClassname == "") exitWith { ERROR("No optic classname provided"); false };
+
+private _isMagnified = GVAR(magnifiedOpticCache) getVariable _opticClassname;
+if (isNil "_isMagnified") then { // cache magnification check
+    TRACE_1("Looking up key: ", _opticClassname);
+    private _minZoom = 999; //FOV, so smaller is more zoomed in
+
+    {
+        if (isNumber (_x >> "opticsZoomMin")) then {
+            _minZoom = _minZoom min (getNumber (_x >> "opticsZoomMin"));
+        } else {
+            if (isText (_x >> "opticsZoomMin")) then { _minZoom = _minZoom min (call compile getText (_x >> "opticsZoomMin")); };
+        };
+        nil
+    } count configProperties [configFile >> "CfgWeapons" >> _opticClassname >> "ItemInfo" >> "OpticsModes"]; // count used here for speed, make sure nil is above this line
+
+    _isMagnified = _minZoom < MAG_OPTIC_ZOOM_THRESHOLD;
+    GVAR(magnifiedOpticCache) setVariable [_opticClassname, _isMagnified];
+};
+
+_isMagnified

--- a/addons/assignGear/functions/fnc_setWeaponAttachment.sqf
+++ b/addons/assignGear/functions/fnc_setWeaponAttachment.sqf
@@ -18,14 +18,6 @@
  */
 
 #include "script_component.hpp"
-#define MUZZLE_NUMBER 101
-#define MUZZLE_INDEX 1
-#define OPTIC_NUMBER 201
-#define OPTIC_INDEX 3
-#define POINTER_NUMBER 301
-#define POINTER_INDEX 2
-#define BIPOD_NUMBER 302
-#define BIPOD_INDEX 6
 
 TRACE_1("params",_this);
 params ["_weaponArray", "_config", "_classname", ["_doOpticCheck", true, [true]]];
@@ -33,37 +25,28 @@ params ["_weaponArray", "_config", "_classname", ["_doOpticCheck", true, [true]]
 private _typeNumber = getNumber (_config >> "itemInfo" >> "type");
 
 // muzzle
-if (_typeNumber == MUZZLE_NUMBER) exitWith {
-    _weaponArray set [MUZZLE_INDEX, _classname];
+if (_typeNumber == MUZZLE_TYPE) exitWith {
+    _weaponArray set [LAW_MUZZLE_INDEX, _classname];
 };
 
 // optic
-if (_typeNumber == OPTIC_NUMBER) exitWith {
-    if (!GVAR(allowMagnifiedOptics) && {_doOpticCheck}) then {
-        private _minZoom = 999; //FOV, so smaller is more zoomed in
-        {
-            if (isNumber (_x >> "opticsZoomMin")) then {_minZoom = _minZoom min (getNumber (_x >> "opticsZoomMin"));};
-            if (isText (_x >> "opticsZoomMin")) then {_minZoom = _minZoom min (call compile getText (_x >> "opticsZoomMin"));};
-            nil
-        } count configProperties [_config >> "ItemInfo" >> "OpticsModes"]; // count used here for speed, make sure nil is above this line
-
-        if (_minZoom < 0.25) then {
-            diag_log text format ["[POTATO-assignGear] allowMagnifiedOptics is false, not adding %1 (opticsZoomMin %2)", _classname, _minZoom];
-            _classname = "";
-        };
+if (_typeNumber == OPTIC_TYPE) exitWith {
+    if (!GVAR(allowMagnifiedOptics) && {_doOpticCheck} && {[_classname] call FUNC(isOpticMagnified)}) then {
+        diag_log text format ["[POTATO-assignGear] allowMagnifiedOptics is false, not adding %1", _classname];
+        _classname = "";
     };
 
-    _weaponArray set [OPTIC_INDEX, _classname];
+    _weaponArray set [LAW_OPTIC_INDEX, _classname];
 };
 
 // pointer
-if (_typeNumber == POINTER_NUMBER) exitWith {
-    _weaponArray set [POINTER_INDEX, _classname];
+if (_typeNumber == POINTER_TYPE) exitWith {
+    _weaponArray set [LAW_POINTER_INDEX, _classname];
 };
 
 // bipod
-if (_typeNumber == BIPOD_NUMBER) exitWith {
-    _weaponArray set [BIPOD_INDEX, _classname];
+if (_typeNumber == BIPOD_TYPE) exitWith {
+    _weaponArray set [LAW_BIPOD_INDEX, _classname];
 };
 
 diag_log text format ["[POTATO-assignGear] - Attachment [%1] has unknown type", _classname];

--- a/addons/assignGear/script_component.hpp
+++ b/addons/assignGear/script_component.hpp
@@ -14,3 +14,42 @@
 #endif
 
 #include "\z\potato\addons\core\script_macros.hpp"
+
+// magnified optic zoom threshold
+#define MAG_OPTIC_ZOOM_THRESHOLD 0.25
+
+// loadout array indexes
+#define LA_PRIMARY_WEAPON_INDEX 0
+#define LA_LAUNCHER_WEAPON_INDEX 1
+#define LA_HANDGUN_WEAPON_INDEX 2
+#define LA_UNIFORM_INDEX 3
+#define LA_VEST_INDEX 4
+#define LA_BACKPACK_INDEX 5
+#define LA_HELMET_INDEX 6
+#define LA_FACEWARE_INDEX 7
+#define LA_BINOCULAR_INDEX 8
+#define LA_LINKED_ITEMS_INDEX 9
+
+// loadout array weapon indexes
+#define LAW_WEAPON_INDEX 0
+#define LAW_MUZZLE_INDEX 1
+#define LAW_POINTER_INDEX 2
+#define LAW_OPTIC_INDEX 3
+#define LAW_PRIMARY_MUZZLE_MAG_INDEX 4
+#define LAW_SECONDARY_MUZZLE_MAG_INDEX 5
+#define LAW_BIPOD_INDEX 6
+
+// allowed slots by container
+#define VEST_ALLOWED_SLOTS 701
+#define UNIFORM_ALLOWED_SLOTS 801
+#define BACKPACK_ALLOWED_SLOTS 901
+
+// item types
+#define PRIMARY_TYPE 1
+#define HANDGUN_TYPE 2
+#define LAUNCHER_TYPE 4
+#define MUZZLE_TYPE 101
+#define OPTIC_TYPE 201
+#define POINTER_TYPE 301
+#define BIPOD_TYPE 302
+#define BINO_TYPE 4096


### PR DESCRIPTION
Some pretty minor cleanup for assign gear:
- Simplifies the goggle handling by just setting it in the setUnitLoadout array, instead of handling it separately.
- Adds a function to check if an optic is considered magnified, added a cache lookup on the optic class name. Should help a bit with maintenance and a bit on the optic lookup, only 'problem' is the client (optix) vs server (assignGear) locality nmot fully leveraging the caching.
- Moves a lot of the BI based defined to the scripting component file for easier lookup/tweaking.
- Some minor style tweaks