### PR TITLE
SafeStart additions

### DIFF
--- a/addons/missionTest/functions/fnc_onMissionSave.sqf
+++ b/addons/missionTest/functions/fnc_onMissionSave.sqf
@@ -113,6 +113,14 @@ private _onLoadName = getText (missionConfigFile >> "onLoadName");
 if (_onLoadName == "*** Insert mission name here. ***") then {
     _problems pushBackUnique ["Minor: Need to set loading screen info", ["description.ext -> onLoadName"]];
 };
+private _missionType = (getMissionConfigValue QEGVAR(missionTesting,missionType));
+if (_missionType == 0) then {
+    _problems pushBackUnique ["Need to select mission type", ["POTATO -> Mission Testing Attributes -> Mission Type"]];
+};
+private _missionLength = getMissionConfigValue QEGVAR(missionTesting,missionTimeLength);
+if (_missionLength == "") then {
+    _problems pushBackUnique ["Need to set mission length value", ["POTATO -> Mission Testing Attributes -> Mission Length"]];
+};
 
 
 // Floating units / Fall Damage:

--- a/addons/missionTesting/CfgEden.hpp
+++ b/addons/missionTesting/CfgEden.hpp
@@ -109,17 +109,17 @@ class Cfg3DEN {
                     collapsed = 0;
 					class Attributes{
 						class GVAR(SSTimeGiven) {
-                            displayName = "Safe Start Time Length:";
+                            displayName = "Safe Start Time Length (mins):";
 							property = QGVAR(SSTimeGiven);
                             control = QUOTE(EditShort);
-                            defaultValue = "10";
+                            defaultValue = "";
                             typeName = "STRING";
 						};
 						class GVAR(missionTimeLength) {
-                            displayName = "Mission Length:";
+                            displayName = "Mission Length (mins):";
 							property = QGVAR(missionTimeLength);
                             control = QUOTE(EditShort);
-                            defaultValue = "35";
+                            defaultValue = "";
                             typeName = "STRING";
 						};
 					};

--- a/addons/missionTesting/CfgEden.hpp
+++ b/addons/missionTesting/CfgEden.hpp
@@ -104,6 +104,26 @@ class Cfg3DEN {
 						};
 					};
 				};
+				class MissionTimers {
+                    displayName = "Mission Timers";
+                    collapsed = 0;
+					class Attributes{
+						class GVAR(SSTimeGiven) {
+                            displayName = "Safe Start Time Length:";
+							property = QGVAR(SSTimeGiven);
+                            control = QUOTE(EditShort);
+                            defaultValue = "10";
+                            typeName = "STRING";
+						};
+						class GVAR(missionTimeLength) {
+                            displayName = "Mission Length:";
+							property = QGVAR(missionTimeLength);
+                            control = QUOTE(EditShort);
+                            defaultValue = "35";
+                            typeName = "STRING";
+						};
+					};
+				};
 				class MissionTags {
                     displayName = "Mission Tags";
                     collapsed = 0;

--- a/addons/missionTesting/config.cpp
+++ b/addons/missionTesting/config.cpp
@@ -29,3 +29,9 @@ class GVAR(displayBreifings) {
 #include "CfgEventHandlers.hpp"
 #include "CfgEden.hpp"
 #include "CfgVehicles.hpp"
+
+class CfgCommands{
+	allowedHTMLLoadURIs[] = {
+		"*.bourbonwarfare.com/*", // strings support wildcards '*' and '?'
+	};
+};

--- a/addons/missionTesting/functions/fnc_displayMenu.sqf
+++ b/addons/missionTesting/functions/fnc_displayMenu.sqf
@@ -167,13 +167,12 @@ if (!EGVAR(spectate,running)) then {
     _keyBindInst ctrlCommit 0;
 };
 
-/*  Waiting for CTRLSETURL to be added from Dev branch, else it will have to be added via config when I get around to that.... oh well.
 private _openForumFinishedMissions = DISPLAY_TESTMENU ctrlCreate [QUOTE(RscButtonMenu),-1];
 _openForumFinishedMissions ctrlSetText "Forum";
-_openForumFinishedMissions ctrlSetURL "http://forums.bourbonwarfare.com/viewforum.php?f=30";
+_openForumFinishedMissions ctrlSetURL "https://forums.bourbonwarfare.com/viewforum.php?f=30";
 _openForumFinishedMissions ctrlSetPosition [0.34,1,0.12,0.1];
 _openForumFinishedMissions ctrlCommit 0;
- */
+
 private _missionMaker = getMissionConfigValue ["author","????"];
 private _missionName = getMissionConfigValue ["onLoadName", getMissionConfigValue ["briefingName","????"]];
 private _missionType = A_MISSION_TYPE select (getMissionConfigValue QGVAR(missionType));

--- a/addons/safeStart/XEH_PREP.hpp
+++ b/addons/safeStart/XEH_PREP.hpp
@@ -5,3 +5,4 @@ PREP(handleFired);
 PREP(toggleTimer);
 PREP(updateTimer);
 PREP(toggleSafeStart);
+PREP(missionTimeWarning);

--- a/addons/safeStart/XEH_preInit.sqf
+++ b/addons/safeStart/XEH_preInit.sqf
@@ -23,4 +23,12 @@ GVAR(safeStartEnabled) = true;
     [] call FUNC(missionTimeWarning);
 }] call CBA_fnc_addEventHandler;
 
