### PR TITLE
Create zeusHC modules from pre-placed vehicles

### DIFF
--- a/addons/aiCfgFixes/config.cpp
+++ b/addons/aiCfgFixes/config.cpp
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-#ifndef POTATO_LEAN_CONFIGS
+#ifndef POTATO_LEAN_RHS_CUP_HLC
 
 class CfgPatches {
     class ADDON {

--- a/addons/aiVehicleBail/config.cpp
+++ b/addons/aiVehicleBail/config.cpp
@@ -1,5 +1,7 @@
 #include "script_component.hpp"
 
+#ifndef POTATO_LEAN_RHS_CUP_HLC
+
 class CfgPatches {
     class ADDON {
         units[] = {};
@@ -16,3 +18,4 @@ class CfgPatches {
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicles.hpp"
 
+#endif

--- a/addons/core/script_macros.hpp
+++ b/addons/core/script_macros.hpp
@@ -1,5 +1,6 @@
 //Add all ACE and CBA macros:
 #include "\z\ace\addons\main\script_macros.hpp"
+#include "script_macros_debug.hpp"
 
 #define ACE_PREFIX ace
 
@@ -25,6 +26,3 @@
 #define FADE_LENGTH 0.25
 #define FADE_ENABLED 0
 #define FADE_DISABLED 0.7
-
-// Dev Ony: Enabling this will skip configs from any potato addons that require external mods
-// #define POTATO_LEAN_CONFIGS

--- a/addons/core/script_macros_debug.hpp
+++ b/addons/core/script_macros_debug.hpp
@@ -1,0 +1,5 @@
+// Dev Ony: Enabling these will skip configs from any potato addons that require external mods
+// Allows loading just cba/ace/potato
+
+// #define POTATO_LEAN_RHS_CUP_HLC
+// #define POTATO_LEAN_ACRE

--- a/addons/cswCompat/config.cpp
+++ b/addons/cswCompat/config.cpp
@@ -1,5 +1,7 @@
 #include "script_component.hpp"
 
+#ifndef POTATO_LEAN_RHS_CUP_HLC
+
 class CfgPatches {
     class ADDON {
         units[] = {};
@@ -17,3 +19,4 @@ class CfgPatches {
 #include "CfgMagazines.hpp"
 #include "CfgMagazineGroups.hpp"
 
+#endif

--- a/addons/cswCompat/script_component.hpp
+++ b/addons/cswCompat/script_component.hpp
@@ -7,7 +7,8 @@
 
 #include "\z\ace\addons\main\script_macros.hpp"
 
+// because this is a "ace" addon we have to include this manually
+#include "\z\potato\addons\core\script_macros_debug.hpp"
 
 #define ACE_CSW_PATH(XX) QUOTE(\z\ace\addons\csw\XX)
 #define ACE_APL_PATH(XX) QUOTE(\z\ace\addons\apl\XX)
-

--- a/addons/filledSmoke/config.cpp
+++ b/addons/filledSmoke/config.cpp
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-#ifndef POTATO_LEAN_CONFIGS
+#ifndef POTATO_LEAN_RHS_CUP_HLC
 
 class CfgPatches {
     class ADDON {

--- a/addons/flares/config.cpp
+++ b/addons/flares/config.cpp
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-#ifndef POTATO_LEAN_CONFIGS
+#ifndef POTATO_LEAN_RHS_CUP_HLC
 
 class CfgPatches {
     class ADDON {

--- a/addons/hitEffects/config.cpp
+++ b/addons/hitEffects/config.cpp
@@ -1,7 +1,5 @@
 #include "script_component.hpp"
 
-#ifndef POTATO_LEAN_CONFIGS
-
 class CfgPatches {
     class ADDON {
         units[] = {};
@@ -17,5 +15,3 @@ class CfgPatches {
 #include "CfgCloudlets.hpp"
 #include "impactEffects.hpp"
 #include "CfgAmmo.hpp"
-
-#endif

--- a/addons/massCompat/config.cpp
+++ b/addons/massCompat/config.cpp
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-#ifndef POTATO_LEAN_CONFIGS
+#ifndef POTATO_LEAN_RHS_CUP_HLC
 
 class CfgPatches {
     class ADDON {

--- a/addons/miscFixes/config.cpp
+++ b/addons/miscFixes/config.cpp
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-#ifndef POTATO_LEAN_CONFIGS
+#ifndef POTATO_LEAN_RHS_CUP_HLC
 
 class CfgPatches {
     class ADDON {

--- a/addons/miscMedical/XEH_postInit.sqf
+++ b/addons/miscMedical/XEH_postInit.sqf
@@ -9,7 +9,7 @@ if (isServer) then {
         INFO_2("SLOG - %1: %2",_type,_msg);
     }] call CBA_fnc_addEventHandler;
 
-    #include "serverOnlyFix.sqf";
+    #include "serverOnlyFix.sqf"
 
     // Determine if TVT or COOP
     [{

--- a/addons/radios/config.cpp
+++ b/addons/radios/config.cpp
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-#ifndef POTATO_LEAN_CONFIGS
+#ifndef POTATO_LEAN_ACRE
 
 class CfgPatches {
     class ADDON {

--- a/addons/spectate/XEH_postClientInit.sqf
+++ b/addons/spectate/XEH_postClientInit.sqf
@@ -2,11 +2,7 @@
 
 if (GVAR(enabled) && hasInterface) then {
     // setup babel
-    GVAR(availableLanguages) = [];
-    {
-        GVAR(availableLanguages) pushBack (_x select 0);
-    } forEach EGVAR(radios,availableLanguages);
-
+    GVAR(availableLanguages) = (missionNamespace getVariable [QEGVAR(radios,availableLanguages), []]) apply {_x select 0};
     GVAR(classEHInstalled) = false;
 
     GVAR(boundingBoxCache) = call CBA_fnc_createNamespace;

--- a/addons/spectate/config.cpp
+++ b/addons/spectate/config.cpp
@@ -1,13 +1,11 @@
 #include "script_component.hpp"
 
-#ifndef POTATO_LEAN_CONFIGS
-
 class CfgPatches {
     class ADDON {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"potato_radios"};
+        requiredAddons[] = {"potato_core"};
         author = "Potato";
         authors[] = {"AACO"};
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
@@ -20,5 +18,3 @@ class CfgPatches {
 #include "CfgVehicleIcons.hpp"
 #include "CfgVehicles.hpp"
 #include "Displays.hpp"
-
-#endif

--- a/addons/spectate/functions/fnc_setup.sqf
+++ b/addons/spectate/functions/fnc_setup.sqf
@@ -49,7 +49,7 @@ HELP ctrlShow false;
 // create spectator unit
 private _tempGroup = createGroup [sideLogic, true]; // explicitly mark for cleanup (even though we delete below)
 GVAR(unit) = _tempGroup createUnit [QGVAR(spectator), ZERO_POS, [], 100, "NONE"];
-GVAR(unit) setVariable [QEGVAR(radios,assignedLanguages), GVAR(availableLanguages)];
+GVAR(unit) setVariable [(missionNamespace getVariable [QEGVAR(radios,assignedLanguages), []]), GVAR(availableLanguages)];
 selectPlayer GVAR(unit);
 
 if (isNil QGVAR(group) || {isNull GVAR(group)}) then {

--- a/addons/units/CfgVehicles.hpp
+++ b/addons/units/CfgVehicles.hpp
@@ -2,7 +2,7 @@ class CfgVehicles {
     #include "subClasses\unitDef.hpp"
     // add POTATO East
     #define FACTION_MACRO(unit) MSV(unit)
-    FACTION_DEF(SoldierEB,e);
+    FACTION_DEF(SoldierEB,e)
 
     // add POTATO MSV (Backwards Compat)
     #include "subClasses\bwc_msv.hpp"
@@ -10,11 +10,11 @@ class CfgVehicles {
     // add POTATO West
     #undef FACTION_MACRO
     #define FACTION_MACRO(unit) USMC(unit)
-    FACTION_DEF(SoldierWB,w);
+    FACTION_DEF(SoldierWB,w)
 
     // add POTATO Indy
     #undef FACTION_MACRO
     #define FACTION_MACRO(unit) AIR(unit)
-    FACTION_DEF(SoldierGB,i);
+    FACTION_DEF(SoldierGB,i)
 
 };

--- a/addons/zeusFactory/functions/fnc_addVehiclesToArray.sqf
+++ b/addons/zeusFactory/functions/fnc_addVehiclesToArray.sqf
@@ -1,9 +1,10 @@
+#include "script_component.hpp"
 /*
  * Author: AACO
  * Moves and validates a config array of vic classnames to a provided variable array of vic classnames
  *
  * Arguments:
- * 0: Array to store the vic classnames in <ARRAY>
+ * 0: Array to store the vic classnames in (modified by reference) <ARRAY>
  * 1: Config array to lookup <STRING>
  *
  * Return Value:
@@ -14,10 +15,8 @@
  * [GVAR(apcArray), "apcs"] call potato_zeusFactory_fnc_addVehiclesToArray;
  */
 
-#include "script_component.hpp"
-TRACE_1("params",_this);
-
 params ["_storageArray", "_lookup"];
+TRACE_2("addVehiclesToArray",_storageArray,_lookup);
 
 private _arrayToParse = if (isClass (missionConfigFile >> "CfgZeusFactory") && {isArray (missionConfigFile >> "CfgZeusFactory" >> _lookup)}) then {
     getArray (missionConfigFile >> "CfgZeusFactory" >> _lookup)
@@ -32,5 +31,23 @@ private _arrayToParse = if (isClass (missionConfigFile >> "CfgZeusFactory") && {
         WARNING_1("Vehicle Classname [%1] does not exist in modset",_x);
     };
 } forEach _arrayToParse;
+TRACE_1("",count _storageArray);
 
-TRACE_1("_storageArray", _storageArray);
+// Add vehicles from autoModule in zeusHC
+// Lots of refinement could be done here (side-specific, check crew size)
+private _zeusAutoVics = missionNamespace getVariable [QEGVAR(zeusHC,vehicleList), []];
+{
+    _x params ["_type"];
+    if ((_storageArray findIf {_x == _type}) == -1) then { // avoid duplicates (case-insensitive)
+        if (_type isKindOf "Plane") exitWith {};
+        if (_type isKindOf "Ship") exitWith {};
+        if (_type isKindOf "Helicopter") exitWith { // note: pularality (helicopters/Helicopter)s
+            if (_lookup == "helicopters") then { _storageArray pushBack _type; };
+        };
+        if ((_type isKindOf "Wheeled_APC") || {_type IsKindOf "Wheeled_APC_F"} || {_type IsKindOf "Tank"}) exitWith { 
+            if (_lookup == "apcs") then { _storageArray pushBack _type; };
+        };
+        if (_lookup == "cars") then { _storageArray pushBack _type; };
+    };
+} forEach _zeusAutoVics;
+TRACE_1("",count _storageArray);

--- a/addons/zeusHC/CfgEventHandlers.hpp
+++ b/addons/zeusHC/CfgEventHandlers.hpp
@@ -12,6 +12,6 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        serverInit = QUOTE(call COMPILE_FILE(XEH_postServerInit));
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };

--- a/addons/zeusHC/CfgVehicles.hpp
+++ b/addons/zeusHC/CfgVehicles.hpp
@@ -48,22 +48,27 @@ class CfgVehicles {
     };
     class GVAR(east_manpadTeam): GVAR(east_rifleman) {
         displayName = "#MANPAD Team (2)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_e_msamg","potato_e_msamag"};
     };
     class GVAR(east_matTeam): GVAR(east_rifleman) {
         displayName = "#MAT Team (2)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_e_matg","potato_e_matag"};
     };
     class GVAR(east_patrol): GVAR(east_rifleman) {
         displayName = "#Patrol (2)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_e_rifleman","potato_e_rifleman"};
     };
     class GVAR(east_fireteam): GVAR(east_rifleman) {
         displayName = "#Fireteam (4)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_e_ftl","potato_e_AR","potato_e_rifleman","potato_e_LAT"};
     };
     class GVAR(east_squad): GVAR(east_rifleman) {
         displayName = "#Squad (8)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_e_sl","potato_e_ftl","potato_e_ar","potato_e_ar","potato_e_lat","potato_e_rifleman","potato_e_rifleman","potato_e_rifleman"};
     };
     class GVAR(east_aaModern): GVAR(east_rifleman) {
@@ -310,22 +315,27 @@ class CfgVehicles {
     };
     class GVAR(west_manpadTeam): GVAR(west_rifleman) {
         displayName = "#MANPAD Team (2)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_w_msamg","potato_w_msamag"};
     };
     class GVAR(west_matTeam): GVAR(west_rifleman) {
         displayName = "#MAT Team (2)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_w_matg","potato_w_matag"};
     };
     class GVAR(west_patrol): GVAR(west_rifleman) {
         displayName = "#Patrol (2)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_w_rifleman","potato_w_rifleman"};
     };
     class GVAR(west_fireteam): GVAR(west_rifleman) {
         displayName = "#Fireteam (4)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_w_ftl","potato_w_ar","potato_w_rifleman","potato_w_lat"};
     };
     class GVAR(west_squad): GVAR(west_rifleman) {
         displayName = "#Squad (8)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_w_sl","potato_w_ftl","potato_w_ar","potato_w_ar","potato_w_lat","potato_w_rifleman","potato_w_rifleman","potato_w_rifleman"};
     };
     class GVAR(west_cupAvenger): GVAR(west_rifleman) {
@@ -700,22 +710,27 @@ class CfgVehicles {
     };
     class GVAR(ind_manpadTeam): GVAR(ind_rifleman) {
         displayName = "#MANPAD Team (2)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_i_msamg","potato_i_msamag"};
     };
     class GVAR(ind_matTeam): GVAR(ind_rifleman) {
         displayName = "#MAT Team (2)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_i_matg","potato_i_matag"};
     };
     class GVAR(ind_patrol): GVAR(ind_rifleman) {
         displayName = "#Patrol (2)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_i_rifleman","potato_i_rifleman"};
     };
     class GVAR(ind_fireteam): GVAR(ind_rifleman) {
         displayName = "#Fireteam (4)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_i_ftl","potato_i_ar","potato_i_rifleman","potato_i_lat"};
     };
     class GVAR(ind_squad): GVAR(ind_rifleman) {
         displayName = "#Squad (8)";
+        icon = "\a3\Ui_F_Curator\Data\Displays\RscDisplayCurator\modeGroups_ca.paa";
         GVAR(createUnits)[] = {"potato_i_sl","potato_i_ftl","potato_i_ar","potato_i_ar","potato_i_lat","potato_i_rifleman","potato_i_rifleman","potato_i_rifleman"};
     };
     class GVAR(ind_gazZu): GVAR(ind_rifleman) {

--- a/addons/zeusHC/XEH_PREP.hpp
+++ b/addons/zeusHC/XEH_PREP.hpp
@@ -1,5 +1,9 @@
 TRACE_1("",QUOTE(ADDON));
 
+PREP(autoModule_createLocal);
+PREP(autoModule_module);
+PREP(autoModule_setup);
+
 PREP(createEntityZeus);
 PREP(createEntityLocal);
 PREP(createEntityDismounts);

--- a/addons/zeusHC/XEH_postInit.sqf
+++ b/addons/zeusHC/XEH_postInit.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+if (isServer) then {
+    [false] spawn COMPILE_FILE(functions\fnc_transferGroupsToHC);
+};
+
+if (hasInterface) then {
+    ["Misc", "Z Dummy Loadorder fix until next ZEN vers", {systemChat "k";}] call zen_custom_modules_fnc_register;
+    ["zen_curatorDisplayLoaded", LINKFUNC(autoModule_setup)] call CBA_fnc_addEventHandler;
+    // ["zen_editor_treesLoaded", { diag_log text "zen_editor_treesLoaded"; }] call CBA_fnc_addEventHandler; // next vers
+};

--- a/addons/zeusHC/XEH_postServerInit.sqf
+++ b/addons/zeusHC/XEH_postServerInit.sqf
@@ -1,3 +1,0 @@
-#include "script_component.hpp"
-
-[false] spawn COMPILE_FILE(functions\fnc_transferGroupsToHC);

--- a/addons/zeusHC/functions/fnc_autoModule_createLocal.sqf
+++ b/addons/zeusHC/functions/fnc_autoModule_createLocal.sqf
@@ -1,0 +1,43 @@
+#include "script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Creates the custom module's vehicle on the HC
+ *
+ * Examples:
+ * [[0,0,0], "somevic", west] call potato_zeusHC_fnc_autoModule_createLocal
+ */
+
+params ["_posATL", "_vehType", "_side"];
+TRACE_3("autoModule_createLocal",_posATL,_vehType,_side);
+
+private _posATL = aslToAtl _posASL;
+private _sideUnitConfig = switch (_side) do {
+    case west: { configFile >> "CfgVehicles" >> QGVAR(west_rifleman) };
+    case east: { configFile >> "CfgVehicles" >> QGVAR(east_rifleman) };
+    case resistance: { configFile >> "CfgVehicles" >> QGVAR(ind_rifleman) };
+    default {configNull};
+};
+
+private _createArg = "NONE";
+private _crewType = "";
+switch (true) do {
+    case (_vehType isKindOf "Air"): {
+        _createArg = "FLY"; 
+        _crewType = getText (_sideUnitConfig >> QGVAR(crewAir));
+    };
+    case (_vehType isKindOf "Wheeled_APC");
+    case (_vehType isKindOf "Wheeled_APC_F");
+    case (_vehType isKindOf "Tank"): {
+        _crewType = getText (_sideUnitConfig >> QGVAR(crewArmor));
+        };
+    default {
+        _crewType = (getArray (_sideUnitConfig >> QGVAR(createUnits))) param [0, "#"];
+    }
+};
+
+private _newVehicle = createVehicle [_vehType, _posATL, [], 0, _createArg];
+TRACE_3("Created Vic",_newVehicle,_vehType,_crewType);
+_newVehicle setVariable ["F_Gear", "Empty", true]; // Clear gear on these [BWMF]
+[_newVehicle] call EFUNC(core,addToCurator);
+
+[_side, _newVehicle, _crewType, true] spawn FUNC(createCrew);

--- a/addons/zeusHC/functions/fnc_autoModule_module.sqf
+++ b/addons/zeusHC/functions/fnc_autoModule_module.sqf
@@ -1,0 +1,13 @@
+#include "script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Called where module is local (zeus), passes vehicle type and side to HC
+ *
+ * Examples:
+ * [[0,0,0], "somevic", west] call potato_zeusHC_fnc_autoModule_module
+ */
+
+params ["_posASL", "_vehType", "_side"];
+TRACE_3("autoModule_module",_posASL,_vehType,_side);
+
+[[_posASL, _vehType, _side], QFUNC(autoModule_createLocal)] call FUNC(hcPassthrough);

--- a/addons/zeusHC/functions/fnc_autoModule_setup.sqf
+++ b/addons/zeusHC/functions/fnc_autoModule_setup.sqf
@@ -1,0 +1,54 @@
+#include "script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Called when opening zeus interface ("zen_curatorDisplayLoaded" Event)
+ * Adds existing vehicles to the placeable modules list
+ *
+ * Examples:
+ * [] call potato_zeusHC_fnc_autoModule_setup
+ */
+
+TRACE_1("autoModule_setup",_this);
+if (isNil "zen_custom_modules_fnc_register") exitWith { ERROR("zen_custom_modules_fnc_register undefined"); };
+if (isNil QGVAR(vehicleList)) then { GVAR(vehicleList) = []; };
+
+{
+    if ((count GVAR(vehicleList)) > 50) exitWith {};
+    private _veh = _x;
+    if ((alive _veh) && {(["Car", "Tank", "Air", "Ship"] findIf {_veh isKindOf _x}) != -1}) then {
+        if ((getNumber (configOf _veh >> "scope")) != 2) exitWith {};
+        private _type = typeOf _veh;
+
+        // Determine side by crew or nearest mans
+        private _nearMan = (crew _veh) param [0, objNull];
+        if (!alive _nearMan) then { _nearMan = nearestObject [_veh, "CaManBase"]; };
+        private _side = side group _nearMan;
+
+        private _index = GVAR(vehicleList) pushBackUnique [_type, _side];
+        if (_index == -1) exitWith {}; // ignore duplicates
+
+        private _category = "";
+        switch (_side) do {
+            case west: { 
+                _side = "west";
+                _category = getText (configFile >> "CfgFactionClasses" >> QGVAR(west) >> "displayName");
+            };
+            case east: { 
+                _side = "east";
+                _category =getText (configFile >> "CfgFactionClasses" >> QGVAR(east) >> "displayName"); 
+            };
+            case resistance: {
+                _side = "resistance";
+                _category = getText (configFile >> "CfgFactionClasses" >> QGVAR(ind) >> "displayName"); 
+            };
+        };
+        if (_category == "") exitWith {};
+
+        private _displayName = format [">>> %1", getText (configOf _veh >> "displayName")];
+        private _code = compile format [QUOTE([ARR_3(_this select 0, '%1', %2)] call DFUNC(autoModule_module)), _type, _side];
+        private _icon = getText (configOf _veh >> "icon");
+        private _ret = [_category, _displayName, _code, _icon] call zen_custom_modules_fnc_register;
+        TRACE_3("added custom",_type,_side,_ret);
+    };
+} forEach vehicles;
+INFO_1("autoModule - Total %1", count GVAR(vehicleList));

--- a/addons/zeusHC/functions/fnc_createCrew.sqf
+++ b/addons/zeusHC/functions/fnc_createCrew.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: AACO
  * Function used to safely spawn a crew, will check for a group count and a total AI count
@@ -18,15 +19,13 @@
  * Public: Yes
  */
 
-#include "script_component.hpp"
-TRACE_1("params",_this);
-
 params [
     ["_side", civilian, [civilian]],
     ["_vehicle", objNull, [objNull]],
     ["_crewType", "", [""]],
     ["_delayed", false, [false]]
 ];
+TRACE_4("createCrew",_side,_vehicle,_crewType,_delayed);
 
 private _crew = [];
 private _crewCount = {
@@ -67,8 +66,7 @@ if ([_side, _crewCount] call FUNC(canCreateGroup)) then {
                 _unit moveInGunner _vehicle;
             };
         };
-
-        if (_delayed && {_forEachIndex < (_crewCount - 1)}) then {
+        if (_delayed && canSuspend && {_forEachIndex < (_crewCount - 1)}) then {
             sleep GVAR(delayBetweenUnitCreation);
         };
     } forEach _crew;

--- a/addons/zeusHC/functions/fnc_getSpawnMachineId.sqf
+++ b/addons/zeusHC/functions/fnc_getSpawnMachineId.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: AACO
  * Helper function to get the least loaded HC, or server if no HCs are available
@@ -12,11 +13,8 @@
  * Public: Yes
  */
 
-#include "script_component.hpp"
-TRACE_1("Params",_this);
-
 private _allHCs = (entities "HeadlessClient_F") select {isPlayer _x};
-TRACE_1("",_allHCs);
+TRACE_1("getSpawnMachineId",_allHCs);
 
 private _returnClientId = SERVER_CLIENT_ID;
 


### PR DESCRIPTION
Adds zeusHC modules for mission vehicles at runtime.
Vehicles also show up in factory

Guide for Mission makers:
- Place vic with the camo you want
- Place a unit of the side you want near the vic
it uses the side of the crew or nearest unit to the vic to determine what side it is
once all zeuses have loaded in you can then delete them or do whatever

Vehicles should show up in HC spawn modules and in factory