### PR TITLE
Make AI see farther away

### DIFF
--- a/addons/aiCfgFixes/CfgVehicles.hpp
+++ b/addons/aiCfgFixes/CfgVehicles.hpp
@@ -1,0 +1,23 @@
+class CfgVehicles {
+    class Land;
+    class Man: Land {
+        sensitivityEar = 1.0;
+    };
+    class CAManBase: Man {
+        sensitivity = 4;
+        sensitivityEar = 0.75;
+    };
+    class SoldierWB: CAManBase {
+        sensitivity = 5;
+        sensitivityEar = 1.0;
+    };
+    class SoldierEB: CAManBase {
+        sensitivity = 5;
+        sensitivityEar = 1.0;
+    };
+    class SoldierGB: CAManBase {
+        sensitivity = 5;
+        sensitivityEar = 1.0;
+    };
+};
+

--- a/addons/aiCfgFixes/config.cpp
+++ b/addons/aiCfgFixes/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"potato_core", "A3_Weapons_F", "A3_Weapons_F_Exp", "A3_Weapons_F_Mark", "hlcweapons_core", "hlcweapons_g3", "hlcweapons_mp5", "hlcweapons_stgw57",
+        requiredAddons[] = {"potato_core", "A3_Characters_F", "A3_Weapons_F", "A3_Weapons_F_Exp", "A3_Weapons_F_Mark", "hlcweapons_core", "hlcweapons_g3", "hlcweapons_mp5", "hlcweapons_stgw57",
                             "rhs_c_weapons", "rhsgref_c_weapons", "rhsusf_c_weapons", "CUP_Weapons_AA12", "CUP_Weapons_AK", "CUP_Weapons_AS50", "CUP_Weapons_AWM", "CUP_Weapons_Bizon",
                             "CUP_Weapons_Colt1911", "CUP_Weapons_Compact", "CUP_Weapons_CZ750", "CUP_Weapons_CZ805", "CUP_Weapons_Duty", "CUP_Weapons_Evo", "CUP_Weapons_FNFAL", "CUP_Weapons_G36",
                             "CUP_Weapons_GrenadeLaunchers", "CUP_Weapons_Grenades", "CUP_Weapons_Huntingrifle", "CUP_Weapons_Igla", "CUP_Weapons_Items", "CUP_Weapons_Javelin", "CUP_Weapons_KSVK",
@@ -28,6 +28,7 @@ class CfgPatches {
 #include "CfgWeapons.hpp"
 #include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
+#include "CfgVehicles.hpp"
 
 #endif
 


### PR DESCRIPTION
AI currently don't shoot at you at far ranges because they dont have vision. This change makes them see at further ranges, and keep seeing at that range

If an AI group sees you at 500m+ they will keep firing at you for quite a distance until you out-range their weapons or you break line of sight. They will then keep observing that area so if you pop out again, they will light you up. Cool emergent behaviours come out of this, such as an actual AI Base of Fire at distance preventing a player push onto them

In testing the AI can theoretically see out to 700m and engage targets. Because of previous AI fixes they are limited to their weapon configuration and therefore the AR's will engage with long bursts with rifle fire coming at few second intervals. They are incredibly inaccurate at this range, but they land pot-shots

These changes are only relevant to AI engaging at longer ranges and identifying targets at said ranges (when shot at). This makes COOPs on Takistan and other desert maps more viable for infantry due to the combat environment

Spreadsheet showing range changes: https://docs.google.com/spreadsheets/d/1WRIRiCCPT2BjaALJ99sj-itj2ObrwvZWe_RKxeflzus/edit#gid=0

Mission that range changed were tested on: https://drive.google.com/open?id=1khB-1NWL5tQEAOOTxfHTsQUvFzMt--hO

How to run mission:
  Load in editor
  Input `[] spawn run_tests;` into debug console
  Wait until all tests are done
  

Do we want this? Does this break anything?