### PR TITLE
AI Factory Updates

### DIFF
--- a/addons/zeusFactory/UI_RscAttributes.hpp
+++ b/addons/zeusFactory/UI_RscAttributes.hpp
@@ -4,6 +4,7 @@ class RscListbox;
 class RscToolbox;
 class RscXSliderH;
 class RscEdit;
+class RscCheckBox;
 
 class RscDisplayAttributes {
     class Controls {
@@ -170,6 +171,21 @@ class GVAR(RscDisplayAttributes_place): RscDisplayAttributes {
                             x = "22.5 * (((safezoneW / safezoneH) min 1.2) / 40)";
                             y = "8.5 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
                             w = "3 * (((safezoneW / safezoneH) min 1.2) / 40)";
+                            h = "1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
+                        };
+                        class attackMarkText: RscText {
+                            text = "Complete orders at target";
+                            idc = -1;
+                            x = "17.5 * (((safezoneW / safezoneH) min 1.2) / 40)";
+                            y = "0 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
+                            w = "8.5 * (((safezoneW / safezoneH) min 1.2) / 40)";
+                            h = "1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
+                        };
+                        class attackMarkCheckbox: RscCheckBox {
+                            idc = 23076;
+                            x = "17.5 * (((safezoneW / safezoneH) min 1.2) / 40)";
+                            y = "1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
+                            w = "1 * (((safezoneW / safezoneH) min 1.2) / 40)";
                             h = "1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
                         };
                     };

--- a/addons/zeusFactory/UI_RscAttributes.hpp
+++ b/addons/zeusFactory/UI_RscAttributes.hpp
@@ -188,6 +188,21 @@ class GVAR(RscDisplayAttributes_place): RscDisplayAttributes {
                             w = "1 * (((safezoneW / safezoneH) min 1.2) / 40)";
                             h = "1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
                         };
+                        class useLAMBSText: RscText {
+                            text = "Use LAMBS AI Waypoints";
+                            idc = -1;
+                            x = "17.5 * (((safezoneW / safezoneH) min 1.2) / 40)";
+                            y = "2.5 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
+                            w = "8.5 * (((safezoneW / safezoneH) min 1.2) / 40)";
+                            h = "1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
+                        };
+                        class useLAMBSCheckbox: RscCheckBox {
+                            idc = 23077;
+                            x = "17.5 * (((safezoneW / safezoneH) min 1.2) / 40)";
+                            y = "3.5 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
+                            w = "1 * (((safezoneW / safezoneH) min 1.2) / 40)";
+                            h = "1 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)";
+                        };
                     };
                 };
             };

--- a/addons/zeusFactory/functions/fnc_ai_attack.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_attack.sqf
@@ -7,7 +7,7 @@ private _radius = _group getVariable [QGVAR(radius), 200];
 private _attackTarget = _group getVariable [QGVAR(attackTarget), true];
 private _useLAMBS = _group getVariable [QGVAR(useLAMBS), true];
 
