### PR TITLE
re-enable cookoff

### DIFF
--- a/addons/settings/BW_Settings.sqf
+++ b/addons/settings/BW_Settings.sqf
@@ -36,7 +36,7 @@ _settings = [
 
 [QACEGVAR(advanced_fatigue,performanceFactor), 1.4],
 [QACEGVAR(advanced_fatigue,recoveryFactor), 1.6],
-[QACEGVAR(cookoff,enable), 0],
+[QACEGVAR(cookoff,enable), 1],
 [QACEGVAR(cookoff,ammoCookoffDuration), 0.15],
 [QACEGVAR(finger,enabled), true],
 [QACEGVAR(frag,maxTrack), 5],


### PR DESCRIPTION
this being `0` means that we don't get the fire spitting out the tops of vehicles, ammo boxes dont explode with the ammo inside, vehicle ammo doesn't explode