### PR TITLE
Mission testing in 3Den & Time Keeper changes

### DIFF
--- a/addons/adminComs/XEH_postInit.sqf
+++ b/addons/adminComs/XEH_postInit.sqf
@@ -20,6 +20,6 @@ if (isServer) then {
     [{
         private _authorName = getMissionConfigValue ["author", "???"];
         private _authorPresent = (allUnits findIf {(name _x) == _authorName}) > -1;
-        ["potato_adminMsg", [format ["-Mision Maker [Present: %1]", _authorPresent], _authorName]] call CBA_fnc_globalEvent;
+        ["potato_adminMsg", [format ["-Mission Maker [Present: %1]", _authorPresent], _authorName]] call CBA_fnc_globalEvent;
     }, [], 1] call CBA_fnc_waitAndExecute;
 };

--- a/addons/missionTest/functions/fnc_onMissionSave.sqf
+++ b/addons/missionTest/functions/fnc_onMissionSave.sqf
@@ -118,7 +118,7 @@ if (_missionType == 0) then {
     _problems pushBackUnique ["Need to select mission type", ["POTATO -> Mission Testing Attributes -> Mission Type"]];
 };
 private _missionLength = getMissionConfigValue QEGVAR(missionTesting,missionTimeLength);
-if (_missionLength == "") then {
+if (_missionLength == 0) then {
     _problems pushBackUnique ["Need to set mission length value", ["POTATO -> Mission Testing Attributes -> Mission Length"]];
 };
 

--- a/addons/missionTest/functions/fnc_onMissionSave.sqf
+++ b/addons/missionTest/functions/fnc_onMissionSave.sqf
@@ -118,6 +118,7 @@ if (_missionType == 0) then {
     _problems pushBackUnique ["Need to select mission type", ["POTATO -> Mission Testing Attributes -> Mission Type"]];
 };
 private _missionLength = getMissionConfigValue QEGVAR(missionTesting,missionTimeLength);
+if (_missionLength isEqualType "") then { _missionLength = parseNumber _missionLength; }; // BWC with old attribute that was string
 if (_missionLength == 0) then {
     _problems pushBackUnique ["Need to set mission length value", ["POTATO -> Mission Testing Attributes -> Mission Length"]];
 };

--- a/addons/missionTesting/CfgEden.hpp
+++ b/addons/missionTesting/CfgEden.hpp
@@ -116,15 +116,15 @@ class Cfg3DEN {
                             displayName = "Safe Start Time Length (mins):";
 							property = QGVAR(SSTimeGiven);
                             control = QUOTE(EditShort);
-                            defaultValue = 10;
-                            typeName = "STRING";
+                            defaultValue = 0;
+                            typeName = "NUMBER";
 						};
 						class GVAR(missionTimeLength) {
                             displayName = "Mission Length (mins):";
 							property = QGVAR(missionTimeLength);
                             control = QUOTE(EditShort);
-                            defaultValue = 35;
-                            typeName = "STRING";
+                            defaultValue = 0;
+                            typeName = "NUMBER";
 						};
 					};
 				};

--- a/addons/missionTesting/CfgEden.hpp
+++ b/addons/missionTesting/CfgEden.hpp
@@ -10,11 +10,15 @@ class display3DEN {
         class MenuStrip: ctrlMenuStrip {
             class Items {
                 class PREFIX {
-                    items[] += {QGVAR(missionTesting)};
+                    items[] += {QGVAR(missionTesting),QGVAR(editorOpenMenu)};
                 };
                 class GVAR(missionTesting) {
                     text = "Mission Testing Attributes";
                     action = QUOTE(edit3DENMissionAttributes QUOTE(QGVAR(missionTestingInfo)););
+                };
+                class GVAR(editorOpenMenu) {
+                    text = "Open Testing Menu";
+                    action = QUOTE([] call FUNC(displayMenu));
                 };
             };
         };
@@ -112,14 +116,14 @@ class Cfg3DEN {
                             displayName = "Safe Start Time Length (mins):";
 							property = QGVAR(SSTimeGiven);
                             control = QUOTE(EditShort);
-                            defaultValue = "";
+                            defaultValue = 10;
                             typeName = "STRING";
 						};
 						class GVAR(missionTimeLength) {
                             displayName = "Mission Length (mins):";
 							property = QGVAR(missionTimeLength);
                             control = QUOTE(EditShort);
-                            defaultValue = "";
+                            defaultValue = 35;
                             typeName = "STRING";
 						};
 					};