-TRACE_5("ai_attack",_leader,_group,_radius,_attackTarget,_attackTarget,_useLAMBS);
+TRACE_5("ai_attack",_leader,_group,_radius,_attackTarget,_useLAMBS);
 if (!local _leader) exitWith { WARNING_1("Waypoint script ran on non-local unit [%1]",_leader); };
 
 if !(_attackTarget) then {

--- a/addons/zeusFactory/functions/fnc_ai_attack.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_attack.sqf
@@ -4,13 +4,19 @@ params ["_leader"];
 
 private _group = group _leader;
 private _radius = _group getVariable [QGVAR(radius), 200];
+private _attackTarget = _group getVariable [QGVAR(attackTarget), true];
 
-TRACE_3("ai_attack",_leader,_group,_radius);
+TRACE_4("ai_attack",_leader,_group,_radius,_attackTarget);
 if (!local _leader) exitWith { WARNING_1("Waypoint script ran on non-local unit [%1]",_leader); };
 
-private _currentBeacon = (entities QGVAR(attackBeacon)) param [0, objNull];
-if (isNull _currentBeacon) exitWith {
-    WARNING_1("No Becacons [%1]",_currentBeacon);
-};
+if !(_attackTarget) then {
+    // if we don't want to attack a target, search the area instead.
+    this call FUNC(ai_search);
+} else {
+    private _currentBeacon = (entities QGVAR(attackBeacon)) param [0, objNull];
+    if (isNull _currentBeacon) exitWith {
+        WARNING_1("No Beacons [%1]",_currentBeacon);
+    };
 
-[_group, _currentBeacon, _radius, "SAD", "AWARE", "RED", "NORMAL", "LINE"] call CBA_fnc_addWaypoint;
+    [_group, _currentBeacon, _radius, "SAD", "AWARE", "RED", "NORMAL", "LINE"] call CBA_fnc_addWaypoint;
+};

--- a/addons/zeusFactory/functions/fnc_ai_attack.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_attack.sqf
@@ -5,8 +5,9 @@ params ["_leader"];
 private _group = group _leader;
 private _radius = _group getVariable [QGVAR(radius), 200];
 private _attackTarget = _group getVariable [QGVAR(attackTarget), true];
+private _useLAMBS = _group getVariable [QGVAR(useLAMBS), true];
 
-TRACE_4("ai_attack",_leader,_group,_radius,_attackTarget);
+TRACE_5("ai_attack",_leader,_group,_radius,_attackTarget,_attackTarget,_useLAMBS);
 if (!local _leader) exitWith { WARNING_1("Waypoint script ran on non-local unit [%1]",_leader); };
 
 if !(_attackTarget) then {
@@ -18,5 +19,9 @@ if !(_attackTarget) then {
         WARNING_1("No Beacons [%1]",_currentBeacon);
     };
 
-    [_group, _currentBeacon, _radius, "SAD", "AWARE", "RED", "NORMAL", "LINE"] call CBA_fnc_addWaypoint;
+    if (_useLAMBS) then {
+        [_group, _currentBeacon getPos [_radius, random 360]] spawn lambs_wp_fnc_taskAssault;
+    } else {
+        [_group, _currentBeacon, _radius, "SAD", "AWARE", "RED", "NORMAL", "LINE"] call CBA_fnc_addWaypoint;
+    }
 };

--- a/addons/zeusFactory/functions/fnc_ai_garrison.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_garrison.sqf
@@ -5,8 +5,9 @@ params ["_leader"];
 private _group = group _leader;
 private _radius = _group getVariable [QGVAR(radius), 200];
 private _attackTarget = _group getVariable [QGVAR(attackTarget), true];
+private _useLAMBS = _group getVariable [QGVAR(useLAMBS), true];
 
-TRACE_3("ai_garrison",_leader,_group,_radius);
+TRACE_5("ai_garrison",_leader,_group,_radius,_attackTarget,_useLAMBS);
 if (!local _leader) exitWith { WARNING_1("Waypoint script ran on non-local unit [%1]",_leader); };
 
 private _positionToGarrison = getPos _leader;
@@ -18,5 +19,10 @@ if (_attackTarget) then {
 		WARNING_1("No Beacons [%1]",_currentBeacon);
 	};
 };
-//Todo tweak defend garrison ratio: https://github.com/CBATeam/CBA_A3/pull/573/
-[_group, _positionToGarrison, _radius] call CBA_fnc_taskDefend;
+
+if (_useLAMBS) then {
+	[_group, _positionToGarrison, _radius] call lambs_wp_fnc_taskGarrison;
+} else {
+	//Todo tweak defend garrison ratio: https://github.com/CBATeam/CBA_A3/pull/573/
+	[_group, _positionToGarrison, _radius] call CBA_fnc_taskDefend;
+};

--- a/addons/zeusFactory/functions/fnc_ai_garrison.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_garrison.sqf
@@ -4,9 +4,19 @@ params ["_leader"];
 
 private _group = group _leader;
 private _radius = _group getVariable [QGVAR(radius), 200];
+private _attackTarget = _group getVariable [QGVAR(attackTarget), true];
 
 TRACE_3("ai_garrison",_leader,_group,_radius);
 if (!local _leader) exitWith { WARNING_1("Waypoint script ran on non-local unit [%1]",_leader); };
 
