### PR TITLE
Make AI throw potatos when met with threat

### DIFF
--- a/addons/core/CfgAmmo.hpp
+++ b/addons/core/CfgAmmo.hpp
@@ -2,6 +2,8 @@ class CfgAmmo {
     class SmokeShell;
     class GVAR(potato): SmokeShell {
         hit = 1;
+        cost = 30;
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
         model = QPATHTOF(data\potato_ammo.p3d);
         effectsSmoke = "EmptyEffect";
         grenadeFireSound[] = {};


### PR DESCRIPTION
Title.

Use case: Mission with protesting AI and you want players to get freaked out. Default "Stone" class not suitable as for it is not a stone model and it explodes, kinda negating the point.