+[QGVAR(curatorHint_TimeKeeper_15min), {
+        ["Time Keeper", "15 mins to mission end", 30] call BIS_fnc_curatorHint;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(curatorHint_TimeKeeper_end), {
+        ["Time Keeper", "Mission Time has expired", 30] call BIS_fnc_curatorHint;
+}] call CBA_fnc_addEventHandler;
+
 ADDON = true;

--- a/addons/safeStart/XEH_preInit.sqf
+++ b/addons/safeStart/XEH_preInit.sqf
@@ -20,6 +20,7 @@ GVAR(safeStartEnabled) = true;
 ["potato_safeStartOff", {
     GVAR(safeStartEnabled) = false;
     [false] call FUNC(toggleTimer);
+    [] call FUNC(missionTimeWarning);
 }] call CBA_fnc_addEventHandler;
 
 ADDON = true;

--- a/addons/safeStart/functions/fnc_missionTimeWarning.sqf
+++ b/addons/safeStart/functions/fnc_missionTimeWarning.sqf
@@ -7,8 +7,7 @@
  * 0: Start mission length warnings <BOOL>
  *
  * Examples:
- * [true] call potato_safeStart_fnc_missionTimeWarning;
- * [false] call potato_safeStart_fnc_missionTimeWarning;
+ * [] call potato_safeStart_fnc_missionTimeWarning;
  *
  * Public: Yes
  */
@@ -28,34 +27,38 @@ TRACE_1("Mission start time",QGVAR(missionstartTime));
     {
         private _missionStartTime = missionNamespace getVariable QGVAR(missionstartTime);
         private _missionLength = parseNumber getMissionConfigValue QEGVAR(missionTesting,missionTimeLength) * 60;
-        (CBA_missionTime >= (_missionStartTime + _missionLength - 900))
+        (CBA_missionTime >= (_missionStartTime + _missionLength - 900))  || !(isNil QGVAR(timerID))
     },
     {
-        [
-            "potato_adminMsg",
+        if (isNil QGVAR(timerID)) then {
             [
-                "15 mins to mission end",
-                "Time Keeper"
-            ]
-        ] call CBA_fnc_globalEvent;
-        ["Time Keeper", "15 mins to mission end", 30] call BIS_fnc_curatorHint;
-        //End Warning
-        [
-            {
-                (CBA_missionTime >= ((_this select 0) + (_this select 1)))
-            },
-            {
+                "potato_adminMsg",
                 [
-                    "potato_adminMsg",
+                    "15 mins to mission end",
+                    "Time Keeper"
+                ]
+            ] call CBA_fnc_globalEvent;
+            {
+                [QGVAR(curatorHint_TimeKeeper_15min),[],getAssignedCuratorUnit _x] call CBA_fnc_targetEvent;
+            } forEach allcurators;
+            //End Warning
+            [
+                {
                     [
-                        "Mission Time has expired",
-                        "Time Keeper"
-                    ]
-                ] call CBA_fnc_globalEvent;
-            ["Time Keeper", "Mission Time has expired", 30] call BIS_fnc_curatorHint;
-            },
-            [_missionStartTime,_missionLength]
-        ] call CBA_fnc_waitUntilAndExecute;
+                        "potato_adminMsg",
+                        [
+                            "Mission Time has expired",
+                            "Time Keeper"
+                        ]
+                    ] call CBA_fnc_globalEvent;
+                    {
+                        [QGVAR(curatorHint_TimeKeeper_end),[],getAssignedCuratorUnit _x] call CBA_fnc_targetEvent;
+                    } forEach allcurators;
+                },
+                [],
+                900
+            ] call CBA_fnc_waitAndExecute;
+        };
     },
     []
 ] call CBA_fnc_waitUntilAndExecute;
@@ -71,4 +74,3 @@ private _endTime = [_endTimeDec] call BIS_fnc_timeToString;
 
 private _string = format ["|missionEndMarker_0|[0,0,0.0000]|mil_warning|ICON|[1,1]|0|Solid|colorCivilian|1|Mission End Time - %1",_endTime];
 [_string] call BIS_fnc_stringToMarker;
-

--- a/addons/safeStart/functions/fnc_missionTimeWarning.sqf
+++ b/addons/safeStart/functions/fnc_missionTimeWarning.sqf
@@ -21,6 +21,7 @@ if !(isServer) exitWith {};
 params [];
 
 missionNamespace setVariable [QGVAR(missionstartTime), CBA_missionTime, true];
