### PR TITLE
Clean up Spiderholes + old ACE trenches

### DIFF
--- a/addons/miscFixes/CfgEventHandlers.hpp
+++ b/addons/miscFixes/CfgEventHandlers.hpp
@@ -3,3 +3,8 @@ class Extended_PostInit_EventHandlers {
         serverInit = QUOTE(call COMPILE_SCRIPT(XEH_serverPostInit));
     };
 };
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+    };
+};

--- a/addons/miscFixes/XEH_postInit.sqf
+++ b/addons/miscFixes/XEH_postInit.sqf
@@ -1,3 +1,5 @@
+// Temp fix to remove old Ace trenches and SOG spider holes
+
 if (hasInterface) then {
     [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_trenches_digEnvelopeSmall"]] call ace_interact_menu_fnc_removeActionFromClass;
     [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_trenches_digEnvelopeBig"]] call ace_interact_menu_fnc_removeActionFromClass;

--- a/addons/miscFixes/XEH_postInit.sqf
+++ b/addons/miscFixes/XEH_postInit.sqf
@@ -1,9 +1,10 @@
 // Temp fix to remove old Ace trenches and SOG spider holes
 
-if (hasInterface) then {
+if (hasInterface or didJIP) then {
     [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_trenches_digEnvelopeSmall"]] call ace_interact_menu_fnc_removeActionFromClass;
     [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_trenches_digEnvelopeBig"]] call ace_interact_menu_fnc_removeActionFromClass;
     [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_compat_sog_digSpiderhole"]] call ace_interact_menu_fnc_removeActionFromClass;
     [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_compat_sog_digSpiderholeAngled"]] call ace_interact_menu_fnc_removeActionFromClass;
     [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_compat_sog_digSpiderholeDual"]] call ace_interact_menu_fnc_removeActionFromClass;
+    TRACE_1("Removing spiderholes");
 };

--- a/addons/miscFixes/XEH_postInit.sqf
+++ b/addons/miscFixes/XEH_postInit.sqf
@@ -1,0 +1,7 @@
+if (hasInterface) then {
+    [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_trenches_digEnvelopeSmall"]] call ace_interact_menu_fnc_removeActionFromClass;
+    [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_trenches_digEnvelopeBig"]] call ace_interact_menu_fnc_removeActionFromClass;
+    [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_compat_sog_digSpiderhole"]] call ace_interact_menu_fnc_removeActionFromClass;
+    [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_compat_sog_digSpiderholeAngled"]] call ace_interact_menu_fnc_removeActionFromClass;
+    [typeOf player, 1, ["ACE_SelfActions","ACE_Equipment","ace_compat_sog_digSpiderholeDual"]] call ace_interact_menu_fnc_removeActionFromClass;
+};


### PR DESCRIPTION
Removes old ACE trenches + Spiderholes from Entrenching tool globally. 

Draft for the moment. I am doing this on a Mac and can't test at all. But like, it might work. I'm going off of theory and guesses. I'll test it when I'm home and fix it if I need to. 