### PR TITLE
Add body garbage collection

### DIFF
--- a/addons/bodyCleanup/$PBOPREFIX$
+++ b/addons/bodyCleanup/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\potato\addons\bodyCleanup

--- a/addons/bodyCleanup/CfgEventhandlers.hpp
+++ b/addons/bodyCleanup/CfgEventhandlers.hpp
@@ -1,0 +1,17 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        serverinit = QUOTE(call COMPILE_SCRIPT(XEH_serverPostInit));
+    };
+};

--- a/addons/bodyCleanup/XEH_PREP.hpp
+++ b/addons/bodyCleanup/XEH_PREP.hpp
@@ -1,0 +1,10 @@
+TRACE_1("",QUOTE(ADDON));
+
+PREP(initCell);
+PREP(onKill);
+PREP(cleanupPFH);
+PREP(getPlayerViewCones);
+PREP(updateCellPFH);
+PREP(debugPFH);
+PREP(cleanCell);
+PREP(uncleanCell);

--- a/addons/bodyCleanup/XEH_preInit.sqf
+++ b/addons/bodyCleanup/XEH_preInit.sqf
@@ -1,0 +1,12 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+#include "initSettings.sqf"
+
+ADDON = true;
+

--- a/addons/bodyCleanup/XEH_preStart.sqf
+++ b/addons/bodyCleanup/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/bodyCleanup/XEH_serverPostInit.sqf
+++ b/addons/bodyCleanup/XEH_serverPostInit.sqf
@@ -1,0 +1,42 @@
+#include "script_component.hpp"
+
+#ifndef DEBUG_MODE_FULL
+if (hasInterface) exitWith {}; // ignore for mission makers
+#endif
+
+["CBA_settingsInitialized", {
+    TRACE_3("CBA_settingsInitialized",GVAR(enable),GVAR(hideInsteadOfDelete),GVAR(allowVehicles));
+    if !(GVAR(enable)) exitWith {};
+
+    GVAR(cells) = createHashMap;
+    GVAR(run) = true;
+
+    [{
+        TRACE_1("cleanup",GVAR(run));
+        if (GVAR(run)) then {
+            call FUNC(cleanupPFH);
+        };
+    }, CLEANUP_FREQUENCY] call CBA_fnc_addPerFrameHandler;
+
+    [{
+        params ["_args"];
+        _args params ["_lastUpdate"];
+
+        private _dt = CBA_missionTime - _lastUpdate;
+        _args set [0, CBA_missionTime];
+
+        TRACE_2("update",GVAR(run),_dt);
+        if (GVAR(run)) then {
+            [_dt] call FUNC(updateCellPFH);
+        };
+    }, UPDATE_FREQUENCY, [CBA_missionTime]] call CBA_fnc_addPerFrameHandler;
+
+    addMissionEventHandler ["EntityKilled", { _this call FUNC(onKill); }];
+
+    #ifdef DEBUG_MODE_FULL
+    findDisplay 12 displayCtrl 51 ctrlAddEventHandler ["Draw", {
+        _this call FUNC(debugPFH);
+    }];
+    #endif
+
+}] call CBA_fnc_addEventHandler;

--- a/addons/bodyCleanup/config.cpp
+++ b/addons/bodyCleanup/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"potato_core"};
+        author = "Potato";
+        authors[] = {"Bailey <3"};
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/bodyCleanup/functions/fnc_cleanCell.sqf
+++ b/addons/bodyCleanup/functions/fnc_cleanCell.sqf
@@ -1,0 +1,39 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Bailey
+ * Cleans a cell: If deleting bodies enabled, deletes all objects and removes cell from hashmap
+ * If hiding bodies enabled, hides all bodies and disables simulation
+ *
+ * Arguments:
+ * Cell key <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call potato_bodyCleanup_fnc_cleanCell;
+ *
+ * Public: No
+ */
+params ["_key"];
+
+private _units = (GVAR(cells) get _key) select 1;
+{
+    if (_x isKindOf "CAManBase") then {
+        if (GVAR(hideInsteadOfDelete)) then {
+            hideObjectGlobal _x;
+            _x enableSimulationGlobal false;
+        } else {
+            deleteVehicle _x;
+        };
+    };
+} forEach _units;
+
+if (GVAR(hideInsteadOfDelete)) then {
+    private _cell = GVAR(cells) get _key;
+    _cell set [3, true];
+    GVAR(cells) set [_key, _cell];
+} else {
+    GVAR(cells) deleteAt _key;
+};

