### PR TITLE
Make AI shoot rockets more often

### DIFF
--- a/addons/aiCfgFixes/CfgAmmo.hpp
+++ b/addons/aiCfgFixes/CfgAmmo.hpp
@@ -1,12 +1,12 @@
 class CfgAmmo {
     class Default;
-    class ShellCore: Default {
-        audibleFire = 16;
-    };
     class BulletCore: Default {
         audibleFire = 16;
     };
     class SubmunitionCore: Default {
+        audibleFire = 16;
+    };
+    class ShellCore: Default {
         audibleFire = 16;
     };
     class RocketCore: Default {
@@ -33,25 +33,12 @@ class CfgAmmo {
     class ShotgunCore: Default {
         audibleFire = 16;
     };
-    class ShellBase: ShellCore {
-        audibleFire = AI_AUDIBLE_FIRE_0;
-        GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
-    };
-    class ACE_HuntIR_Propell: ShellBase {
-        audibleFire = 1;
-    };
-    class R_230mm_fly: ShellBase {
-        audibleFire = 64;
-    };
     class BulletBase: BulletCore {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
     };
     class FakeAmmo: BulletCore {
         audibleFire = 16;
-    };
-    class RHS_LWIRCM_Ammo_MELB: BulletBase {
-        audibleFire = 0;
     };
     class B_556x45_Ball: BulletBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
@@ -60,6 +47,12 @@ class CfgAmmo {
     class B_762x51_Ball: BulletBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+    };
+    class B_20mm_AP: BulletBase {
+        audibleFire = 200;
+    };
+    class RHS_LWIRCM_Ammo_MELB: BulletBase {
+        audibleFire = 0;
     };
     class ammo_Gun35mmAABase: BulletBase {
         audibleFire = 200;
@@ -189,8 +182,7 @@ class CfgAmmo {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
     };
-    class CUP_B_9x18_Ball: BulletBase {
-    };
+    class CUP_B_9x18_Ball;
     class CUP_B_86x70_Ball_noTracer: BulletBase {
         audibleFire = 22;
     };
@@ -253,8 +245,7 @@ class CfgAmmo {
         audibleFire = AI_AUDIBLE_FIRE_1;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_1";
     };
-    class HLC_9x19_Ball: B_556x45_Ball {
-    };
+    class HLC_9x19_Ball;
     class FH_545x39_Ball: B_556x45_Ball {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
@@ -267,8 +258,7 @@ class CfgAmmo {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
     };
-    class HLC_300WM_BTSP: B_556x45_Ball {
-    };
+    class HLC_300WM_BTSP;
     class HLC_300WM_Tracer: B_556x45_Ball {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
@@ -277,10 +267,8 @@ class CfgAmmo {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
     };
-    class HLC_303Brit_B: B_556x45_Ball {
-    };
-    class HLC_300Blackout_Ball: B_556x45_Ball {
-    };
+    class HLC_303Brit_B;
+    class HLC_300Blackout_Ball;
     class HLC_556NATO_SPR: B_556x45_Ball {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
@@ -332,8 +320,7 @@ class CfgAmmo {
         audibleFire = AI_AUDIBLE_FIRE_1;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_1";
     };
-    class HLC_GP11_FMJ: B_762x51_Ball {
-    };
+    class HLC_GP11_FMJ;
     class rhs_B_762x39_Ball: B_762x51_Ball {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
@@ -342,8 +329,7 @@ class CfgAmmo {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
     };
-    class CUP_B_762x51_noTracer: B_762x51_Ball {
-    };
+    class CUP_B_762x51_noTracer;
     class HLC_GP11_tracer: HLC_GP11_FMJ {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
@@ -388,8 +374,7 @@ class CfgAmmo {
         audibleFire = AI_AUDIBLE_FIRE_1;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_1";
     };
-    class SubmunitionBase: SubmunitionCore {
-    };
+    class SubmunitionBase;
     class VOG25P_SubMunition: SubmunitionBase {
         audibleFire = 6;
     };
@@ -402,7 +387,16 @@ class CfgAmmo {
     class rhs_ammo_30x173mm_GAU8_mixed: SubmunitionBase {
         audibleFire = 250;
     };
-    class SubmunitionBullet: SubmunitionBase {
+    class SubmunitionBullet;
+    class ShellBase: ShellCore {
+        audibleFire = AI_AUDIBLE_FIRE_0;
+        GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+    };
+    class ACE_HuntIR_Propell: ShellBase {
+        audibleFire = 1;
+    };
+    class R_230mm_fly: ShellBase {
+        audibleFire = 64;
     };
     class RocketBase: RocketCore {
         audibleFire = AI_AUDIBLE_FIRE_0;
@@ -419,10 +413,16 @@ class CfgAmmo {
     class rhs_ammo_maaws_HE: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class rhs_ammo_maaws_HEDP: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class rhs_ammo_maaws_HEAT: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
@@ -434,6 +434,9 @@ class CfgAmmo {
     class rhs_ammo_smaw_HEDP: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class rhs_ammo_smaw_HEAA: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
@@ -442,54 +445,92 @@ class CfgAmmo {
     class rhs_ammo_M136_rocket: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
-    class R_PG32V_F: RocketBase {
-    };
+    class R_PG32V_F;
     class CUP_R_SMAW_HEDP_N: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class CUP_R_RPG18_AT: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class CUP_R_MEEWS_HEDP: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 150;
     };
     class CUP_R_M136_AT: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class CUP_R_SMAW_HEDP: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class CUP_R_70mm_Hydra_HE: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 512";
+        allowAgainstInfantry = 1;
+        cost = 100;
     };
     class CUP_R_OG7_AT: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class CUP_R_TBG7V_AT: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256";
+        allowAgainstInfantry = 1;
+        cost = 150;
     };
     class CUP_R_PG7VR_AT: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class CUP_R_PG7VL_AT: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class CUP_R_PG7VM_AT: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class CUP_R_PG7V_AT: RocketBase {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class MissileBase: MissileCore {
         audibleFire = AI_AUDIBLE_FIRE_0;
@@ -499,8 +540,8 @@ class CfgAmmo {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
     };
-    class M_Titan_AA: MissileBase {
-    };
+    class M_Titan_AA;
+    class M_Mo_82mm_AT;
     class rhs_ammo_fim92_missile: M_Titan_AA {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
@@ -524,6 +565,9 @@ class CfgAmmo {
     class rhs_rpg26_rocket: R_PG32V_F {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
     class rhs_rpg7v2_pg7vl: rhs_rpg26_rocket {
         audibleFire = AI_AUDIBLE_FIRE_0;
@@ -572,18 +616,15 @@ class CfgAmmo {
     class GrenadeHand: Grenade {
         audibleFire = 0.05;
     };
-    class GrenadeBase: GrenadeCore {
-    };
-    class FlareCore: GrenadeCore {
-    };
+    class GrenadeBase;
+    class FlareCore;
     class SmokeShellCore: GrenadeCore {
         audibleFire = 0.25;
     };
     class G_40mm_HE: GrenadeBase {
         audibleFire = 30;
     };
-    class CUP_G_40mm_HE: G_40mm_HE {
-    };
+    class CUP_G_40mm_HE;
     class CUP_G_30mm_HE: CUP_G_40mm_HE {
         audibleFire = 18;
     };
@@ -606,16 +647,24 @@ class CfgAmmo {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
     };
-    class B_20mm_Tracer_Red: B_20mm {
-    };
+    class B_20mm_Tracer_Red;
     class rhs_ammo_20mm_AP: B_20mm {
         audibleFire = 28;
     };
     class rhsusf_M61A2: B_20mm_Tracer_Red {
         audibleFire = 28;
     };
-    class FlareBase: FlareCore {
+    class M_Mo_120mm_AT;
+    class M_Mo_155mm_AT;
+    class M_Mo_120mm_AT_LG;
+    class M_Mo_230mm_AT: M_Mo_155mm_AT {
+        audibleFire = 64;
     };
+    class M_Mo_155mm_AT_LG;
+    class M_Mo_230mm_AT_LG: M_Mo_155mm_AT_LG {
+        audibleFire = 64;
+    };
+    class FlareBase;
     class F_40mm_White: FlareBase {
         audibleFire = 20;
     };
@@ -629,6 +678,22 @@ class CfgAmmo {
     class B_65x39_Minigun_Caseless: SubmunitionBullet {
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
+    };
+    class R_80mm_HE;
+    class potato_aiCfgFixes_he_rocket: R_80mm_HE {
+        aiAmmoUsageFlags = "64 + 128 + 512";
+        allowAgainstInfantry = 1;
+        cost = 100;
+    };
+    class CUP_R_57mm_HE: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 150;
+    };
+    class CUP_R_M72A6_AT: RocketBase {
+        aiAmmoUsageFlags = "64 + 128 + 256 + 512";
+        allowAgainstInfantry = 1;
+        cost = 50;
     };
 };
 

--- a/addons/aiCfgFixes/CfgMagazines.hpp
+++ b/addons/aiCfgFixes/CfgMagazines.hpp
@@ -1,0 +1,23 @@
+class CfgMagazines {
+	class 24Rnd_missiles;
+	class CUP_14Rnd_S5_M: 24Rnd_missiles {
+		ammo = QGVAR(he_rocket);
+	};
+	
+	class CUP_64Rnd_S5_M: 24Rnd_missiles {
+		ammo = QGVAR(he_rocket);
+	};
+	
+	class CUP_128Rnd_S5_M: 24Rnd_missiles {
+		ammo = QGVAR(he_rocket);
+	};
+	
+	class CUP_192Rnd_S5_M: 24Rnd_missiles {
+		ammo = QGVAR(he_rocket);
+	};
+	
+	class 38Rnd_80mm_rockets;
+	class CUP_40Rnd_S8_M: 38Rnd_80mm_rockets {
+		ammo = QGVAR(he_rocket);
+	};
+};

--- a/addons/aiCfgFixes/config.cpp
+++ b/addons/aiCfgFixes/config.cpp
@@ -27,6 +27,7 @@ class CfgPatches {
 #include "CfgEventHandlers.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
 
 #endif
 

--- a/addons/aiCfgFixes/functions/fnc_ensurePlayerBurst.sqf
+++ b/addons/aiCfgFixes/functions/fnc_ensurePlayerBurst.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Example:
- * [] call potato_weaponCfgFixes_fnc_ensurePlayerBurst;
+ * [] call potato_aiCfgFixes_fnc_ensurePlayerBurst;
  *
  * Public: Yes
  */

--- a/addons/aiCfgFixes/functions/fnc_generateAmmo.sqf
+++ b/addons/aiCfgFixes/functions/fnc_generateAmmo.sqf
@@ -9,7 +9,7 @@
  * None
  *
  * Example:
- * [] call potato_weaponCfgFixes_fnc_generateAmmo;
+ * [] call potato_aiCfgFixes_fnc_generateAmmo;
  *
  * Public: Yes
  */
@@ -54,35 +54,119 @@ private _ammoToGenerateCorrect = [];
 //reverse _ammoToGenerateCorrect;
 _ammoToGenerate = _ammoToGenerateCorrect;
 
-systemChat "Creating Config...";
-private _finalStr = "class CfgAmmo {" + LINE_BREAK;
-
-{
-    _finalStr = _finalStr + INDENT + "class " + configName(_x) + ";" + LINE_BREAK;
-} forEach _baseClasses;
-
+private _retAmmo = [];
 {
     // _x = ammo_config
     if (!(configName(_x) isEqualTo "")) then {
         if (configName(inheritsFrom(_x)) isEqualTo "") then {
             // nothing
         } else {
-            private _inherit = ": " + configName(inheritsFrom(_x));
-            private _classText = INDENT + "class " + configName(_x) + _inherit + " {" + LINE_BREAK;
+            private _newValue = [[_x, configName(_x)]];
+            private _newData = [];
+            
             private _currentAmmo = _x;
             {
                 if (count configProperties[_currentAmmo, "configName(_x) isEqualTo 'potato_aiCfgFixes_macroUsed'", false] <= 0) then {
-                    _classText = _classText + CFG_CLASS_DATA(configName(_x), str(getNumber(_x)));
+                    _newData pushBack [configName(_x), str(getNumber(_x))];
                 } else {
                     private _macro = getText(configProperties[_currentAmmo, "configName(_x) isEqualTo 'potato_aiCfgFixes_macroUsed'", false] select 0);
-                    _classText = _classText + CFG_CLASS_DATA(configName(_x), _macro);
-                    _classText = _classText + CFG_CLASS_DATA("GVAR(macroUsed)", str(_macro));
+                    _newData pushBack [configName(_x), _macro];
+                    _newData pushBack ["GVAR(macroUsed)", str(_macro)];
                 };
             } forEach configProperties[_x, SEARCH_CONFIG, false];
-            _finalStr = _finalStr + _classText + INDENT + "};" + LINE_BREAK;
+            
+            _newValue pushBack _newData;
+            _retAmmo pushBack _newValue;
         };
     };
 } forEach _ammoToGenerate;
+
+systemChat "Setting usage flags...";
+private _setAiUsageFlags = {
+    params["_retAmmo"];
+    
+    private _setUsageFlags = {
+        params["_retAmmo", "_ammo", "_flags", ["_extra", []]];
+        
+        private _ammoUsageFlags = '"';
+        {
+            _ammoUsageFlags = _ammoUsageFlags + str(_x);
+            if (_foreachindex != (count _flags) - 1) then {
+                _ammoUsageFlags = _ammoUsageFlags + " + ";
+            };
+        } forEach _flags;
+        _ammoUsageFlags = _ammoUsageFlags + '"';
+        
+        private _pos = _retAmmo findIf { ((_x select 0) select 1) isEqualTo _ammo };
+        if (_pos < 0) then {
+            if ((_retAmmo findIf {((_x select 0) select 1) isEqualTo configName(inheritsFrom(configFile >> "CfgAmmo" >> _ammo)) }) < 0) then {
+                _retAmmo pushBack [[inheritsFrom(configFile >> "CfgAmmo" >> _ammo), configName(inheritsFrom(configFile >> "CfgAmmo" >> _ammo))], []];
+            };
+            _retAmmo pushBack [[configFile >> "CfgAmmo" >> _ammo, _ammo], []];
+            _pos = (count _retAmmo) - 1;
+        };
+                
+        ((_retAmmo select _pos) select 1) pushBack ["aiAmmoUsageFlags", _ammoUsageFlags];
+        ((_retAmmo select _pos) select 1) pushBack ["allowAgainstInfantry", "1"];
+        
+        {
+            ((_retAmmo select _pos) select 1) pushBack [_x select 0, _x select 1];
+        } forEach _extra;
+        
+        _retAmmo;
+    };
+    
+    _retAmmo = [_retAmmo, "potato_aiCfgFixes_he_rocket",    [64, 128, 512],         [["cost", "100"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_70mm_Hydra_HE",            [64, 128, 512],         [["cost", "100"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "rhs_ammo_maaws_HE",              [64, 128, 256],         [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "rhs_ammo_maaws_HEDP",            [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "rhs_ammo_smaw_HEDP",             [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "rhs_ammo_M136_rocket",           [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "rhs_rpg26_rocket",               [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    
+    _retAmmo = [_retAmmo, "CUP_R_SMAW_HEDP_N",              [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_RPG18_AT",                 [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_MEEWS_HEDP",               [64, 128, 256, 512],    [["cost", "150"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_M136_AT",                  [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_SMAW_HEDP",                [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_OG7_AT",                   [64, 128, 256],         [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_TBG7V_AT",                 [64, 128, 256],         [["cost", "150"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_PG7VR_AT",                 [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_PG7VM_AT",                 [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_PG7V_AT",                  [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_PG7VL_AT",                 [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_57mm_HE",                  [64, 128, 256, 512],    [["cost", "150"]]] call _setUsageFlags;
+    _retAmmo = [_retAmmo, "CUP_R_M72A6_AT",                 [64, 128, 256, 512],    [["cost", "50"]]] call _setUsageFlags;
+    
+    _retAmmo
+};
+
+_retAmmo = [_retAmmo] call _setAiUsageFlags;
+
+systemChat "Creating Config...";
+private _finalStr = "class CfgAmmo {" + LINE_BREAK;
+
+systemChat "Printing base classes...";
+{
+    _finalStr = _finalStr + INDENT + "class " + configName(_x) + ";" + LINE_BREAK;
+} forEach _baseClasses;
+
+systemChat "Printing modified classes...";
+{
+    _x params ["_ammoArr", "_printValues"];
+    _ammoArr params["_ammoCfg", "_ammoName"];
+    
+    private _inherit = ": " + configName(inheritsFrom(_ammoCfg));
+    private _classText = INDENT + "class " + _ammoName;
+    if ((count _printValues) > 0) then {
+        _classText = _classText + _inherit + " {" + LINE_BREAK;
+        {
+            _classText = _classText + CFG_CLASS_DATA((_x select 0), (_x select 1));
+        } forEach _printValues;
+        _classText = _classText + INDENT + "}";
+    };
+    _finalStr = _finalStr + _classText + ";" + LINE_BREAK;
+} forEach _retAmmo;
 
 _finalStr = _finalStr + CFG_FOOTER;
 

--- a/addons/aiCfgFixes/functions/fnc_generateWeapons.sqf
+++ b/addons/aiCfgFixes/functions/fnc_generateWeapons.sqf
@@ -9,7 +9,7 @@
  * None
  *
  * Example:
- * [] call potato_weaponCfgFixes_fnc_generateWeapons;
+ * [] call potato_aiCfgFixes_fnc_generateWeapons;
  *
  * Public: Yes
  */


### PR DESCRIPTION
Currently AI will not fire MI-8 or MI-24 rocket pods at players if they are not in a vehicle. This changes that, and makes it so the AI will consider shooting regular RPG rockets at players as well

Why:
Currently when a MI-8 with rocket pods fly overhead players ignore it because they dont shoot their rockets. Make that assumption go away with this, and make COOPs more deadly

Custom ammo type implemented as to not break anything that uses R_80mm_HE