### PR TITLE
Add Vehicle Cookoff that doesn't override destroyed state

### DIFF
--- a/addons/aiVehicleBail/CfgVehicles.hpp
+++ b/addons/aiVehicleBail/CfgVehicles.hpp
@@ -412,7 +412,7 @@ class CfgVehicles {
         GVAR(engineFireProb) = 0.5;
         GVAR(detonationDuringFireProb) = 0;
     };
-    class CUP_AAV_Base {
+    class CUP_AAV_Base : Tank_F {
         GVAR(hullDetonationProb) = 0.2;
         GVAR(turretDetonationProb) = 0.2;
         GVAR(engineDetonationProb) = 0;

--- a/addons/aiVehicleBail/CfgVehicles.hpp
+++ b/addons/aiVehicleBail/CfgVehicles.hpp
@@ -1,0 +1,587 @@
+class CfgVehicles {
+    class Tank;
+    class Car_F;
+    class rhs_bmp1tank_base;
+    class Tank_F : Tank {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.2;
+    };
+    class Wheeled_APC_F : Car_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.2;
+    };
+    class APC_Tracked_01_base_F : Tank_F {};
+    class B_APC_Tracked_01_base_F : APC_Tracked_01_base_F {};
+    class B_APC_Tracked_01_AA_F : B_APC_Tracked_01_base_F {
+        GVAR(hullDetonationProb) = 0.4;
+        GVAR(turretDetonationProb) = 0.4;
+        GVAR(engineDetonationProb) = 0.4;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.8;
+    };
+    class B_APC_Tracked_01_rcws_F : B_APC_Tracked_01_base_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.8;
+        GVAR(turretFireProb) = 0.5;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class B_APC_Tracked_01_CRV_F : B_APC_Tracked_01_base_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.8;
+        GVAR(turretFireProb) = 0.5;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class APC_Wheeled_01_base_F : Wheeled_APC_F {};
+    class B_APC_Wheeled_01_cannon_F : APC_Wheeled_01_base_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class B_AFV_Wheeled_01_cannon_F : APC_Wheeled_01_base_F {
+        GVAR(hullDetonationProb) = 0.5;
+        GVAR(turretDetonationProb) = 0.5;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class MBT_01_base_F : Tank_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class APC_Tracked_02_base_F : Tank_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.8;
+        GVAR(turretFireProb) = 0.5;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class O_APC_Tracked_02_base_F : APC_Tracked_02_base_F {};
+    class O_APC_Tracked_02_AA_F : O_APC_Tracked_02_base_F {
+        GVAR(hullDetonationProb) = 0.4;
+        GVAR(turretDetonationProb) = 0.4;
+        GVAR(engineDetonationProb) = 0.4;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.8;
+    };
+    class MBT_04_base_F : Tank_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class MBT_02_base_F : Tank_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class LT_01_base_F : Tank_F {
+        GVAR(hullDetonationProb) = 0.8;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0.3;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.9;
+    };
+    class LT_01_scout_base_F : LT_01_base_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class APC_Tracked_03_base_F : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class APC_Wheeled_03_base_F : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class MBT_03_base_F : Tank_F {
+        GVAR(hullDetonationProb) = 0.3;
+        GVAR(turretDetonationProb) = 0.5;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.3;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.7;
+    };
+    class CUP_BRDM2_Base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class rhsgref_BRDM2 : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_BMP1_base : APC_Tracked_02_base_F { // CUP BMP2 Base inherits from this
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.8;
+        GVAR(turretFireProb) = 0.5;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class rhs_bmp_base : rhs_bmp1tank_base { // RHS BMP1 and BMP2
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.8;
+        GVAR(turretFireProb) = 0.5;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class rhs_bmp3tank_base : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_T72_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.8;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.8;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.2;
+    };
+    class CUP_FV432_Bulldog_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_FV510_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_Mastiff_Base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_Ridgback_Base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_Wolfhound_Base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_Challenger2_base : Tank_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class CUP_Leopard2_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.3;
+        GVAR(turretDetonationProb) = 0.5;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.3;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.7;
+    };
+    class rhs_zsutank_base : APC_Tracked_02_base_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.8;
+    };
+    class CUP_ZSU23_Base : Tank_F {
+        GVAR(turretDetonationProb) = 0;
+        GVAR(hullDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.8;
+    };
+    class rhs_btr_base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class rhs_bmd_base : Tank_F {   // All RHS BMDs
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.8;
+        GVAR(turretFireProb) = 0.5;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class rhs_a3t72tank_base : Tank_F { // rhs t-72s
+        GVAR(hullDetonationProb) = 0.8;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.8;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.2;
+    };
+    class rhs_t72bd_tv: rhs_a3t72tank_base {};
+    class rhs_tank_base : Tank_F {  // RHS T-80s. Maybe everything inherits from rhs_t80b ?
+        GVAR(hullDetonationProb) = 0.8;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.8;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.2;
+    };
+    class CUP_BTR60_Base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_MTLB_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class rhsusf_m113tank_base : APC_Tracked_02_base_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_M113_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_M113_Med_Base : CUP_M113_Base {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class CUP_M2Bradley_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_StrykerBase : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_B_M1128_MGS_Desert : CUP_StrykerBase {
+        GVAR(hullDetonationProb) = 0.5;
+        GVAR(turretDetonationProb) = 0.5;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_M1_Abrams_base : Tank_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class CUP_AAV_Base {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0.5;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_LAV25_Base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.7;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_M60A3_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.5;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0.5;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class RHS_M2A2_Base : APC_Tracked_03_base_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class rhsusf_M1117_base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class rhsusf_m1a1tank_base : Tank_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class CUP_2S6_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.4;
+        GVAR(turretDetonationProb) = 0.4;
+        GVAR(engineDetonationProb) = 0.4;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.8;
+    };
+    class CUP_BMP3_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_BTR90_Base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.5;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0.5;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_GAZ_Vodnik_Base : Wheeled_APC_F { // PKM Vodnik
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0.1;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_GAZ_Vodnik_MedEvac_Base : CUP_GAZ_Vodnik_Base {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class CUP_GAZ_Vodnik_BPPU_Base : CUP_GAZ_Vodnik_Base {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0.1;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class CUP_T90_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class CUP_T55_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.5;
+        GVAR(turretDetonationProb) = 0.5;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class rhs_t90_tv : rhs_t72bd_tv {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.5;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+    class rhs_a3spruttank_base : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0.5;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_T34_Base : Tank_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0.2;
+        GVAR(engineDetonationProb) = 0.2;
+        GVAR(hullFireProb) = 0.2;
+        GVAR(turretFireProb) = 0.2;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.8;
+    };
+    class CUP_BTR40_MG_Base : Wheeled_APC_F {
+        GVAR(hullDetonationProb) = 0.2;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0.1;
+        GVAR(hullFireProb) = 0.7;
+        GVAR(turretFireProb) = 0.7;
+        GVAR(engineFireProb) = 0.8;
+        GVAR(detonationDuringFireProb) = 0.5;
+    };
+    class CUP_BTR40_Base : CUP_BTR40_MG_Base {
+        GVAR(hullDetonationProb) = 0;
+        GVAR(turretDetonationProb) = 0;
+        GVAR(engineDetonationProb) = 0;
+        GVAR(hullFireProb) = 0;
+        GVAR(turretFireProb) = 0;
+        GVAR(engineFireProb) = 0;
+        GVAR(detonationDuringFireProb) = 0;
+    };
+};
+

--- a/addons/aiVehicleBail/XEH_PREP.hpp
+++ b/addons/aiVehicleBail/XEH_PREP.hpp
@@ -4,4 +4,6 @@ PREP(abandon);
 PREP(addEventHandler);
 PREP(handleBail);
 PREP(handleVehicleDamage);
+PREP(handleCookoff);
+PREP(detonate);
 

--- a/addons/aiVehicleBail/config.cpp
+++ b/addons/aiVehicleBail/config.cpp
@@ -14,4 +14,5 @@ class CfgPatches {
 };
 
 #include "CfgEventHandlers.hpp"
+#include "CfgVehicles.hpp"
 

--- a/addons/aiVehicleBail/functions/fnc_addEventHandler.sqf
+++ b/addons/aiVehicleBail/functions/fnc_addEventHandler.sqf
@@ -18,13 +18,12 @@ params["_vehicle"];
 
 _vehicle allowCrewInImmobile true;
 
-if !(GVAR(enableCrewBailing)) exitWith {};
-
 private _eh = _vehicle getVariable[QGVAR(handle_damage), nil];
 if (isNil "_eh") then {
     _vehicle setVariable [QGVAR(handle_damage), _vehicle addEventHandler["HandleDamage", {
-        params ["_vehicle", "", "_damage", "_injurer", "", "_hitIndex", "", "_hitPoint"];
-        [LINKFUNC(handleVehicleDamage), [_vehicle, _hitPoint, _hitIndex, _injurer]] call CBA_fnc_execNextFrame;
+        params ["_vehicle", "", "_damage", "_injurer", "_projectile", "_hitIndex", "", "_hitPoint"];
+        private _newDamage = _damage - (_vehicle getHitIndex _hitIndex);
+        [LINKFUNC(handleVehicleDamage), [_vehicle, _hitPoint, _hitIndex, _injurer, _vehicle getHitIndex _hitIndex, _newDamage, _projectile]] call CBA_fnc_execNextFrame;
         _damage
     }]];
 };

--- a/addons/aiVehicleBail/functions/fnc_detonate.sqf
+++ b/addons/aiVehicleBail/functions/fnc_detonate.sqf
@@ -1,0 +1,30 @@
+/*
+ * Author: Brandon (TCVM)
+ * Detonates vehicle ammo and kills all inside
+ *
+ * Arguments:
+ * 0: The vehicle
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [tank2] call potato_aiVehicleBail_fnc_detonate;
+ *
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+params ["_vehicle", ["_vehicleAmmo", []]];
+
+if (_vehicleAmmo isEqualTo []) then {
+    _vehicleAmmo = [_vehicle] call ACEFUNC(cookoff,getVehicleAmmo);
+};
+
+([_vehicle] + _vehicleAmmo) call ACEFUNC(cookoff,detonateAmmunition);
+
+if ((_vehicleAmmo select 1) > 0) then {
+    {
+        _x setDamage 1;
+    } forEach crew _vehicle;
+};

--- a/addons/aiVehicleBail/functions/fnc_detonate.sqf
+++ b/addons/aiVehicleBail/functions/fnc_detonate.sqf
@@ -17,6 +17,8 @@
 #include "script_component.hpp"
 params ["_vehicle", ["_vehicleAmmo", []]];
 
+if !(GVAR(enableCookoffDetonations)) exitWith {};
+
 if (_vehicleAmmo isEqualTo []) then {
     _vehicleAmmo = [_vehicle] call ACEFUNC(cookoff,getVehicleAmmo);
 };

--- a/addons/aiVehicleBail/functions/fnc_handleBail.sqf
+++ b/addons/aiVehicleBail/functions/fnc_handleBail.sqf
@@ -19,6 +19,8 @@
 #include "script_component.hpp"
 params["_vehicle", "_canMove", "_canShoot"];
 
+if !(GVAR(enableCrewBailing)) exitWith {};
+
 if (_canMove) then {
     _canMove = alive driver _vehicle;
 };
@@ -34,25 +36,25 @@ private _rand = random 1;
 
 if (!_canMove && !_canShoot) exitWith { // If you can't move and you can't shoot, you better GTFO
     [_vehicle] spawn FUNC(abandon);
-    diag_log text format["[POTATO] [%1] is a sitting duck and is bailing", _vehicle];
+    diag_log text format["[POTATO] [%1] is a sitting duck and is bailing [%2 | %3]", _vehicle, _canMove, _canShoot];
 };
 
 if (!_canShoot) exitWith {
     if (0.5 > _rand) then { // 50% chance of bailing out if turret/gun is destroyed
         [_vehicle] spawn FUNC(abandon);
-        diag_log text format["[POTATO] [%1] Cannot shoot and is bailing with chance [%2]", _vehicle, _rand];
+        diag_log text format["[POTATO] [%1] Cannot shoot and is bailing with chance [%2] [%3 | %4]", _vehicle, _rand, _canMove, _canShoot];
     } else {
         _vehicle allowFleeing 1;
-        diag_log text format["[POTATO] [%1] Cannot shoot and is fleeing with chance [%2]", _vehicle, _rand];
+        diag_log text format["[POTATO] [%1] Cannot shoot and is fleeing with chance [%2] [%3 | %4]", _vehicle, _rand, _canMove, _canShoot];
     };
 };
 
 if (!_canMove) exitWith {
     if (0.8 > _rand) then { // 80% Chance of bailing out if engine is destroyed
         [_vehicle] spawn FUNC(abandon);
-        diag_log text format["[POTATO] [%1] Cannot move and is bailing with chance [%2]", _vehicle, _rand];
+        diag_log text format["[POTATO] [%1] Cannot move and is bailing with chance [%2] [%3 | %4]", _vehicle, _rand, _canMove, _canShoot];
     } else {
-        diag_log text format["[POTATO] [%1] Cannot move and is bunkering with chance [%2]", _vehicle, _rand];
+        diag_log text format["[POTATO] [%1] Cannot move and is bunkering with chance [%2] [%3 | %4]", _vehicle, _rand, _canMove, _canShoot];
     };
 };
 

--- a/addons/aiVehicleBail/functions/fnc_handleCookoff.sqf
+++ b/addons/aiVehicleBail/functions/fnc_handleCookoff.sqf
@@ -73,7 +73,7 @@ private _alreadyDetonating = _vehicle getVariable [QGVAR(detonating), false];
 private _alreadyCookingOff = _vehicle getVariable [QGVAR(cookingOff), false];
 
 if (!_alreadyDetonating && { _chanceOfDetonate > random 1 }) exitWith {
-    [_vehicle, _currentAmmoCount] call FUNC(detonate);
+    [_vehicle, _currentVehicleAmmo] call FUNC(detonate);
     diag_log text format["[POTATO] (cookoff) Detonating [%1] with a chance-to-detonate [%2] hit [%3]", _vehicle, _chanceOfDetonate, _hitPoint];
     _vehicle setVariable [QGVAR(detonating), true];
 };
@@ -81,7 +81,7 @@ if (!_alreadyDetonating && { _chanceOfDetonate > random 1 }) exitWith {
 if (!_alreadyCookingOff && { _chanceOfFire > random 1 }) exitWith {
     [_vehicle] call ACEFUNC(cookoff,cookOff);
     if (!_alreadyDetonating && { [_vehicleConfig >> QGVAR(detonationDuringFireProb), "number", 0] call CBA_fnc_getConfigEntry > random 1 }) then {
-        [_vehicle, _currentAmmoCount] call FUNC(detonate);
+        [_vehicle, _currentVehicleAmmo] call FUNC(detonate);
         diag_log text format["[POTATO] (cookoff) Detonating [%1] while cooking off with a chance of [%2] hit [%3]", _vehicle, [_vehicleConfig >> QGVAR(detonationDuringFireProb), "number", 0] call CBA_fnc_getConfigEntry, _hitPoint];
         _vehicle setVariable [QGVAR(detonating), true];
     };

--- a/addons/aiVehicleBail/functions/fnc_handleCookoff.sqf
+++ b/addons/aiVehicleBail/functions/fnc_handleCookoff.sqf
@@ -1,0 +1,95 @@
+/*
+ * Author: Brandon (TCVM)
+ * Checks hitpoint damage and determines if a vehicle should cookoff
+ *
+ * Arguments:
+ * 0: The vehicle
+ * 1: Hitindex that got hit
+ * 2: Vehicle damage before hit
+ * 3: Damage applied
+ * 4: Projectile
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [tank2] call potato_aiVehicleBail_fnc_handleCookoff;
+ *
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+params ["_vehicle", "_hitIndex", "_oldDamage", "_newDamage", "_projectile"];
+
+if !(GVAR(enableCookoff)) exitWith {};
+
+private _hitPoint = toLower ((getAllHitPointsDamage _vehicle param [0, []]) select _hitIndex);
+
+private _possibleCookoff = (_hitPoint isEqualTo "hitturret") || { _hitPoint isEqualTo "hithull" } || { _hitPoint isEqualTo "hitengine" };
+if !(_possibleCookoff) exitWith {};
+private _currentVehicleAmmo = [_vehicle] call ACEFUNC(cookoff,getVehicleAmmo);
+
+private _chanceOfDetonation = 0;
+private _countOfExplodableAmmo = 0;
+if (count (_currentVehicleAmmo select 0) > 0) then {
+    private _magConfig = configFile >> "CfgMagazines";
+    {
+        _x params ["_ammoClassname", "_currentAmmoCount"];
+        private _initialAmmoCount = getNumber(_magConfig >> _ammoClassname >> "count");
+        _chanceOfDetonation = _chanceOfDetonation + (_currentAmmoCount / _initialAmmoCount);
+        _countOfExplodableAmmo = _countOfExplodableAmmo + 1;
+    } forEach (_currentVehicleAmmo select 0);
+    _chanceOfDetonation = _chanceOfDetonation / _countOfExplodableAmmo;
+};
+private _currentFuel = fuel _vehicle;
+
+private _warheadType = getText (_projectile call CBA_fnc_getObjectConfig >> "warheadName");
+private _incendiary = 1;
+private _explosiveType = ["HE", "AP", "HEAT", "TandemHEAT"] find _warheadType;
+if (_explosiveType >= 0) then {
+    _incendiary = [0.3, 1, 1, 1] select _explosiveType;
+};
+private _chanceOfDetonate = 0;
+private _chanceOfFire = 0;
+
+private _vehicleConfig = _vehicle call CBA_fnc_getObjectConfig;
+
+switch (_hitPoint) do {
+    case "hitturret": {
+        _chanceOfDetonate = ([_vehicleConfig >> QGVAR(turretDetonationProb), "number", 0] call CBA_fnc_getConfigEntry) * _incendiary * _chanceOfDetonation;
+        _chanceOfFire = ([_vehicleConfig >> QGVAR(turretFireProb), "number", 0] call CBA_fnc_getConfigEntry) * _incendiary * _chanceOfDetonation;
+    };
+    case "hithull": {
+        _chanceOfDetonate = ([_vehicleConfig >> QGVAR(hullDetonationProb), "number", 0] call CBA_fnc_getConfigEntry) * _incendiary * ((_chanceOfDetonation + _currentFuel) / 2);
+        _chanceOfFire = ([_vehicleConfig >> QGVAR(hullFireProb), "number", 0] call CBA_fnc_getConfigEntry) * _incendiary * ((_chanceOfDetonation + _currentFuel) / 2);
+    };
+    case "hitengine": {
+        _chanceOfDetonate = ([_vehicleConfig >> QGVAR(engineDetonationProb), "number", 0] call CBA_fnc_getConfigEntry) * _incendiary * _currentFuel;
+        _chanceOfFire = ([_vehicleConfig >> QGVAR(engineFireProb), "number", 0] call CBA_fnc_getConfigEntry) * _incendiary * _currentFuel;
+    };
+};
+
+private _alreadyDetonating = _vehicle getVariable [QGVAR(detonating), false];
+private _alreadyCookingOff = _vehicle getVariable [QGVAR(cookingOff), false];
+
+if (!_alreadyDetonating && { _chanceOfDetonate > random 1 }) exitWith {
+    [_vehicle, _currentAmmoCount] call FUNC(detonate);
+    diag_log text format["[POTATO] (cookoff) Detonating [%1] with a chance-to-detonate [%2] hit [%3]", _vehicle, _chanceOfDetonate, _hitPoint];
+    _vehicle setVariable [QGVAR(detonating), true];
+};
+
+if (!_alreadyCookingOff && { _chanceOfFire > random 1 }) exitWith {
+    [_vehicle] call ACEFUNC(cookoff,cookOff);
+    if (!_alreadyDetonating && { [_vehicleConfig >> QGVAR(detonationDuringFireProb), "number", 0] call CBA_fnc_getConfigEntry > random 1 }) then {
+        [_vehicle, _currentAmmoCount] call FUNC(detonate);
+        diag_log text format["[POTATO] (cookoff) Detonating [%1] while cooking off with a chance of [%2] hit [%3]", _vehicle, [_vehicleConfig >> QGVAR(detonationDuringFireProb), "number", 0] call CBA_fnc_getConfigEntry, _hitPoint];
+        _vehicle setVariable [QGVAR(detonating), true];
+    };
+    _vehicle setVariable [QGVAR(cookingOff), true];
+    diag_log text format["[POTATO] (cookoff) Cooking-off [%1] with a chance-of-fire [%2] hit [%3]", _vehicle, _chanceOfFire, _hitPoint];
+};
+
+// Avoid RPT spam
+if (_alreadyDetonating || _alreadyCookingOff) exitWith { };
+
+diag_log text format["[POTATO] (cookoff) [%1] No Cook-off, no detonations (Chance of fire [%2] Chance of detonation [%3] Incendiary [%4] Warhead Type [%5])", _vehicle, _chanceOfFire, _chanceOfDetonate, _incendiary, _warheadType];

--- a/addons/aiVehicleBail/functions/fnc_handleCookoff.sqf
+++ b/addons/aiVehicleBail/functions/fnc_handleCookoff.sqf
@@ -47,7 +47,7 @@ private _warheadType = getText (_projectile call CBA_fnc_getObjectConfig >> "war
 private _incendiary = 1;
 private _explosiveType = ["HE", "AP", "HEAT", "TandemHEAT"] find _warheadType;
 if (_explosiveType >= 0) then {
-    _incendiary = [0.3, 1, 1, 1] select _explosiveType;
+    _incendiary = [0.3, 0.85, 1, 1] select _explosiveType;
 };
 private _chanceOfDetonate = 0;
 private _chanceOfFire = 0;

--- a/addons/aiVehicleBail/functions/fnc_handleCookoff.sqf
+++ b/addons/aiVehicleBail/functions/fnc_handleCookoff.sqf
@@ -87,6 +87,8 @@ if (!_alreadyCookingOff && { _chanceOfFire > random 1 }) exitWith {
     };
     _vehicle setVariable [QGVAR(cookingOff), true];
     diag_log text format["[POTATO] (cookoff) Cooking-off [%1] with a chance-of-fire [%2] hit [%3]", _vehicle, _chanceOfFire, _hitPoint];
+    [_vehicle] spawn FUNC(abandon);
+    diag_log text format["[POTATO] [%1] is on fire is bailing", _vehicle];
 };
 
 // Avoid RPT spam

--- a/addons/aiVehicleBail/functions/fnc_handleVehicleDamage.sqf
+++ b/addons/aiVehicleBail/functions/fnc_handleVehicleDamage.sqf
@@ -79,6 +79,11 @@ if (_ignoreHit) exitWith {
 
 if !(_ignoreBailCheck) then {
     [_vehicle, _canMove, _canShoot] call FUNC(handleBail);
+    if !(GVAR(enableCookoffMultihit)) then {
+        [_vehicle, _hitIndex, _oldDamage, _newDamage, _projectile] call FUNC(handleCookoff);
+    };
 };
-[_vehicle, _hitIndex, _oldDamage, _newDamage, _projectile] call FUNC(handleCookoff);
+if (GVAR(enableCookoffMultihit)) then {
+        [_vehicle, _hitIndex, _oldDamage, _newDamage, _projectile] call FUNC(handleCookoff);
+    };
 

--- a/addons/aiVehicleBail/functions/fnc_handleVehicleDamage.sqf
+++ b/addons/aiVehicleBail/functions/fnc_handleVehicleDamage.sqf
@@ -6,6 +6,7 @@
  * 0: The vehicle
  * 1: The selection which got hit
  * 2: The index of what got hit
+ * 3: The damage that the new part took
  *
  * Return Value:
  * None
@@ -18,7 +19,7 @@
  */
 #include "script_component.hpp"
 
-params["_vehicle", "_hitPoint", "_hitIndex", "_injurer"];
+params["_vehicle", "_hitPoint", "_hitIndex", "_injurer", "_oldDamage", "_newDamage", "_projectile"];
 TRACE_4("handleVehicleDamage",_vehicle,_hitPoint,_hitIndex,_injurer);
 
 if !(alive _vehicle) exitWith {
@@ -51,19 +52,33 @@ switch (true) do {
 
 // Ignore multiple hits at the same time
 private _ignoreHit = false;
+private _ignoreBailCheck = false;
 private _multHit = _vehicle getVariable [QGVAR(hit_time), nil];
 if (isNil "_multHit") then {
-    _vehicle setVariable[QGVAR(hit_time), [time, _injurer]];
+    _vehicle setVariable[QGVAR(hit_time), [time, _injurer, [_hitPoint]]];
 } else {
-    if (time <= (_multHit select 0) + CONST_TIME && {_injurer == (_multHit select 1)}) then {
+    private _hitPointInOldArray = _hitPoint in (_multHit select 2);
+    private _withinTime = time <= (_multHit select 0) + CONST_TIME && { _injurer == (_multHit select 1) };
+    if (_hitPointInOldArray && _withinTime) then {
         _ignoreHit = true;
     } else {
-        _vehicle setVariable[QGVAR(hit_time), [time, _injurer]];
+        // If the hitpoint isnt in the old array then that means that the time expired and a new array should be generated
+        if !(_hitPointInOldArray) then {
+            private _oldHitPoints = _multHit select 2;
+            _oldHitPoints pushBack _hitPoint;
+            _vehicle setVariable[QGVAR(hit_time), [time, _injurer, _oldHitPoints]];
+            _ignoreBailCheck = true;
+        } else {
+            _vehicle setVariable[QGVAR(hit_time), [time, _injurer, [_hitPoint]]];
+        };
     };
 };
 if (_ignoreHit) exitWith {
-    diag_log text format["[POTATO] Ignoring multiple hits done to vehicle [%1] by [%2]", _vehicle, _injurer];
+    diag_log text format["[POTATO] Ignoring multiple hits done to vehicle [%1] by [%2].", _vehicle, _injurer];
 };
 
-[_vehicle, _canMove, _canShoot] call FUNC(handleBail);
+if !(_ignoreBailCheck) then {
+    [_vehicle, _canMove, _canShoot] call FUNC(handleBail);
+};
+[_vehicle, _hitIndex, _oldDamage, _newDamage, _projectile] call FUNC(handleCookoff);
 

--- a/addons/aiVehicleBail/initSettings.sqf
+++ b/addons/aiVehicleBail/initSettings.sqf
@@ -18,4 +18,13 @@
     true, // isGlobal
     {[QGVAR(enableCookoff), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
 ] call CBA_settings_fnc_init;
+[
+    QGVAR(enableCookoffMultihit),
+    "CHECKBOX",
+    ["Enable Multi-Hit Cookoff Check", "Enable/Disable whether or not multiple hits can be checked in the same frame"],
+    "POTATO AI Behaviours",
+    false, // default value
+    true, // isGlobal
+    {[QGVAR(enableCookoffMultihit), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
 

--- a/addons/aiVehicleBail/initSettings.sqf
+++ b/addons/aiVehicleBail/initSettings.sqf
@@ -19,6 +19,15 @@
     {[QGVAR(enableCookoff), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
 ] call CBA_settings_fnc_init;
 [
+    QGVAR(enableCookoffDetonations),
+    "CHECKBOX",
+    ["Enable Ammo Detonation", "Enable/Disable Whether or not vehicles will detonate their ammo when hit"],
+    "POTATO AI Behaviours",
+    true, // default value
+    true, // isGlobal
+    {[QGVAR(enableCookoffDetonations), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+[
     QGVAR(enableCookoffMultihit),
     "CHECKBOX",
     ["Enable Multi-Hit Cookoff Check", "Enable/Disable whether or not multiple hits can be checked in the same frame"],

--- a/addons/aiVehicleBail/initSettings.sqf
+++ b/addons/aiVehicleBail/initSettings.sqf
@@ -9,4 +9,13 @@
     true, // isGlobal
     {[QGVAR(enableCrewBailing), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
 ] call CBA_settings_fnc_init;
+[
+    QGVAR(enableCookoff),
+    "CHECKBOX",
+    ["Enable Cook-off", "Enable/Disable Vehicles cooking off when they take appropiate amounts of damage"],
+    "POTATO AI Behaviours",
+    true, // default value
+    true, // isGlobal
+    {[QGVAR(enableCookoff), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
 

--- a/addons/aiVehicleBail/script_component.hpp
+++ b/addons/aiVehicleBail/script_component.hpp
@@ -2,7 +2,7 @@
 #include "\z\potato\addons\core\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+ #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_AI_VEHICLE_BAIL

--- a/addons/aiVehicleBail/script_macros.hpp
+++ b/addons/aiVehicleBail/script_macros.hpp
@@ -1,7 +1,7 @@
 #define CONST_TIME 0.03
+#define IS_EXPLOSIVE_AMMO(ammo) (getNumber (ammo call CBA_fnc_getObjectConfig >> "explosive") > 0.5)
 #define ENGINE_HITPOINTS [["hitengine"], "engine"]
 #define HULL_HITPOINTS [["hithull"], "hull"]
 #define TURRET_HITPOINTS [["hitgun", "hitturret"], "turret"]
 #define TRACK_HITPOINTS [["hitltrack", "hitrtrack"], "track"]
 #define WHEEL_HITPOINTS [["hitlbwheel", "hitlmwheel", "hitlfwheel", "hitlf2wheel", "hitrbwheel", "hitrlwheel", "hitrfwheel", "hitrf2wheel"], "wheel"]
-


### PR DESCRIPTION
Adds cookoff to vehicles when they receive damage to certain spots. Because this doesn't modify the damage vehicles will not be forced to cook off in order to die.

Features:
  -Cook-off fire that destroys the vehicle after 15 seconds (occupants can bail out)
  -Cook-off detonations that leaves the vehicle "alive" (occupants dies instantly)
  -Both things can happen during the same cook-off sequence

The system works by rolling a dice every time certain spots are damaged, and if the check is high enough the vehicle will cook off. The dice roll is influenced by the ammo that hit it (sort of), how much ammo and how much fuel is in the vehicle depending on where it gets hit. Unfortunately this means that each vehicle has to be configured for this, but it won't break anything if it isn't.

Why do we need this? Because cooking off vehicles makes them more vulnerable to infantry and it looks pretty rad.

https://youtu.be/5RmyHer-cp4