### PR TITLE
Battle Belt XL

### DIFF
--- a/addons/miscFixes/CfgVehicles.hpp
+++ b/addons/miscFixes/CfgVehicles.hpp
@@ -14,6 +14,12 @@ class CfgVehicles {
         mapSize = 0.47;
         scope = 2;
     };
+    class B_Battle_Belt_XL_F: B_Battle_Belt_F {
+        displayName = "Battle Belt XL";
+        author = "Alablm";
+        maximumLoad = 320;
+        mass = 60;
+    };
 
     // Add SMAW box
     class Box_NATO_Support_F;


### PR DESCRIPTION
Duplicates the Carryall backpack in the style of a Battle Belt. Mainly to be used for heavy weapons teams to get rid of the weapon/mount clipping.