### PR TITLE
Remove ACE_PLAYER

### DIFF
--- a/addons/missionTesting/functions/fnc_displayMenu.sqf
+++ b/addons/missionTesting/functions/fnc_displayMenu.sqf
@@ -202,7 +202,7 @@ private _missionSummary = "You are not the mission maker so this is currently un
 if (isServer && name ACE_PLAYER == _missionMaker) then {_missionSummary = "Intel" get3DENMissionAttribute "IntelOverviewText"};
 private _masterChecklistArray = nil;
 
-if(_missionMaker == name ACE_PLAYER) then {
+if(_missionMaker == name player) then {
     _masterChecklistArray = GVAR(MissionMakerChecklistMaster);
 } else {
     _masterChecklistArray = GVAR(MissionTestingChecklistMaster);


### PR DESCRIPTION
Want this to be the player unit and not the RC unit named in the case of mission testing using the "Play As Character" or using Zeus to RC a unit. This will cause the wrong menu to open.