--- a/addons/bodyCleanup/functions/fnc_cleanupPFH.sqf
+++ b/addons/bodyCleanup/functions/fnc_cleanupPFH.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Bailey
+ * Cleans up cells
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call potato_bodyCleanup_fnc_cleanupPFH;
+ *
+ * Public: No
+ */
+
+private _cellsToCleanup = [];
+{
+    _y params ["_sideLength", "_deadUnits", "_lastTimeObserved"];
+    if (CBA_missionTime - _lastTimeObserved >= TIME_BEFORE_CLEANUP) then {
+        _cellsToCleanup pushBack [_x];
+    };
+} forEach GVAR(cells);
+
+{
+    _x params ["_key"];
+    [_key] call FUNC(cleanCell);
+} forEach _cellsToCleanup;

--- a/addons/bodyCleanup/functions/fnc_debugPFH.sqf
+++ b/addons/bodyCleanup/functions/fnc_debugPFH.sqf
@@ -1,0 +1,75 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Bailey
+ * Draws debug information for every cell
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call potato_bodyCleanup_fnc_debugPFH;
+ *
+ * Public: No
+ */
+params ["_map"];
+{
+    _y params ["_sideLength", "_deadUnits", "_lastTimeObserved", "_isHidden", "_position"];
+    _map drawIcon [
+		"#(rgb,1,1,1)color(1,1,1,1)",
+		[0,0,1,1],
+		_position,
+		0,
+		0,
+		0,
+		format ["%1", 0 max floor (TIME_BEFORE_CLEANUP - (CBA_missionTime - _lastTimeObserved))],
+        false,
+        -1,
+        "TahomaB",
+        "center"
+	];
+    _map drawRectangle [
+        _position,
+        _sideLength / 2,
+        _sideLength / 2,
+        0,
+        [1, 0, 0, 1],
+        ""
+    ];
+} forEach GVAR(cells);
+
+private _views = call FUNC(getPlayerViewCones);
+{
+    _x params ["_origin", "_viewDir", "_polar", "_fov"];
+    _polar params ["", "_azimuth"];
+
+    private _length = MAX_CLEANUP_DISTANCE / cos _fov;
+
+    private _left = (_azimuth - _fov);
+    private _right = (_azimuth + _fov);
+
+    private _h2 = [sin _left, cos _left, 0] vectorMultiply _length;
+    private _h3 = [sin _right, cos _right, 0] vectorMultiply _length;
+
+    private _p1 = _origin;
+    private _p2 = _origin vectorAdd _h2;
+    private _p3 = _origin vectorAdd _h3;
+
+    _map drawIcon [
+		"#(rgb,1,1,1)color(1,1,1,1)",
+		[0,1,1,1],
+		_p1,
+		15,
+		15,
+		0
+	];
+
+    _map drawTriangle [
+        [_p1, _p2, _p3],
+        [0, 1, 0, 1],
+        ""
+    ];
+} forEach _views;

--- a/addons/bodyCleanup/functions/fnc_getPlayerViewCones.sqf
+++ b/addons/bodyCleanup/functions/fnc_getPlayerViewCones.sqf
@@ -1,0 +1,48 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Bailey
+ * Returns array of view cones of all players
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * View Cones <ARRAY>
+ *
+ * Example:
+ * [] call potato_bodyCleanup_fnc_getPlayerViewCones;
+ *
+ * Public: No
+ */
+
+private _viewCones = [];
+
+private _players = allPlayers select {
+    alive _x &&
+    _x isEqualTo vehicle _x &&
+    !(_x isKindOf "VirtualMan_F")
+};
+
+private _sampleSize = ceil (MAX_SAMPLE_SIZE * count _players);
+
+// Sample a random selection of players to determine if anyone can see any cells
+// Since cleanup isnt immediate, we assume that we will sample enough players such that in the majority
+// of cases we won't accidentally delete something within view
+private _sample = [];
+for "_i" from 0 to _sampleSize do {
+    private _index = floor random count _players;
+    _sample pushBack (_players select _index);
+    _players deleteAt _index;
+};
+
+{
+    _viewCones pushBack [
+        getPosASLVisual _x,
+        getCameraViewDirection _x,
+        (getCameraViewDirection _x) call CBA_fnc_vect2polar,
+        ARMA_DEFAULT_FOV
+    ];
+} forEach _sample;
+
+_viewCones