+private _positionToGarrison = getPos _leader;
+if (_attackTarget) then {
+	private _currentBeacon = (entities QGVAR(attackBeacon)) param [0, objNull];
+    if !(isNull _currentBeacon) then {
+		_positionToGarrison = _currentBeacon;
+    } else {
+		WARNING_1("No Beacons [%1]",_currentBeacon);
+	};
+};
 //Todo tweak defend garrison ratio: https://github.com/CBATeam/CBA_A3/pull/573/
-[_group, getPos _leader, _radius] call CBA_fnc_taskDefend;
+[_group, _positionToGarrison, _radius] call CBA_fnc_taskDefend;

--- a/addons/zeusFactory/functions/fnc_ai_paradrop.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_paradrop.sqf
@@ -1,73 +1,83 @@
 #include "script_component.hpp"
 
+#define DROP_DELAY 0.4
+#define CHECK_DELAY 0.3
+#define PARACHUTE_DEPLOY_DELAY 2
+#define EXPAND_MULTIPLIER 0.5
+#define PARACHUTE "Steerable_Parachute_F"
+#define FLY_IN_HEIGHT 125
+
 params [["_vehicleGroup", grpNull, [grpNull]], ["_wpPos", [0, 0, 0], [[]], 3]];
 TRACE_2("ai_paradrop",_vehicleGroup,_wpPos);
 if (!local _vehicleGroup) exitWith { WARNING_1("Waypoint script ran on non-local group [%1]",_vehicleGroup); };
 
-_wpPos = _wpPos vectorAdd [0,0,125];
 private _vehicle = vehicle leader _vehicleGroup;
-private _commander = driver _vehicle;
+private _pilot = driver _vehicle;
 
-_vehicle flyInHeight 125;
-if ((_vehicle distance2D _wpPos) > 50) then {
-    _vehicleGroup move _wpPos;
+private _dropPos = _wpPos;
+private _movePos = _wpPos vectorAdd [0, 0, 125];
+private _expandedPos = _dropPos vectorAdd((_dropPos vectorDiff (getPosASL _vehicle)) vectorMultiply EXPAND_MULTIPLIER);
+
+private _prevVelocity = velocityModelSpace _vehicle;
+private _heading = _vehicle getDir _dropPos;
+_vehicle setDir _heading;
+_vehicle setVelocityModelSpace _prevVelocity;
+
+_vehicle doMove _expandedPos;
+_pilot doMove _expandedPos;
+
+_vehicleGroup setCombatMode "BLUE";
+_vehicleGroup setBehaviour "CARELESS";
+_vehicle flyInHeight FLY_IN_HEIGHT;
+
+private _origDot = ((getPosASL _vehicle) vectorDiff _dropPos) vectorDotProduct (_expandedPos vectorDiff _dropPos);
+
+waitUntil {
+    private _dot = ((getPosASL _vehicle) vectorDiff _dropPos) vectorDotProduct (_expandedPos vectorDiff _dropPos);
+    sleep CHECK_DELAY;
+    (_origDot * _dot) < 0
 };
 
-waitUntil {sleep 1; (!alive _vehicle) || {!alive _commander} || {(_vehicle distance2D _wpPos) < 100}};
-if ((!alive _vehicle) || {!alive _commander}) exitWith {WARNING_2("para problem [veh %1, com %2]",alive _vehicle, alive _commander); true};
-
-// Fly level and straight while dropping infantry:
-private _unloadFlightPos = _vehicle getRelPos [500, 0];
-_vehicle flyInHeight 125;
-_vehicleGroup setSpeedMode "LIMITED";
-_vehicleGroup move _unloadFlightPos;
-
-private _altitude = (getPosATL _vehicle) select 2;
+// drop
 private _crewToUnload = (crew _vehicle) select {(group _x) != _vehicleGroup};
-TRACE_2("Starting Unload",_altitude,count _crewToUnload);
-
+private _planeVelocity = velocity _vehicle;
 {
-    moveOut _x;
-    unassignVehicle _x;
+    if ((driver (vehicle _x)) != _x) then {
+        _x disableAI "MOVE";
 
-    // Handle Parachute:
-    [{
-        params ["_vehicle", "_unit"];
-        ((isTouchingGround _unit) || {!alive _unit}) || {(((getPosATL _unit) select 2) < 200) && {(_vehicle distance _unit) > 10}}
-    }, {
-        params ["_vehicle", "_unit"];
-        if ((isTouchingGround _unit) || {!alive _unit}) exitWith {};
+        _x allowDamage false;
+        _x disableCollisionWith _vehicle;
+        moveOut _x;
+        unassignVehicle _x;
+        [_x] allowGetIn false;
+        _x setDir (getDir _vehicle);
 
-        private _posASL = getPosASL _unit;
-        private _vel = velocity _unit;
-        _vel set [2, ((_vel select 2) + (0 max (-0.3 * (_vel select 2))))];
-
-        private _chute = "NonSteerable_Parachute_F" createVehicle _posASL;
-        TRACE_2("opening chute",_unit,_chute);
-        [_chute] call EFUNC(core,addToCurator);
-
-        //make sure the idiots don't get out
-        _unit moveInAny _chute;
         [{
-            params ["_unit", "_chute"];
-            if ((!alive _unit) || {!alive _chute} || {isTouchingGround _unit}) exitWith {true};
-            if ((vehicle _unit) == _chute) then {
-                _unit moveInAny _chute;
-                TRACE_2("moving into chute",_unit,_chute);
-            };
-            false
-        }, {TRACE_1("finished",_this);}, [_unit, _chute], 5, {TRACE_1("timeout",_this);}] call CBA_fnc_waitUntilAndExecute;
+            params["_unit", "_parachute", "_vehicle", "_planeVelocity"];
+            
+            private _para = createVehicle [_parachute, [0, 0, 0], [], 0, "NONE"];
+            _unit disableCollisionWith _para;
+            
+            _para setPosASL (getPosASLVisual _unit);
+            _para setVectorDirAndUp [vectorDirVisual _unit, vectorUpVisual _unit];
+            _para setVelocity _planeVelocity;
+            
+            _unit moveInDriver _para;
+            _unit assignAsDriver _para;
+            [_unit] allowGetIn true;
+            [_unit] orderGetIn true;
+            
+            _unit enableCollisionWith _vehicle;
+            _unit allowDamage true;
+            
+        }, [_x, PARACHUTE, _vehicle, _planeVelocity], PARACHUTE_DEPLOY_DELAY] call CBA_fnc_waitAndExecute;
 
-        _chute setPosASL _posASL;
-        _chute setVelocity _vel;
-    }, [_vehicle, _x]] call CBA_fnc_waitUntilAndExecute;
-    sleep 2;
+        _x enableAI "MOVE";
+        
+        sleep DROP_DELAY;
+    };
 } forEach _crewToUnload;
 
