### PR TITLE
Add engine script setting

### DIFF
--- a/addons/aceSettings/XEH_preInit.sqf
+++ b/addons/aceSettings/XEH_preInit.sqf
@@ -1,11 +1,15 @@
 #include "script_component.hpp"
 
-LOG("Setting STUI settings");
-STUI_Occlusion = false; // Default: true
-// STHud_ShowBearingInVehicle = true; // Default: true
-STHud_NoSquadBarMode = true; // Default: false
-// STUI_RemoveDeadViaProximity = true; // Default: true
-
+// handle RHS engine startup script
+[
+    QGVAR(rhsEngineStartup),
+    "CHECKBOX",
+    ["RHS Engine startup script", "True on, false off"],
+    "POTATO Misc",
+    false,
+    1,
+    { diag_log _this; RHS_ENGINE_STARTUP_OFF = ([0, nil] select _this); }
+] call cba_settings_fnc_init;
 
 // Settings Test:
 if (isServer) then {

--- a/addons/aceSettings/XEH_preInit.sqf
+++ b/addons/aceSettings/XEH_preInit.sqf
@@ -1,15 +1,7 @@
 #include "script_component.hpp"
 
-// handle RHS engine startup script
-[
-    QGVAR(rhsEngineStartup),
-    "CHECKBOX",
-    ["RHS Engine startup script", "True on, false off"],
-    "POTATO Misc",
-    false,
-    1,
-    { diag_log _this; RHS_ENGINE_STARTUP_OFF = ([0, nil] select _this); }
-] call cba_settings_fnc_init;
+// turn off RHS engine startup script
+RHS_ENGINE_STARTUP_OFF = 1; // any non-nil value turns this off
 
 // Settings Test:
 if (isServer) then {


### PR DESCRIPTION
Adds a setting that turns off RHS engine startup delay scripting. Discussion point: should we leave this defaulted to true, then update it in BWMF?

Also cleans up STUI variables that are unused.