--- a/addons/bodyCleanup/functions/fnc_initCell.sqf
+++ b/addons/bodyCleanup/functions/fnc_initCell.sqf
@@ -1,0 +1,45 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Bailey
+ * Initialises grid cell which bodies are kept in
+ *
+ * Arguments:
+ * 0: The side length of the grid cell <NUMBER>
+ * 1: Units to inititally populate cell with <ARRAY>
+ * 2: Position of cell in world <ARRAY>
+ *
+ * Return Value:
+ * Cell key <ARRAY>
+ * Cell data <ARRAY>
+ *  Array in form ["_sideLength", "_deadUnits", "_lastTimeObserved", "_isHidden", "_position", "_key"]
+ *                [Number,        Array,        Number,              Boolean,     Array,       Array]
+ *
+ * Example:
+ * [50] spawn potato_bodyCleanup_fnc_initGrid;
+ *
+ * Public: No
+ */
+params ["_sideLength", "_position"];
+
+private _key = [
+    floor ((_position select 0) / _sideLength),
+    floor ((_position select 1) / _sideLength),
+    0
+];
+
+// If cell exists in our hashmap, then we just return the cell that already exists rather than update
+if (_key in GVAR(cells)) exitWith {
+    [_key, GVAR(cells) get _key]
+};
+
+private _cell = [];
+
+_cell pushBack _sideLength;
+_cell pushBack [];
+_cell pushBack CBA_missionTime;
+_cell pushBack false;
+_cell pushBack ((_key vectorMultiply _sideLength) vectorAdd [_sideLength / 2, _sideLength / 2, 0]);
+_cell pushBack _key;
+
+[_key, _cell]

--- a/addons/bodyCleanup/functions/fnc_onKill.sqf
+++ b/addons/bodyCleanup/functions/fnc_onKill.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Bailey
+ * Adds entity to dead pool for future cleanup
+ *
+ * Arguments:
+ * 0: The entity which was killed <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [player] spawn potato_bodyCleanup_fnc_onKill;
+ *
+ * Public: No
+ */
+params ["_entity"];
+
+private _cell = [CELL_SIZE, getPosASLVisual _entity] call FUNC(initCell);
+_cell params ["_key", "_data"];
+
+private _deadUnits = _data select 1;
+_deadUnits pushBack _entity;
+_cell set [1, _deadUnits];
+
+GVAR(cells) set [_key, _data];
+

--- a/addons/bodyCleanup/functions/fnc_uncleanCell.sqf
+++ b/addons/bodyCleanup/functions/fnc_uncleanCell.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Bailey
+ * Uncleans a cell: If the cell is "hidden", then we unhide the bodies and re-enable simulation
+ *
+ * Arguments:
+ * Cell key <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call potato_bodyCleanup_fnc_uncleanCell;
+ *
+ * Public: No
+ */
+params ["_key"];
+
+if (GVAR(hideInsteadOfDelete)) then {
+    private _cell = GVAR(cells) get _key;
+    _cell set [3, false];
+    _cell set [2, CBA_missionTime];
+    GVAR(cells) set [_key, _cell];
+
+    private _units = _cell select 1;
+    {
+        if (_x isKindOf "CAManBase") then {
+            _x hideObjectGlobal false;
+            _x enableSimulationGlobal true;
+        };
+    } forEach _units;
+};