-TRACE_1("Unload Finished",crew _vehicle);
+sleep 5;
 
-sleep 1;
-
-_vehicleGroup setSpeedMode "NORMAL";
-TRACE_1("WP Done",crew _vehicle);
 true

--- a/addons/zeusFactory/functions/fnc_ai_patrol.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_patrol.sqf
@@ -5,18 +5,23 @@ params ["_leader"];
 private _group = group _leader;
 private _radius = _group getVariable [QGVAR(radius), 200];
 private _attackTarget = _group getVariable [QGVAR(attackTarget), true];
+private _useLAMBS = _group getVariable [QGVAR(useLAMBS), true];
 
-TRACE_3("ai_patrol",_leader,_group,_radius);
+TRACE_5("ai_patrol",_leader,_group,_radius,_attackTarget,_useLAMBS);
 if (!local _leader) exitWith { WARNING_1("Waypoint script ran on non-local unit [%1]",_leader); };
 
 private _positionToPatrol = getPos _leader;
 if (_attackTarget) then {
 	private _currentBeacon = (entities QGVAR(attackBeacon)) param [0, objNull];
-    if !(isNull _currentBeacon) then {
+	if !(isNull _currentBeacon) then {
 		_positionToPatrol = _currentBeacon;
-    } else {
+	} else {
 		WARNING_1("No Beacons [%1]",_currentBeacon);
 	};
 };
 
-[_group, _positionToPatrol, _radius] call CBA_fnc_taskPatrol;
+if (_useLAMBS) then {
+	[_group, _positionToPatrol, _radius] call lambs_wp_fnc_taskPatrol;
+} else {
+	[_group, _positionToPatrol, _radius] call CBA_fnc_taskPatrol;
+};

--- a/addons/zeusFactory/functions/fnc_ai_patrol.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_patrol.sqf
@@ -4,8 +4,19 @@ params ["_leader"];
 
 private _group = group _leader;
 private _radius = _group getVariable [QGVAR(radius), 200];
+private _attackTarget = _group getVariable [QGVAR(attackTarget), true];
 
 TRACE_3("ai_patrol",_leader,_group,_radius);
 if (!local _leader) exitWith { WARNING_1("Waypoint script ran on non-local unit [%1]",_leader); };
 
-[_group, getPos _leader, _radius] call CBA_fnc_taskPatrol;
+private _positionToPatrol = getPos _leader;
+if (_attackTarget) then {
+	private _currentBeacon = (entities QGVAR(attackBeacon)) param [0, objNull];
+    if !(isNull _currentBeacon) then {
+		_positionToPatrol = _currentBeacon;
+    } else {
+		WARNING_1("No Beacons [%1]",_currentBeacon);
+	};
+};
+
+[_group, _positionToPatrol, _radius] call CBA_fnc_taskPatrol;

--- a/addons/zeusFactory/functions/fnc_ai_search.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_search.sqf
@@ -5,8 +5,9 @@ params ["_leader"];
 private _group = group _leader;
 private _radius = _group getVariable [QGVAR(radius), 200];
 private _attackTarget = _group getVariable [QGVAR(attackTarget), true];
+private _useLAMBS = _group getVariable [QGVAR(useLAMBS), true];
 
-TRACE_3("ai_search",_leader,_group,_radius);
+TRACE_5("ai_search",_leader,_group,_radius,_attackTarget,_useLAMBS);
 if (!local _leader) exitWith { WARNING_1("Waypoint script ran on non-local unit [%1]",_leader); };
 
 private _positionToSearch = getPos _leader;
@@ -19,4 +20,9 @@ if (_attackTarget) then {
 	};
 };
 
