### PR TITLE
feat: automatic Safestart off

### DIFF
--- a/addons/missionTesting/CfgEden.hpp
+++ b/addons/missionTesting/CfgEden.hpp
@@ -118,6 +118,13 @@ class Cfg3DEN {
                             control = QUOTE(EditShort);
                             defaultValue = 0;
                             typeName = "NUMBER";
+                        };
+						class GVAR(ForceSS) {
+                            displayName = "Enforce safestart time:";
+							property = QGVAR(ForceSS);
+                            control = QUOTE(Checkbox);
+                            defaultValue = QUOTE(false);
+                            expression = "_this setVariable ['%s',_value];";
 						};
 						class GVAR(missionTimeLength) {
                             displayName = "Mission Length (mins):";

--- a/addons/safeStart/XEH_postInit.sqf
+++ b/addons/safeStart/XEH_postInit.sqf
@@ -15,6 +15,27 @@ if (isServer) then {
         {time > 0},
         { [GVAR(enabled)] call FUNC(toggleSafeStart); }
     ] call CBA_fnc_waitUntilAndExecute;
+
+	if (getMissionConfigValue "potato_missionTesting_forceSS") then {
+		if (parseNumber (GetMissionConfigValue "potato_missionTesting_SSTimeGiven") isEqualTo 0) exitWith {"[BWMF] WARNING: THIS MISSION IS LIVE IMMEDIATELY" remoteExec ["systemChat", 0];};
+		
+		[format ["[BWMF] Safe start time is enforced: %1 minutes",GetMissionConfigValue "potato_missionTesting_SSTimeGiven"]] remoteExec ["systemChat", 0];
+		
+		[
+			{CBA_missionTime >= ((parseNumber (GetMissionConfigValue "potato_missionTesting_SSTimeGiven") * 60) / 2)},
+			{ 
+				"[BWMF] Half of safe start time remains" remoteExec ["systemChat", 0];	
+			}
+		] call CBA_fnc_waitUntilAndExecute; 
+		
+		[
+			{CBA_missionTime >= (parseNumber (GetMissionConfigValue "potato_missionTesting_SSTimeGiven") * 60)},
+			{ 
+				"[BWMF] Safe start time has expired" remoteExec ["systemChat", 0];
+				["potato_safeStartOff"] call CBA_fnc_globalEvent;
+			}
+		] call CBA_fnc_waitUntilAndExecute;
+	};
 };
 
 if (didJip) then {


### PR DESCRIPTION
fixes #445 

backport from https://github.com/tanaaKa/POTATO/blob/788ad0cf7e6f6d1bba964aeaf4c0f68625f7cb48/addons/safeStart/XEH_postInit.sqf

adds an Eden toggle to "force" safestart, making it automatically turn off when time expires

also provides reminder at halfway through safestart

maybe we make this automatically turned on for TvTs somehow eventually

i haven't tested this yet, so draft