--- a/addons/missionTesting/XEH_postInit.sqf
+++ b/addons/missionTesting/XEH_postInit.sqf
@@ -67,7 +67,7 @@ if (hasInterface) then { // Change briefing map's "Continue" button to red "BRIE
     {
         private _missionTagVar = getMissionConfigValue _x;
         private _missionTag = if(isNil QUOTE(_missionTagVar)) then {"NONE"} else {A_MISSION_TAGS select _missionTagVar};
-        if (_missionTag == "BRIEF ON MAP") exitWith { 
+        if (_missionTag == "BRIEF ON MAP") exitWith {
             INFO("brief on map");
             [{
                 (!isNull findDisplay 37) || {!isNull findDisplay 52} || {!isNull findDisplay 53} || {!isNull findDisplay 12}
@@ -83,3 +83,4 @@ if (hasInterface) then { // Change briefing map's "Continue" button to red "BRIE
         };
     } forEach [QGVAR(missionTag1), QGVAR(missionTag2), QGVAR(missionTag3)];
 };
+

--- a/addons/missionTesting/functions/fnc_displayMenu.sqf
+++ b/addons/missionTesting/functions/fnc_displayMenu.sqf
@@ -148,23 +148,25 @@ _menuCancel ctrlSetPosition [0.73,1,0.12,0.1];
 _menuCancel buttonSetAction "closeDialog 2;";
 _menuCancel ctrlCommit 0;
 private _menuBreifingPage = DISPLAY_TESTMENU ctrlCreate [QUOTE(RscButtonMenu),-1];
-_menuBreifingPage ctrlSetText "Brieifing";
+_menuBreifingPage ctrlSetText "Briefing";
 _menuBreifingPage ctrlSetPosition [0.60,1,0.12,0.1];
 _menuBreifingPage buttonSetAction QUOTE([] call FUNC(openBriefings));
 _menuBreifingPage ctrlCommit 0;
 
-if (!EGVAR(spectate,running)) then {
-    private _killGoToSpec = DISPLAY_TESTMENU ctrlCreate [QUOTE(RscButtonMenu),-1];
-    _killGoToSpec ctrlSetText "Goto Spec";
-    _killGoToSpec ctrlSetTooltip "Kill player and go to POTATO spectator if enabled (which it should be enabled else MM messed up)";
-    _killGoToSpec buttonSetAction QUOTE(ACE_player setDamage 1);
-    _killGoToSpec ctrlSetPosition [0.47,1,0.12,0.1];
-    _killGoToSpec ctrlCommit 0;
-} else {
-    private _keyBindInst = DISPLAY_TESTMENU ctrlCreate [QUOTE(RscText),-1];
-    _keyBindInst ctrlSetText "To reopen this menu in spectator press CTRL + SHIFT + F5";
-    _keyBindInst ctrlSetPosition [0,1,1,0.05];
-    _keyBindInst ctrlCommit 0;
+if (!is3DEN) then {
+    if (!EGVAR(spectate,running)) then {
+        private _killGoToSpec = DISPLAY_TESTMENU ctrlCreate [QUOTE(RscButtonMenu),-1];
+        _killGoToSpec ctrlSetText "Goto Spec";
+        _killGoToSpec ctrlSetTooltip "Kill player and go to POTATO spectator if enabled (which it should be enabled else MM messed up)";
+        _killGoToSpec buttonSetAction QUOTE(ACE_player setDamage 1);
+        _killGoToSpec ctrlSetPosition [0.47,1,0.12,0.1];
+        _killGoToSpec ctrlCommit 0;
+    } else {
+        private _keyBindInst = DISPLAY_TESTMENU ctrlCreate [QUOTE(RscText),-1];
+        _keyBindInst ctrlSetText "To reopen this menu in spectator press CTRL + SHIFT + F5";
+        _keyBindInst ctrlSetPosition [0,1,1,0.05];
+        _keyBindInst ctrlCommit 0;
+    };
 };
 
 private _openForumFinishedMissions = DISPLAY_TESTMENU ctrlCreate [QUOTE(RscButtonMenu),-1];
@@ -180,6 +182,9 @@ private _missionVersion = getMissionConfigValue QGVAR(missionVersion);
 private _missionPlayerCountMax = getMissionConfigValue QGVAR(playerCountMaximum);
 private _missionPlayerCountMin = getMissionConfigValue QGVAR(playerCountMinimum);
 private _missionPlayerCountRec = getMissionConfigValue QGVAR(playerCountRecommended);
+
+private _missionSSTime = getMissionConfigValue QGVAR(SSTimeGiven);
+private _missionTimeLength = getMissionConfigValue QGVAR(missionTimeLength);
 
 private _missionTag1Var = getMissionConfigValue QGVAR(missionTag1);
 private _missionTag1 = if(isNil QUOTE(_missionTag1Var)) then {"NONE"} else {A_MISSION_TAGS select _missionTag1Var};
@@ -202,7 +207,9 @@ private _missionSummary = "You are not the mission maker so this is currently un
 if (isServer && name ACE_PLAYER == _missionMaker) then {_missionSummary = "Intel" get3DENMissionAttribute "IntelOverviewText"};
 private _masterChecklistArray = nil;
 
-if(_missionMaker == name player) then {
+if (is3DEN) then {call compileScript ['\z\potato\addons\missiontesting\XEH_postInit.sqf']};
+
+if(_missionMaker == name player || is3DEN) then {
     _masterChecklistArray = GVAR(MissionMakerChecklistMaster);
 } else {
     _masterChecklistArray = GVAR(MissionTestingChecklistMaster);
@@ -220,7 +227,7 @@ _createCtrlLine4 ctrlCommit 0;
 INCREMENT_YCOORD;
 
 private _ctrlGeneralMMNotesTitle = DISPLAY_TESTMENU ctrlCreate [QUOTE(RscText),-1,CONTROL_GROUP_L];
-if(_missionMaker == name ACE_PLAYER) then {
+if(_missionMaker == name ACE_PLAYER || is3DEN) then {
     _ctrlGeneralMMNotesTitle ctrlSetText "Any other Notes for Mission Testers/Version";
 } else {
     _ctrlGeneralMMNotesTitle ctrlSetText "General Notes for Mission Maker:";
@@ -269,6 +276,11 @@ _ctrlCreateInfoBlockText = composeText [
     ,parseText "<t color='#FF8000'>MISSION PLAYER COUNT</t>"
     ,_separator
     ,parseText "<t color='#0080FF'>Min:</t> ",_missionPlayerCountMin,parseText "<t color='#0080FF'>  Rec:</t> ",_missionPlayerCountRec,parseText "<t color='#0080FF'>  Max:</t> ",_missionPlayerCountMax, lineBreak
+    ,lineBreak
+    ,parseText "<t color='#FF8000'>MISSION TIMERS</t>"
+    ,_separator
+    ,parseText "<t color='#0080FF'>Mission SS Time (mins):</t> ",_missionSSTime, linebreak
+    ,parseText "<t color='#0080FF'>Mission Run Time (mins):</t> ",_missionTimeLength, linebreak
     ,lineBreak
     ,parseText "<t color='#FF8000'>MISSION TAGS</t>"
     ,_separator

--- a/addons/missionTesting/functions/fnc_displayMenu.sqf
+++ b/addons/missionTesting/functions/fnc_displayMenu.sqf
@@ -183,8 +183,8 @@ private _missionPlayerCountMax = getMissionConfigValue QGVAR(playerCountMaximum)
 private _missionPlayerCountMin = getMissionConfigValue QGVAR(playerCountMinimum);
 private _missionPlayerCountRec = getMissionConfigValue QGVAR(playerCountRecommended);
 
-private _missionSSTime = getMissionConfigValue QGVAR(SSTimeGiven);
-private _missionTimeLength = getMissionConfigValue QGVAR(missionTimeLength);
+private _missionSSTime = str getMissionConfigValue QGVAR(SSTimeGiven);
+private _missionTimeLength = str getMissionConfigValue QGVAR(missionTimeLength);
 
 private _missionTag1Var = getMissionConfigValue QGVAR(missionTag1);
 private _missionTag1 = if(isNil QUOTE(_missionTag1Var)) then {"NONE"} else {A_MISSION_TAGS select _missionTag1Var};

--- a/addons/missionTesting/functions/fnc_generateReport.sqf
+++ b/addons/missionTesting/functions/fnc_generateReport.sqf
@@ -70,6 +70,8 @@ private _missionSummary = "Intel" get3DENMissionAttribute "IntelOverviewText";
 private _missionPlayerCountMax = getMissionConfigValue QGVAR(playerCountMaximum);
 private _missionPlayerCountMin = getMissionConfigValue QGVAR(playerCountMinimum);
 private _missionPlayerCountRec = getMissionConfigValue QGVAR(playerCountRecommended);
+private _missionSSTime = getMissionConfigValue QGVAR(SSTimeGiven);
+private _missionTimeLength = getMissionConfigValue QGVAR(missionTimeLength);
 private _missionTag1Var = getMissionConfigValue QGVAR(missionTag1);
 private _missionTag1 = if(isNil QUOTE(_missionTag1Var)) then {"NONE"} else {A_MISSION_TAGS select _missionTag1Var};
 private _missionTag2Var = getMissionConfigValue QGVAR(missionTag2);
@@ -89,11 +91,11 @@ private _masterChecklistArray = nil;
 private _textArray = [];
 private _textArrayShort = [];
 
-if(_missionMaker == name ACE_PLAYER) then {
+if(_missionMaker == name ACE_PLAYER || is3DEN) then {
     _masterChecklistArray = GVAR(MissionMakerChecklistMaster);
     S_NEWTEXTLINE ["[size=200][u][b]Mission : [color=#FF4000]%1[/color][/b][/u]   [b][u]Type : [color=#FF4000]%2[/color][/u][/b][/size]", _missionName, _missionType];
     S_NEWTEXTLINE ["[size=200][u][b]Version : [color=#FF4000]%1[/color][/b][/u][/size]   [size=150][u][b]BWMF Version : [color=#FF4000]%2[/color][/b][/u][/size]",_missionVersion,_missionFrameworkDate];
-    S_NEWTEXTLINE ["[size=150]Mission Tags : [color=#FF4000]%1, %2, %3[/color]  [/size] ",_missionTag1,_missionTag2,_missionTag3];
+    S_NEWTEXTLINE ["[size=150]Mission Tags : [color=#FF4000]%1, %2, %3[/color]  SS Length : [color=#FF4000]%4[/color]  Mission Length : [color=#FF4000]%5[/color][/size] ",_missionTag1,_missionTag2,_missionTag3,_missionSSTime,_missionTimeLength];
     if (isServer && name ACE_PLAYER == _missionMaker) then {
         S_NEWTEXTLINE ["[size=150][u]Mission Summary (As shown in Slotting screen, Inc of Ratio if TvT) :[/u][/size]"];
         S_NEWTEXTLINE ["[color=#FF4000]%1[/color]",_missionSummary];

--- a/addons/safeStart/XEH_postInit.sqf
+++ b/addons/safeStart/XEH_postInit.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 
 if (isServer) then {
-    // Setting to sync to ace_fortify        
+    // Setting to sync to ace_fortify
     ["potato_safeStartOn", {
         if (!GVAR(syncFortify)) exitWith {};
         missionNamespace setVariable [QACEGVAR(fortify,fortifyAllowed), true, true];
@@ -28,4 +28,18 @@ if (didJip) then {
             };
         }
     ] call CBA_fnc_waitUntilAndExecute;
+};
+
+if(hasInterface) then {
+    [QGVAR(addMissionEndMarkerLocal),{
+        params["_markerStr"];
+        TRACE_1("Params",_this);
+
+        private _markerName = "_USER_DEFINED missionEndMarker_0";
+        private _markerExists = allMapMarkers find _markerName;
+
+        if !(_markerExists isEqualTo -1) then {deleteMarkerLocal _markerName;};
+
+        _markerStr call BIS_fnc_stringToMarkerLocal;
+    }] call CBA_fnc_addEventHandler;
 };

--- a/addons/safeStart/functions/fnc_missionTimeWarning.sqf
+++ b/addons/safeStart/functions/fnc_missionTimeWarning.sqf
@@ -20,6 +20,7 @@ if !(isServer) exitWith {};
 params [];
 
 private _missionLength = getMissionConfigValue [QEGVAR(missionTesting,missionTimeLength),0];
+if (_missionLength isEqualType "") then { _missionLength = parseNumber _missionLength; }; // BWC with old attribute that was string
 private _missionLengthSec = _missionLength * 60;
 
 if (_missionLength == 0) then {

--- a/addons/safeStart/functions/fnc_missionTimeWarning.sqf
+++ b/addons/safeStart/functions/fnc_missionTimeWarning.sqf
@@ -19,6 +19,18 @@ if !(isServer) exitWith {};
 
 params [];
 
+private _missionLength = getMissionConfigValue [QEGVAR(missionTesting,missionTimeLength),0];
+private _missionLengthSec = _missionLength * 60;
+
+if (_missionLength == 0) then {
+    private _missionType = getMissionConfigValue QEGVAR(missionTesting,missionType);
+    switch (_missionType) do {
+        case 1: {_missionLength = 65};
+        case 2: {_missionLength = 35};
+        default {if(true) exitWith {TRACE_1("Something is seriously wrong, exiting timer")}};
+    };
+};
+
 missionNamespace setVariable [QGVAR(missionstartTime), CBA_missionTime, true];
 TRACE_1("Mission start time",QGVAR(missionstartTime));
 
@@ -26,8 +38,7 @@ TRACE_1("Mission start time",QGVAR(missionstartTime));
 [
     {
         private _missionStartTime = missionNamespace getVariable QGVAR(missionstartTime);
-        private _missionLength = parseNumber getMissionConfigValue QEGVAR(missionTesting,missionTimeLength) * 60;
-        (CBA_missionTime >= (_missionStartTime + _missionLength - 900))  || !(isNil QGVAR(timerID))
+        (CBA_missionTime >= (_missionStartTime + _missionLengthSec - 900))  || !(isNil QGVAR(timerID))
     },
     {
         if (isNil QGVAR(timerID)) then {
@@ -60,7 +71,7 @@ TRACE_1("Mission start time",QGVAR(missionstartTime));
             ] call CBA_fnc_waitAndExecute;
         };
     },
-    []
+    [_missionLengthSec]
 ] call CBA_fnc_waitUntilAndExecute;
 
 // Add Map Marker at 0,0 position with mission end time.
@@ -68,9 +79,8 @@ TRACE_1("Mission start time",QGVAR(missionstartTime));
 // Check if mission end map marker already exists.
 
 private _startTime = daytime;
-private _missionLengthDec = parseNumber getMissionConfigValue QEGVAR(missionTesting,missionTimeLength) / 60;
-private _endTimeDec = _startTime + _missionLengthDec;
+private _endTimeDec = _startTime + (_missionLength / 60);
 private _endTime = [_endTimeDec] call BIS_fnc_timeToString;
 
-private _string = format ["|missionEndMarker_0|[0,0,0.0000]|mil_warning|ICON|[1,1]|0|Solid|colorCivilian|1|Mission End Time - %1",_endTime];
-[_string] call BIS_fnc_stringToMarker;
+private _string = format ["|_USER_DEFINED missionEndMarker_0|[0,0,0.0000]|mil_warning|ICON|[1,1]|0|Solid|colorCivilian|1|Mission End Time - %1",_endTime];
+[QGVAR(addMissionEndMarkerLocal),[_string]] call CBA_fnc_globalEventJIP;

--- a/addons/safeStart/script_component.hpp
+++ b/addons/safeStart/script_component.hpp
@@ -1,9 +1,9 @@
 #define COMPONENT safestart
 #include "\z\potato\addons\core\script_mod.hpp"
 
-//#define DEBUG_MODE_FULL
-//#define DISABLE_COMPILE_CACHE
-//#define ENABLE_PERFORMANCE_COUNTERS
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
+#define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_SAFESTART
     #define DEBUG_MODE_FULL

--- a/addons/safeStart/script_component.hpp
+++ b/addons/safeStart/script_component.hpp
@@ -1,9 +1,9 @@
 #define COMPONENT safestart
 #include "\z\potato\addons\core\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
-#define ENABLE_PERFORMANCE_COUNTERS
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_SAFESTART
     #define DEBUG_MODE_FULL


### PR DESCRIPTION
Have added the ability to open the mission making checklist in 3Den. Available through [POTATO --> Open Testing Menu]

 - Time Keeper has been changed so that we no longer get weird values in the Attributes Menu. The defaults have been set to 0 in the attributes menu.
 - This means that they will also report in missionTest module if a value has been set. 
 - The time keeper now creates local markers so that they it can be moved around the map to make it easier to reference. 
       - I am a little concerned about the method used here. I don't believe that it will create a boat load of new markers for all players in the same spot, but it needs testing.
- Briefing is not longer Brieifing (Thanks kilo).
- Mission timers are also now in the MM report and will show in the testing menu for quicker reference. 
- The time keeper has been given some default values in the case that the mission length attribute is not set correctly by the MM. 35 mins for a TvT and 65 mins for a COOP.