### PR TITLE
Adjust Smoke Plume near or on the fringes of water

### DIFF
--- a/addons/filledSmoke/config.cpp
+++ b/addons/filledSmoke/config.cpp
@@ -24,7 +24,7 @@ class CfgCloudlets {
         moveVelocity[] = {0,0.1,0}; //default {0,0.3,0}
         weight = 6.4; //default 1.26
         volume = 5; //default 1
-        destoryOnWaterSurface = 1;
+        destroyOnWaterSurface = 1;
         destroyOnWaterSurfaceOffset = 0.05; //default -0.3
         destroyAfterCrossing = "true";
         onSurface = "true";

--- a/addons/filledSmoke/config.cpp
+++ b/addons/filledSmoke/config.cpp
@@ -18,32 +18,17 @@ class CfgCloudlets {
     class GVAR(SmokeShellWhiteFilled): SmokeShellWhiteSmall {
         animationSpeedCoef=0.75; //default 1
         colorCoef[] = {"colorR", "colorG", "colorB", 3}; //default 1.8
-        // particleFSNtieth = 16; //default 16
-        // particleFSIndex = 12; //default 12
-        // particleFSFrameCount = 8; //default 8
         sizeCoef = 2; //default 1
         interval = 0.13; //default 0.2
         lifeTime = 22; //default 14
         moveVelocity[] = {0,0.1,0}; //default {0,0.3,0}
         weight = 6.4; //default 1.26
         volume = 5; //default 1
-        // rubbing = 0.05; //default 0.05
-        // size[] = {0.2,6,10}; //default {0.2,6,10}
-        // color[] = {
-        // {0.7,0.7,0.7,0.24},
-        // {0.7,0.7,0.7,0.26},
-        // {0.7,0.7,0.7,0.25},
-        // {0.7,0.7,0.7,0.22},
-        // {0.7,0.7,0.7,0.18},
-        // {0.7,0.7,0.7,0.1},
-        // {0.7,0.7,0.7,0.01}
-        // };
-        // randomDirectionPeriod= 0.3; //default 0.3
-        // randomDirectionIntensity = 0.15; //default 0.15
-        // destroyOnWaterSurfaceOffset = -0.3; //default -0.3
-        // MoveVelocityVar[] = {0.5,0.2,0.5}; //default {0.5,0.2,0.5}
-        // sizeVar = 0.6; //default 0.6
-        // colorVar[] = {0,0,0,0.05}; //default {0,0,0,0.05}
+        destoryOnWaterSurface = 1;
+        destroyOnWaterSurfaceOffset = 0.05; //default -0.3
+        destroyAfterCrossing = "true";
+        onSurface = "true";
+        keepOnSurface = "true";
     };
 };
 


### PR DESCRIPTION
Noted during testing of a mission on Isla Pera that even on land smoke was not filling as expected. 
This appeared to be a result of being near but not in water. 
These adjusted values change how the smoke behaves on the fringes of water. Any smoke created will plume above the water. And any smoke that is created underwater will not plume and fill, unless it is very very close to the surface. 

Example images from Isla Pera Before:
![20231123021911_1](https://github.com/BourbonWarfare/POTATO/assets/5899996/2bc4db26-5b6d-46f6-af2c-a82651249d12)
![20231123021843_1](https://github.com/BourbonWarfare/POTATO/assets/5899996/d40fc38d-52c0-45e8-8fc5-6d4ba1d8712f)


After:
![20231123021337_1](https://github.com/BourbonWarfare/POTATO/assets/5899996/10451893-2a1a-4150-96d3-7c39afdf4681)
![20231123021503_1](https://github.com/BourbonWarfare/POTATO/assets/5899996/87c9db66-9cda-49d2-9540-7d626f91fbd2)
![20231123021606_1](https://github.com/BourbonWarfare/POTATO/assets/5899996/9e0a9d0f-c753-4f42-8dc6-3a69c0db9331)


After also tested in Tanoa:
![20231123020617_1](https://github.com/BourbonWarfare/POTATO/assets/5899996/2963f943-1d08-4fbf-8955-c64e52377ac2)
![20231123020657_1](https://github.com/BourbonWarfare/POTATO/assets/5899996/7c5de21c-4b0f-4a4c-b9f7-3d9f6be6c993)
![20231123020755_1](https://github.com/BourbonWarfare/POTATO/assets/5899996/d93f6cdf-7c8c-4867-97c6-dd2c63295bb9)
![20231123020829_1](https://github.com/BourbonWarfare/POTATO/assets/5899996/0060d62b-5138-47cb-a491-dc10f5ab3ce7)