### PR TITLE
Add HLC<->CUP G36 support

### DIFF
--- a/addons/massCompat/CfgWeapons.hpp
+++ b/addons/massCompat/CfgWeapons.hpp
@@ -85,7 +85,25 @@
 "CUP_100Rnd_556x45_BetaCMag", \
 "CUP_100Rnd_TE1_Red_Tracer_556x45_BetaCMag", \
 "CUP_100Rnd_TE1_Green_Tracer_556x45_BetaCMag", \
-"CUP_100Rnd_TE1_Yellow_Tracer_556x45_BetaCMag"
+"CUP_100Rnd_TE1_Yellow_Tracer_556x45_BetaCMag", \
+"hlc_30rnd_556x45_S", \
+"hlc_30rnd_556x45_Tracers_G36", \
+"hlc_30rnd_556x45_TDIM_G36", \
+"hlc_30rnd_556x45_MDIM_G36", \
+"hlc_30rnd_556x45_EPR_G36", \
+"hlc_30rnd_556x45_SOST_G36", \
+"hlc_30rnd_556x45_SPR_G36", \
+"hlc_100rnd_556x45_EPR_G36", \
+"hlc_100rnd_556x45_M_G36", \
+"hlc_100rnd_556x45_Mdim_G36"
+
+#define HLC_G36_SWITCH_CLASS(CMAG_GUN) \
+class nia_magSwitch { \
+    CUP_100Rnd_556x45_BetaCMag = QUOTE(CMAG_GUN); \
+    CUP_100Rnd_TE1_Red_Tracer_556x45_BetaCMag =  QUOTE(CMAG_GUN); \
+    CUP_100Rnd_TE1_Green_Tracer_556x45_BetaCMag = QUOTE(CMAG_GUN); \
+    CUP_100Rnd_TE1_Yellow_Tracer_556x45_BetaCMag = QUOTE(CMAG_GUN); \
+}
 
 #define NATO_LMG_65 \
 "200Rnd_65x39_cased_Box", \
