### PR TITLE
Normalize water floatation for vanilla heavy-lift helicopters to match CUP 

### DIFF
--- a/addons/miscFixes/CfgVehicles.hpp
+++ b/addons/miscFixes/CfgVehicles.hpp
@@ -50,6 +50,11 @@ class CfgVehicles {
         class TransportBackpacks {};
     };
 
+    // Make vanilla Chinook and EH302 (IDAP/FIA transport heli) float on water. Matches CUP Chinook/CH-53e and other heavy lift helos. Should be extended to all helicopters from mods that could feasibly float. 
+    class Helicopter_Base_H;
+	class Heli_Transport_03_base_F: Helicopter_Base_H {waterLeakiness=0.1;};
+    class Heli_Transport_02_base_F: Helicopter_Base_H {waterLeakiness=0.1;};
+
     // Fix CBA XEH Fallback Code for misc logic/objects that don't support it: [Not needed for RHS as of 4.6]
     // x3 = [true] call CBA_fnc_supportMonitor;
     // {

--- a/addons/miscFixes/CfgVehicles.hpp
+++ b/addons/miscFixes/CfgVehicles.hpp
@@ -50,7 +50,7 @@ class CfgVehicles {
         class TransportBackpacks {};
     };
 
-    // Make vanilla Chinook and EH302 (IDAP/FIA transport heli) float on water. Matches CUP Chinook/CH-53e and other heavy lift helos. Should be extended to all helicopters from mods that could feasibly float. 
+    // Make vanilla Chinook and EH302 (IDAP/FIA transport heli) float on water. Matches CUP Chinook/CH-53e and other heavy lift helos. Should be extended to all helicopters from mods that could feasibly float. Direction on BIS method from Steam Workshop user "crub"
     class Helicopter_Base_H;
 	class Heli_Transport_03_base_F: Helicopter_Base_H {waterLeakiness=0.1;};
     class Heli_Transport_02_base_F: Helicopter_Base_H {waterLeakiness=0.1;};


### PR DESCRIPTION
Make vanilla "Chinook" (aka Huron) and EH302 (IDAP/FIA heavy transport heli) float on water. 
This now matches CUP Chinook/CH-53e heavy lift helos. 

This change should eventually be extended to all helicopters from mods that could feasibly "float" (aka hover on surface of water for pseudo-helocast extract). I just don't currently have time to go through the editor and find all helos that should do this. I'll try to outsource it. 