--- a/addons/bodyCleanup/functions/fnc_updateCellPFH.sqf
+++ b/addons/bodyCleanup/functions/fnc_updateCellPFH.sqf
@@ -1,0 +1,127 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Bailey
+ * Updates cells
+ *
+ * Arguments:
+ * Time since last update <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call potato_bodyCleanup_fnc_updateCellPFH;
+ *
+ * Public: No
+ */
+params ["_dt"];
+
+private _inTriangle = {
+    params ["_p", "_p1", "_p2", "_p3"];
+    _p params ["_px", "_py"];
+    _p1 params ["_x1", "_y1"];
+    _p2 params ["_x2", "_y2"];
+    _p3 params ["_x3", "_y3"];
+
+    private _d1 = (_px - _x2) * (_y1 - _y2) - (_x1 - _x2) * (_py - _y2);
+    private _d2 = (_px - _x3) * (_y2 - _y3) - (_x2 - _x3) * (_py - _y3);
+    private _d3 = (_px - _x1) * (_y3 - _y1) - (_x3 - _x1) * (_py - _y1);
+
+    private _hasNeg = (_d1 < 0) || (_d2 < 0) || (_d3 < 0);
+    private _hasPos = (_d1 > 0) || (_d2 > 0) || (_d3 > 0);
+    
+    !(_hasNeg && _hasPos)
+};
+
+private _viewCones = call FUNC(getPlayerViewCones);
+// We will cull as many cells as we can to avoid the O(n*m) complexity
+private _cellsToCheck = values GVAR(cells);
+
+// First: Remove cells that lay outside of maximum visible range of any unit
+private _meanPosition = [0, 0, 0];
+{
+    _x params ["_position"];
+    _meanPosition = _meanPosition vectorAdd _position;
+} forEach _viewCones;
+_meanPosition = _meanPosition vectorMultiply (1 / count _viewCones);
+
+private _maxDistance = 0;
+{
+    _x params ["_position"];
+    _maxDistance = _maxDistance max (_position vectorDistance _meanPosition);
+} forEach _viewCones;
+_maxDistance = _maxDistance + MAX_CLEANUP_DISTANCE;
+
+// Cull cells that lay outside of bounding circle of all units
+_cellsToCheck = _cellsToCheck select {
+    _x params ["", "", "", "", "_position"];
+    (_position vectorDistance _meanPosition) <= _maxDistance
+};
+
+// Determine which cells can be seen
+private _visibleCells = [];
+{
+    _x params ["_origin", "_viewDirection", "_polar", "_fov"];
+    _polar params ["", "_azimuth"];
+
+    {
+        _x params ["_sideLength", "", "", "_isHidden", "_cellCenter", "_key"];
+        // Ignore all cells out of bounds
+        if ((_origin vectorDistance _cellCenter) > MAX_CLEANUP_DISTANCE) then {
+            continue;
+        };
+
+        // If we are within the minimum cleanup distance, then we will update the cell
+        if ((_origin vectorDistance _cellCenter) <= MIN_CLEANUP_DISTANCE) then {
+            _visibleCells pushBack _x;
+            continue;
+        };
+
+        // First: Cull any cells that aren't in the direction we are facing
+        private _directionToCell = _origin vectorFromTo _cellCenter;
+        private _dot = _viewDirection vectorDotProduct _directionToCell;
+
+        // If dot product < 0, then we are looking away from the cell so we don't consider it
+        if (_dot <= 0) then {
+            continue;
+        };
+
+        private _length = MAX_CLEANUP_DISTANCE / cos _fov;
+
+        // Second: Determine if cell is within bounding box of FOV
+        private _left = (_azimuth - _fov);
+        private _right = (_azimuth + _fov);
+
+        private _h2 = [sin _left, cos _left, 0] vectorMultiply _length;
+        private _h3 = [sin _right, cos _right, 0] vectorMultiply _length;
+
+        private _p1 = _origin;
+        private _p2 = _origin vectorAdd _h2;
+        private _p3 = _origin vectorAdd _h3;
+
+        private _minX = (_p1 select 0) min (_p2 select 0) min (_p3 select 0);
+        private _maxX = (_p1 select 0) max (_p2 select 0) max (_p3 select 0);
+        private _minY = (_p1 select 1) min (_p2 select 1) min (_p3 select 1);
+        private _maxY = (_p1 select 1) max (_p2 select 1) max (_p3 select 1);
+
+        if !(_minX < (_cellCenter select 0) - _sideLength / 2 && _maxX >= (_cellCenter select 0) + _sideLength / 2 &&
+             _minY < (_cellCenter select 1) - _sideLength / 2 && _maxY >= (_cellCenter select 1) + _sideLength / 2) then {
+            continue;
+        };
+
+        // Third: Determine if cell lays within the triangle
+        // We only check if the cell's center is within the FOV. This is for optimisation. We miss a few, but no biggie
+        if ([_cellCenter, _p1, _p2, _p3] call _inTriangle) then {
+            _visibleCells pushBack _x;
+        };
+    } forEach _cellsToCheck;
+} forEach _viewCones;
+
+{
+    _x params ["", "", "", "_isHidden", "", "_key"];
+    _x set [2, CBA_missionTime];
+    if (_isHidden) then {
+        [_key] call FUNC(uncleanCell);
+    };
+} forEach _visibleCells;

--- a/addons/bodyCleanup/functions/script_component.hpp
+++ b/addons/bodyCleanup/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\z\potato\addons\bodyCleanup\script_component.hpp"