@@ -387,6 +405,63 @@ class CfgWeapons {
     };
     class CUP_arifle_MG36: CUP_arifle_G36C {
         magazines[] = { NATO_PMAG_556 };
+    };
+    class hlc_G36_base: Rifle_Base_F {
+        magazines[] = { NATO_PMAG_556 };
+    };
+    class hlc_rifle_MG36: hlc_G36_base {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_MG36);
+    };
+    class hlc_rifle_G36A1: hlc_G36_base {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36A1_CMAG);
+    };
+    class hlc_rifle_G36A1AG36: hlc_rifle_G36A1 {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36A1AG36_CMAG);
+    };
+    class hlc_rifle_G36E1AG36 : hlc_rifle_G36A1AG36 {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36E1AG36_CMAG);
+    };
+    class hlc_rifle_G36E1AG36_Romi : hlc_rifle_G36E1AG36 {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36E1AG36_Romi_CMAG);
+    };
+    class hlc_rifle_G36KA1: hlc_rifle_G36A1 {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36KA1_CMAG);
+    };
+    class hlc_rifle_G36KE1: hlc_rifle_g36KA1 {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36KE1_CMAG);
+    };
+    class hlc_rifle_G36E1: hlc_rifle_g36A1 {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36E1_CMAG);
+    };
+    class hlc_rifle_G36V : hlc_rifle_G36E1 {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36V_CMAG);
+    };
+    class hlc_rifle_G36VAG36: hlc_rifle_G36V {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36VAG36_CMAG);
+    };
+    class hlc_rifle_G36TAC: hlc_rifle_G36V {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36TAC_CMAG);
+    };
+    class hlc_rifle_G36C: hlc_G36_base {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36C_CMAG);
+    };
+    class hlc_rifle_G36CV: hlc_rifle_G36C {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36CV_CMAG);
+    };
+    class hlc_rifle_G36CTac: hlc_rifle_G36CV {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36CTac_CMAG);
+    };
+    class hlc_rifle_G36KV: hlc_rifle_G36KE1 {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36KV_CMAG);
+    };
+    class hlc_rifle_g36KTac: hlc_rifle_G36KV {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_g36KTac_CMAG);
+    };
+    class hlc_rifle_G36KA1KSK: hlc_rifle_G36KV {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36KA1KSK_CMAG);
+    };
+    class HLC_Rifle_G36KSKAG36 : hlc_rifle_G36KA1KSK {
+        HLC_G36_SWITCH_CLASS(hlc_rifle_G36KSKAG36_CMAG);
     };
     class CUP_arifle_XM8_Base: Rifle_Base_f {
         magazines[] = { NATO_PMAG_556 };

--- a/addons/massCompat/CfgWeapons.hpp
+++ b/addons/massCompat/CfgWeapons.hpp
@@ -418,10 +418,10 @@ class CfgWeapons {
     class hlc_rifle_G36A1AG36: hlc_rifle_G36A1 {
         HLC_G36_SWITCH_CLASS(hlc_rifle_G36A1AG36_CMAG);
     };
-    class hlc_rifle_G36E1AG36 : hlc_rifle_G36A1AG36 {
+    class hlc_rifle_G36E1AG36: hlc_rifle_G36A1AG36 {
         HLC_G36_SWITCH_CLASS(hlc_rifle_G36E1AG36_CMAG);
     };
-    class hlc_rifle_G36E1AG36_Romi : hlc_rifle_G36E1AG36 {
+    class hlc_rifle_G36E1AG36_Romi: hlc_rifle_G36E1AG36 {
         HLC_G36_SWITCH_CLASS(hlc_rifle_G36E1AG36_Romi_CMAG);
     };
     class hlc_rifle_G36KA1: hlc_rifle_G36A1 {
@@ -433,7 +433,7 @@ class CfgWeapons {
     class hlc_rifle_G36E1: hlc_rifle_g36A1 {
         HLC_G36_SWITCH_CLASS(hlc_rifle_G36E1_CMAG);
     };
-    class hlc_rifle_G36V : hlc_rifle_G36E1 {
+    class hlc_rifle_G36V: hlc_rifle_G36E1 {
         HLC_G36_SWITCH_CLASS(hlc_rifle_G36V_CMAG);
     };
     class hlc_rifle_G36VAG36: hlc_rifle_G36V {
@@ -460,7 +460,7 @@ class CfgWeapons {
     class hlc_rifle_G36KA1KSK: hlc_rifle_G36KV {
         HLC_G36_SWITCH_CLASS(hlc_rifle_G36KA1KSK_CMAG);
     };
-    class HLC_Rifle_G36KSKAG36 : hlc_rifle_G36KA1KSK {
+    class HLC_Rifle_G36KSKAG36: hlc_rifle_G36KA1KSK {
         HLC_G36_SWITCH_CLASS(hlc_rifle_G36KSKAG36_CMAG);
     };
     class CUP_arifle_XM8_Base: Rifle_Base_f {

--- a/addons/massCompat/config.cpp
+++ b/addons/massCompat/config.cpp
@@ -19,7 +19,7 @@ class CfgPatches {
             "CUP_Weapons_MP5", "CUP_Weapons_L129", "CUP_Weapons_M14",
             "CUP_Weapons_M14_DMR", "CUP_Weapons_Mk48", "CUP_Weapons_AWM",
             "CUP_Weapons_M107", "CUP_Weapons_M24", "CUP_Weapons_SVD",
-            "hlcweapons_mp5", "hlcweapons_core"
+            "hlcweapons_mp5", "hlcweapons_core", "hlcweapons_G36"
         };
         author = "Potato";
         authors[] = {"PabstMirror", "AACO"};

--- a/addons/miscFixes/CfgWeapons.hpp
+++ b/addons/miscFixes/CfgWeapons.hpp
@@ -50,6 +50,30 @@ class CfgWeapons {
         };
     };
 
+    // add zeroing to iron sighted G36es
+    class hlc_rifle_G36E1;
+    class hlc_rifle_G36V : hlc_rifle_G36E1 {
+        class OpticsModes {
+            class Kolimator {
+                distancezoommax = 100;
+                distancezoommin = 500;
+                discreteDistance[] = {100, 200, 300, 400, 500};
+                discreteDistanceInitIndex = 1
+            };
+        };
+    };
+    class hlc_rifle_G36KE1;
+    class hlc_rifle_G36KV : hlc_rifle_G36KE1 {
+        class OpticsModes {
+            class Kolimator {
+                distancezoommax = 100;
+                distancezoommin = 500;
+                discreteDistance[] = {100, 200, 300, 400, 500};
+                discreteDistanceInitIndex = 1
+            };
+        };
+    };
+
     // Create RPK from CUP RPK-74, just need to fill a gap
     class CUP_arifle_RPK74;
     class potato_arifle_RPK: CUP_arifle_RPK74 {

--- a/addons/miscFixes/CfgWeapons.hpp
+++ b/addons/miscFixes/CfgWeapons.hpp
@@ -58,7 +58,7 @@ class CfgWeapons {
                 distancezoommax = 100;
                 distancezoommin = 500;
                 discreteDistance[] = {100, 200, 300, 400, 500};
-                discreteDistanceInitIndex = 1
+                discreteDistanceInitIndex = 1;
             };
         };
     };
@@ -69,7 +69,7 @@ class CfgWeapons {
                 distancezoommax = 100;
                 distancezoommin = 500;
                 discreteDistance[] = {100, 200, 300, 400, 500};
-                discreteDistanceInitIndex = 1
+                discreteDistanceInitIndex = 1;
             };
         };
     };

--- a/addons/miscFixes/config.cpp
+++ b/addons/miscFixes/config.cpp
@@ -17,7 +17,8 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
             "potato_core", "mbg_celle2", "ace_ui",
-            "rhs_c_weapons", "rhsusf_c_weapons", "CUP_Weapons_AK"
+            "rhs_c_weapons", "rhsusf_c_weapons",
+            "CUP_Weapons_AK", "hlcweapons_G36"
         };
         author = "Potato";
         authors[] = {"PabstMirror", "AACO"};


### PR DESCRIPTION
This PR will:
- Add cross magazine support between CUP and HLC (M)G36es.
- Add display support for loading CUP 30/100rnd mags into HLC (M)G36es
- Allow the iron sighted HLC G36es to be zeroed from 100-500m

These changes should allow the HLC/CUP (M)G36es to be better integrated into sessions