-[_group, [getPos _positionToSearch, _radius, _radius, 0, false]] call CBA_fnc_taskSearchArea;
+if (_useLAMBS) then {
+	[_group, _positionToSearch, _radius] spawn lambs_wp_fnc_taskCQB;
+} else {
+	[_group, [getPos _positionToSearch, _radius, _radius, 0, false]] call CBA_fnc_taskSearchArea;
+}
+

--- a/addons/zeusFactory/functions/fnc_ai_search.sqf
+++ b/addons/zeusFactory/functions/fnc_ai_search.sqf
@@ -4,8 +4,19 @@ params ["_leader"];
 
 private _group = group _leader;
 private _radius = _group getVariable [QGVAR(radius), 200];
+private _attackTarget = _group getVariable [QGVAR(attackTarget), true];
 
 TRACE_3("ai_search",_leader,_group,_radius);
 if (!local _leader) exitWith { WARNING_1("Waypoint script ran on non-local unit [%1]",_leader); };
 
-[_group, [(getPos _leader), _radius, _radius, 0, false]] call CBA_fnc_taskSearchArea;
+private _positionToSearch = getPos _leader;
+if (_attackTarget) then {
+	private _currentBeacon = (entities QGVAR(attackBeacon)) param [0, objNull];
+    if !(isNull _currentBeacon) then {
+		_positionToSearch = _currentBeacon;
+    } else {
+		WARNING_1("No Beacons [%1]",_currentBeacon);
+	};
+};
+
+[_group, [getPos _positionToSearch, _radius, _radius, 0, false]] call CBA_fnc_taskSearchArea;

--- a/addons/zeusFactory/functions/fnc_createTransport.sqf
+++ b/addons/zeusFactory/functions/fnc_createTransport.sqf
@@ -5,7 +5,7 @@ params ["_factoryLogic", "_transportType", "_group", "_side"];
 TRACE_4("createTransport",_factoryLogic,_transportType,_group,_side);
 
 ([_factoryLogic,_transportType,_side] call FUNC(getTransportType)) params ["_vehType", "_crewType"];
-TRACE_4("getTransportType",_vehType,_crewType);
+TRACE_2("getTransportType",_vehType,_crewType);
 if ((_vehType == "") || {_crewType == ""}) exitWith {ERROR_2("bad data[%1-%2]",_vehType,_crewType);};
 
 private _vehicle = _vehType createVehicle ((leader _group) getRelPos [5, 0]);
