### PR TITLE
update Client ID for rich presence

### DIFF
--- a/addons/core/BW_CfgDiscordRichPresence.hpp
+++ b/addons/core/BW_CfgDiscordRichPresence.hpp
@@ -1,6 +1,6 @@
 // Discord Rich Presence
 class CfgDiscordRichPresence {
-    applicationID="1059590927930368170";                                    // Provided by discord
+    applicationID="1115795653860278354";                                    // Provided by discord
     defaultDetails="BW ARMA";                                               // Upper text
     defaultState="https://bourbonwarfare.com/";                             // Lower text  
     defaultLargeImageKey="bwlogo";                                          // Large image


### PR DESCRIPTION
updates Rich Presence client ID so as not to conflict with BadWolf's new bot system. Uses new Discord Developer Application made expressly for the purpose of Rich Presence without also doing other, silly, things like running bots. 

@PabstMirror 
- Ping kilo before/after you merge and whatever modpack update that this becomes part of, goes live. We need to update the Application title on the Discord dev portal from "BW rich presence (temp)" back to "BW ARMA" and rename the current "BW ARMA" to "potato_bot"