### PR TITLE
PatchPTV - Fix XEH configs

### DIFF
--- a/addons/miscFixes/CfgVehicles.hpp
+++ b/addons/miscFixes/CfgVehicles.hpp
@@ -39,18 +39,9 @@ class CfgVehicles {
     };
 
     // Increase storage capacity of Contact DLC Radio Backpack to hold ACRE radios and radio accessories.
-    class B_RadioBag_01_base_F;
-    class B_RadioBag_01_black_F: B_RadioBag_01_base_F {maximumLoad=300;};
-    class B_RadioBag_01_digi_F: B_RadioBag_01_base_F {maximumLoad=300;};
-    class B_RadioBag_01_eaf_F: B_RadioBag_01_base_F {maximumLoad=300;};
-    class B_RadioBag_01_ghex_F: B_RadioBag_01_base_F {maximumLoad=300;};
-    class B_RadioBag_01_hex_F: B_RadioBag_01_base_F {maximumLoad=300;};
-    class B_RadioBag_01_mtp_F: B_RadioBag_01_base_F {maximumLoad=300;};
-    class B_RadioBag_01_tropic_F: B_RadioBag_01_base_F {maximumLoad=300;};
-    class B_RadioBag_01_oucamo_F: B_RadioBag_01_base_F {maximumLoad=300;};
-    class B_RadioBag_01_wdl_F: B_RadioBag_01_base_F {maximumLoad=300;};
-    class ptv_RadioBag_01_Desert: B_RadioBag_01_base_F {maximumLoad=300;}; // from Project True Viking
-    class ptv_RadioBag_01_Woodland: B_RadioBag_01_base_F {maximumLoad=300;};
+    class B_RadioBag_01_base_F: Bag_Base {
+        maximumLoad = 300;
+    };
 
     // Add SMAW box (no longer used, kept for bwc)
     class Box_NATO_Support_F;

--- a/addons/miscFixes/patchPTV/config.cpp
+++ b/addons/miscFixes/patchPTV/config.cpp
@@ -36,11 +36,11 @@ class CfgVehicles {
     class ptv_RadioBag_01_Woodland: B_RadioBag_01_base_F {maximumLoad=300;};
 };
 
-class CfgWeapons {
+
 class Mode_SemiAuto;
 class Mode_Burst;
 class Mode_FullAuto;
-class cfgWeapons {
+class CfgWeapons {
     class Pistol;
     class Pistol_Base_F: Pistol {};
     class Rifle;

--- a/addons/miscFixes/patchPTV/config.cpp
+++ b/addons/miscFixes/patchPTV/config.cpp
@@ -1,0 +1,37 @@
+#include "\z\potato\addons\miscFixes\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT miscFixes_patchPTV
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = { "potato_core", "ptv_vehicles", "ptv_characters_cfg" };
+        skipWhenMissingDependencies = 1;
+        author = "Bourbon Warfare";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+
+
+class CBA_Extended_EventHandlers;
+class CfgVehicles {
+    // Fix XEH: "[CBA] (xeh) WARNING: ptv_Pnd_Base_F does not support Extended Event Handlers! Addon: 3092130870"
+    class B_APC_Wheeled_03_cannon_F;
+    class ptv_Pnd_Base_F: B_APC_Wheeled_03_cannon_F {
+        class EventHandlers { class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {}; };
+    };
+    class I_APC_tracked_03_cannon_F;
+    class ptv_Warrior_Base_F: I_APC_tracked_03_cannon_F {
+        class EventHandlers { class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {}; };
+    };
+
+
+    // Increase storage capacity of Contact DLC Radio Backpack to hold ACRE radios and radio accessories.
+    class B_RadioBag_01_base_F;
+    class ptv_RadioBag_01_Desert: B_RadioBag_01_base_F {maximumLoad=300;}; // from Project True Viking
+    class ptv_RadioBag_01_Woodland: B_RadioBag_01_base_F {maximumLoad=300;};
+};

--- a/addons/miscFixes/patchPTV/config.cpp
+++ b/addons/miscFixes/patchPTV/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "potato_core", "ptv_vehicles", "ptv_characters_cfg" , "ptv_characters" };
+        requiredAddons[] = { "potato_core", "ptv_vehicles", "ptv_characters_cfg", "ptv_characters" };
         skipWhenMissingDependencies = 1;
         author = "Bourbon Warfare";
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
@@ -36,7 +36,7 @@ class CfgVehicles {
     class ptv_RadioBag_01_Woodland: B_RadioBag_01_base_F {maximumLoad=300;};
 };
 
-class cfgWeapons {
+class CfgWeapons {
     class Pistol;
     class Pistol_Base_F: Pistol {};
     class Rifle;


### PR DESCRIPTION
Fixes
```
[CBA] (xeh) WARNING: ptv_Pnd_Base_F does not support Extended Event Handlers! Addon: 3092130870
[CBA] (xeh) WARNING: ptv_Warrior_Base_F does not support Extended Event Handlers! Addon: 3092130870
```