+TRACE_1("Mission start time",QGVAR(missionstartTime));
 
 // 15 min Warning
 [
@@ -37,6 +38,7 @@ missionNamespace setVariable [QGVAR(missionstartTime), CBA_missionTime, true];
                 "Time Keeper"
             ]
         ] call CBA_fnc_globalEvent;
+        ["Time Keeper", "15 mins to mission end", 30] call BIS_fnc_curatorHint;
         //End Warning
         [
             {
@@ -50,6 +52,7 @@ missionNamespace setVariable [QGVAR(missionstartTime), CBA_missionTime, true];
                         "Time Keeper"
                     ]
                 ] call CBA_fnc_globalEvent;
+            ["Time Keeper", "Mission Time has expired", 30] call BIS_fnc_curatorHint;
             },
             [_missionStartTime,_missionLength]
         ] call CBA_fnc_waitUntilAndExecute;

--- a/addons/safeStart/functions/fnc_missionTimeWarning.sqf
+++ b/addons/safeStart/functions/fnc_missionTimeWarning.sqf
@@ -1,0 +1,71 @@
+/*
+ * Author: BadWolf
+ * Function used to start/stop mission length timer
+ * Sould only be called on the server
+ *
+ * Arguments:
+ * 0: Start mission length warnings <BOOL>
+ *
+ * Examples:
+ * [true] call potato_safeStart_fnc_missionTimeWarning;
+ * [false] call potato_safeStart_fnc_missionTimeWarning;
+ *
+ * Public: Yes
+ */
+
+#include "script_component.hpp"
+TRACE_1("Params",_this);
+
+if !(isServer) exitWith {};
+
+params [];
+
+missionNamespace setVariable [QGVAR(missionstartTime), CBA_missionTime, true];
+
+// 15 min Warning
+[
+    {
+        private _missionStartTime = missionNamespace getVariable QGVAR(missionstartTime);
+        private _missionLength = parseNumber getMissionConfigValue QEGVAR(missionTesting,missionTimeLength) * 60;
+        (CBA_missionTime >= (_missionStartTime + _missionLength - 900))
+    },
+    {
+        [
+            "potato_adminMsg",
+            [
+                "15 mins to mission end",
+                "Time Keeper"
+            ]
+        ] call CBA_fnc_globalEvent;
+        //End Warning
+        [
+            {
+                (CBA_missionTime >= ((_this select 0) + (_this select 1)))
+            },
+            {
+                [
+                    "potato_adminMsg",
+                    [
+                        "Mission Time has expired",
+                        "Time Keeper"
+                    ]
+                ] call CBA_fnc_globalEvent;
+            },
+            [_missionStartTime,_missionLength]
+        ] call CBA_fnc_waitUntilAndExecute;
+    },
+    []
+] call CBA_fnc_waitUntilAndExecute;
+
+// Add Map Marker at 0,0 position with mission end time.
+
+// Check if mission end map marker already exists.
+
+private _startTime = daytime;
+private _missionLengthDec = parseNumber getMissionConfigValue QEGVAR(missionTesting,missionTimeLength) / 60;
+private _endTimeDec = _startTime + _missionLengthDec;
+private _endTime = [_endTimeDec] call BIS_fnc_timeToString;
+
+private _string = format ["|missionEndMarker_0|[0,0,0.0000]|mil_warning|ICON|[1,1]|0|Solid|colorCivilian|1|Mission End Time - %1",_endTime];
+[_string] call BIS_fnc_stringToMarker;
+

--- a/addons/safeStart/script_component.hpp
+++ b/addons/safeStart/script_component.hpp
@@ -1,9 +1,9 @@
 #define COMPONENT safestart
 #include "\z\potato\addons\core\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
-#define ENABLE_PERFORMANCE_COUNTERS
+//#define DEBUG_MODE_FULL
+//#define DISABLE_COMPILE_CACHE
+//#define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_SAFESTART
     #define DEBUG_MODE_FULL

--- a/addons/safeStart/script_component.hpp
+++ b/addons/safeStart/script_component.hpp
@@ -1,9 +1,9 @@
 #define COMPONENT safestart
 #include "\z\potato\addons\core\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
-// #define ENABLE_PERFORMANCE_COUNTERS
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
+#define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_SAFESTART
     #define DEBUG_MODE_FULL


### PR DESCRIPTION
Adds a mission attribute to the "Mission Testing Attributes" for SS length and Mission Length.

Provides a warning to admins and Curators at 15mins before the end of the mission length, and one at the expiry of mission time. 

Creates a marker with the listed mission end time. 

Includes a fix for the forum link in the Mission Testers checklist. 

Known issues:
Will create two warnings if for whatever reason safestart is re-added and removed. Will not effect the time that the message is displayed. 
If in the case above, this does not update the marker. Have tried to get this working but for whatever reason it will not at this time. Might need some help. 

EDIT: https://github.com/BourbonWarfare/POTATO/pull/295/commits/9e1caa0f287c5b9b1b7fd2d663a38a66e945e722 With this commit I have added a check to `missionTest` that will give feedback if Mission Type is not selected and if Mission Length has not been entered. 