@@ -43,8 +43,7 @@ private _turrets = allTurrets [_vehicle, false];
     if (((getNumber (_config >> "isCopilot")) == 0) && {count getArray (_config >> "weapons") > 0}) then {
         _gunnerTurrets pushBack _x;
     };
-    false
-} count _turrets;
+} forEach _turrets;
 
 {
     private _gunner = _group createUnit [_crewType, (getPos _vehicle), [], 0, "NONE"];

--- a/addons/zeusFactory/functions/fnc_dispatch.sqf
+++ b/addons/zeusFactory/functions/fnc_dispatch.sqf
@@ -102,6 +102,9 @@ private _readyCondition = "(count thisList) == ({isTouchingGround _x} count this
 private _attackTarget = _placeLogic getVariable [QGVAR(attackTarget), true];
 _group setVariable [QGVAR(attackTarget), _attackTarget];
 
+private _useLAMBS = _placeLogic getVariable [QGVAR(useLAMBS), true];
+_group setVariable [QGVAR(useLAMBS), _useLAMBS];
+
 switch (_ordersType) do {
 case (ORDERS_MOVE): {}; // nothing
 case (ORDERS_GARRISION): {

--- a/addons/zeusFactory/functions/fnc_dispatch.sqf
+++ b/addons/zeusFactory/functions/fnc_dispatch.sqf
@@ -99,6 +99,9 @@ private _ordersWP = _group addWaypoint [getPos _placeLogic, 0];
 _ordersWP setWaypointType "MOVE";
 private _readyCondition = "(count thisList) == ({isTouchingGround _x} count thisList)";
 
+private _attackTarget = _placeLogic getVariable [QGVAR(attackTarget), true];
+_group setVariable [QGVAR(attackTarget), _attackTarget];
+
 switch (_ordersType) do {
 case (ORDERS_MOVE): {}; // nothing
 case (ORDERS_GARRISION): {

--- a/addons/zeusFactory/functions/fnc_getTransportType.sqf
+++ b/addons/zeusFactory/functions/fnc_getTransportType.sqf
@@ -21,16 +21,5 @@ case (east): {"potato_e_" + _crewType};
 case (resistance): {"potato_i_" + _crewType};
 };
 
-private _maxCargoRoom = 99;
-private _addGunner = false;
-
-if (_vehType != "") then {
-    _maxCargoRoom = ([_vehType, true] call BIS_fnc_crewCount) - 1;
-    if (_transportType in [TRANSPORT_APC_RTB, TRANSPORT_APC_FOLLOW]) then {
-        _addGunner = true;
-        _maxCargoRoom = _maxCargoRoom - 1;
-    };
-};
-
 // Return:
-[_vehType, _crewType, _maxCargoRoom, _addGunner]
+[_vehType, _crewType]

--- a/addons/zeusFactory/functions/fnc_getTransportType.sqf
+++ b/addons/zeusFactory/functions/fnc_getTransportType.sqf
@@ -21,5 +21,22 @@ case (east): {"potato_e_" + _crewType};
 case (resistance): {"potato_i_" + _crewType};
 };
 
+private _maxCargoRoom = 99;
+private _addGunner = false;
+
+if (_vehType != "") then {
+	private _config = configFile >> "CfgVehicles" >> _vehType;
+
+	private _cargo = [];
+	private _codrivers = getArray (_config >> "cargoIsCoDriver");
+
+	for "_index" from 0 to (getNumber (_config >> "transportSoldier") - 1) do {
+		if !(_index in _codrivers && {_vehType isKindOf "Car"} && {!(_vehType isKindOf "Wheeled_APC_F")}) then {
+			_cargo pushBack _index;
+		};
+	};
+    _maxCargoRoom = count _cargo;
+};
+
 // Return:
-[_vehType, _crewType]
+[_vehType, _crewType, _maxCargoRoom]

--- a/addons/zeusFactory/functions/fnc_zeusAttributes_place.sqf
+++ b/addons/zeusFactory/functions/fnc_zeusAttributes_place.sqf
@@ -15,6 +15,7 @@ if (isNil QGVAR(lastTransport)) then {GVAR(lastTransport) = 0};
 if (isNil QGVAR(lastOrders)) then {GVAR(lastOrders) = 0};
 if (isNil QGVAR(lastRadius)) then {GVAR(lastRadius) = 100};
 if (isNil QGVAR(attackTarget)) then {GVAR(attackTarget) = true};
+if (isNil QGVAR(useLAMBS)) then {GVAR(useLAMBS) = true};
 
 // Init: Transport List
 lbClear (_display displayCtrl 23071);
@@ -56,7 +57,7 @@ private _radius = _logicObject getVariable [QGVAR(radius), GVAR(lastRadius)];
 [_control controlsgroupctrl 23074, _control controlsgroupctrl 23075, "m"] call bis_fnc_initSliderValue;
 
 (_control controlsgroupctrl 23076) cbSetChecked GVAR(attackTarget);
-
+(_control controlsgroupctrl 23077) cbSetChecked GVAR(useLAMBS);
 
 private _fnc_onUnload = {
     params [["_display", displayNull, [displayNull]], ["_exitCode", -1]];
@@ -98,6 +99,10 @@ private _fnc_onConfirm = {
     private _attackTarget = cbChecked (_display displayCtrl 23076);
     GVAR(attackTarget) = _attackTarget;
     _logicVariable setVariable [QGVAR(attackTarget), _attackTarget, true];
+
+    private _useLAMBS = cbChecked (_display displayCtrl 23077);
+    GVAR(useLAMBS) = _useLAMBS;
+    _logicVariable setVariable [QGVAR(useLAMBS), _useLAMBS, true];
 
     _logicObject setVariable [QGVAR(set), true, true];
     TRACE_3("set",_transportType,_ordersType,_radius);

--- a/addons/zeusFactory/functions/fnc_zeusAttributes_place.sqf
+++ b/addons/zeusFactory/functions/fnc_zeusAttributes_place.sqf
@@ -14,7 +14,7 @@ _control ctrlRemoveAllEventHandlers "setFocus";
 if (isNil QGVAR(lastTransport)) then {GVAR(lastTransport) = 0};
 if (isNil QGVAR(lastOrders)) then {GVAR(lastOrders) = 0};
 if (isNil QGVAR(lastRadius)) then {GVAR(lastRadius) = 100};
-
+if (isNil QGVAR(attackTarget)) then {GVAR(attackTarget) = true};
 
 // Init: Transport List
 lbClear (_display displayCtrl 23071);
@@ -55,6 +55,7 @@ private _radius = _logicObject getVariable [QGVAR(radius), GVAR(lastRadius)];
 [_control controlsgroupctrl 23074, _control controlsgroupctrl 23075, "m", _radius] call bis_fnc_initSliderValue;
 [_control controlsgroupctrl 23074, _control controlsgroupctrl 23075, "m"] call bis_fnc_initSliderValue;
 
+(_control controlsgroupctrl 23076) cbSetChecked GVAR(attackTarget);
 
 
 private _fnc_onUnload = {
@@ -93,6 +94,10 @@ private _fnc_onConfirm = {
     private _radius = sliderposition (_display displayCtrl 23074);
     GVAR(lastRadius) = _radius;
     _logicObject setVariable [QGVAR(radius), _radius, true];
+
+    private _attackTarget = cbChecked (_display displayCtrl 23076);
+    GVAR(attackTarget) = _attackTarget;
+    _logicVariable setVariable [QGVAR(attackTarget), _attackTarget, true];
 
     _logicObject setVariable [QGVAR(set), true, true];
     TRACE_3("set",_transportType,_ordersType,_radius);


### PR DESCRIPTION
* Change Paradrop script to be better; implements my paradrop script. No more helicopters hanging in the air awkwardly
* AI will now always occupy vehicle gunner seats while before they only spawned in IFVs. This should allow AI helicopters to have door gunners and AI cars to have gunners so they can defend themselves
* AI will now have option to use LAMBS waypoints to complete their mission
* Add check-box to allow Zeus to tell AI to execute order at target mark after dismount, or dismount location
* Add check-box to allow Zeus to tell AI to use LAMBS AI waypoints after dismount

These should be good changes that allow for better flow in missions. Nothing tested in multiplayer/dedicated server, I don't see why anything wouldn't work however. This should make AI a bit more realistic to fight against when using POTATO Factory