--- a/addons/bodyCleanup/initSettings.sqf
+++ b/addons/bodyCleanup/initSettings.sqf
@@ -16,12 +16,3 @@
     true, // isGlobal
     {[QGVAR(hideInsteadOfDelete), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
 ] call CBA_settings_fnc_init;
-[
-    QGVAR(allowVehicles),
-    "CHECKBOX",
-    ["Operate on Vehicles", "Whether or not dead vehicles are considered for cleanup"],
-    ["POTATO - Body Cleanup", "Body Cleanup"],
-    false, // default value
-    true, // isGlobal
-    {[QGVAR(allowVehicles), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
-] call CBA_settings_fnc_init;

--- a/addons/bodyCleanup/initSettings.sqf
+++ b/addons/bodyCleanup/initSettings.sqf
@@ -1,0 +1,27 @@
+[
+    QGVAR(enable),
+    "CHECKBOX",
+    ["Enable Body Cleanup", "Enable/Disable whether or not AI bodies will be automatically cleaned up upon their deaths"],
+    ["POTATO - Body Cleanup", "Body Cleanup"],
+    false, // default value
+    true, // isGlobal
+    {[QGVAR(enable), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+[
+    QGVAR(hideInsteadOfDelete),
+    "CHECKBOX",
+    ["Hide bodies", "Whether or not we will hide and disable simulation on dead bodies instead of deleting them outright"],
+    ["POTATO - Body Cleanup", "Body Cleanup"],
+    false, // default value
+    true, // isGlobal
+    {[QGVAR(hideInsteadOfDelete), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;
+[
+    QGVAR(allowVehicles),
+    "CHECKBOX",
+    ["Operate on Vehicles", "Whether or not dead vehicles are considered for cleanup"],
+    ["POTATO - Body Cleanup", "Body Cleanup"],
+    false, // default value
+    true, // isGlobal
+    {[QGVAR(allowVehicles), _this] call ACEFUNC(common,cbaSettings_settingChanged)}
+] call CBA_settings_fnc_init;

--- a/addons/bodyCleanup/script_component.hpp
+++ b/addons/bodyCleanup/script_component.hpp
@@ -1,8 +1,8 @@
 #define COMPONENT bodyCleanup
 #include "\z\potato\addons\core\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #include "\z\potato\addons\core\script_macros.hpp"

--- a/addons/bodyCleanup/script_component.hpp
+++ b/addons/bodyCleanup/script_component.hpp
@@ -1,0 +1,22 @@
+#define COMPONENT bodyCleanup
+#include "\z\potato\addons\core\script_mod.hpp"
+
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#include "\z\potato\addons\core\script_macros.hpp"
+
+// How many times/second event happens
+#define CLEANUP_FREQUENCY (10 / 1)
+#define UPDATE_FREQUENCY (1 / 1)
+
+// Minimum distance that a cell has to be before it is considered for cleanup
+#define MIN_CLEANUP_DISTANCE 500
+// Maximum distance that is considered within a units FOV
+#define MAX_CLEANUP_DISTANCE 1250
+#define TIME_BEFORE_CLEANUP 120
+
+#define CELL_SIZE 300
+#define ARMA_DEFAULT_FOV 45
+#define MAX_SAMPLE_SIZE (30 / 100)

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env py
+#!/usr/bin/env python3
 
 #######################
 #  POTATO Setup Script (From ACE3) #

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env py
 
 #######################
 #  POTATO Setup Script (From ACE3) #


### PR DESCRIPTION
# A implementation of automated garbage collection to ease Zeus intervention.

When enabled, any `Man` type unit will be put into a bucket within a uniform grid. Periodically there will be a check against each grid cell for each human player, and if a grid cell is not visible to any player it will be marked for deletion. When marked, there is a two minute countdown before the body is removed.

Bodies can be removed in two ways depending on settings: First, basic deletion. Just deleted, gone. However, a setting can be enabled to have bodies stop being rendered and their simulation disabled. With this setting, players would be able to return to their past massacres and view the bodies without immersion being lost.

This is an experimental feature disabled by default. My plan is to coordinate with some mission makers to have this be run during their coop and for me to ensure it is running smoothly. It can be killed during session, so if it is a performance hog it can be remedied with the the debug console (`potato_bodyCleanup_run = false;`)

## Performance considerations:
I was worried about performance hits, and this does have instances when it will be slow. The biggest issue is checking which cells are visible. The defaults are sensible and should let there be limited performance hit. The worst case I encountered in testing was with 200 simulated players and 100x100 meter cells, which had an impact of roughly 1200 milliseconds every second. Since this runs on the server, those jitters should be "fine". In practical testing (300x300m cells, with 30 simulated players), there will be a 16 millisecond hit every second. This will be fine for all intents and purposes. The main optimisation here would be to implement a better way to check every vision cone against the grid. I didn't want to implement a tree structure so I let it lay. Potential approach would be to use the vision cone AABB and use the properties of the uniform grid to select the specific cells which lay within.

Another optimisation was to sample at random the view of 30% of players. This should allow all cells to be covered, with a probability of a cell being missed approaching 0. This was just to limit the "worst case" of 200 active players all being polled.

## Deployment Plan:
We will merge this and I will coordinate with a mission maker to have it run in their mission. I will then remain in Zeus and watch over performance metrics to ensure everything runs fine. After, I will discuss with admins to see if we want this enabled by default.