### PR TITLE
RHS Medic Bag (Large)

### DIFF
--- a/addons/miscFixes/patchRHSAFRF/config.cpp
+++ b/addons/miscFixes/patchRHSAFRF/config.cpp
@@ -17,7 +17,6 @@ class CfgPatches {
 
 class CfgWeapons {
     class ItemCore;
-    class B_AssaultPack_Base;
     class Vest_Camo_Base: ItemCore {
         class ItemInfo;
     };
@@ -51,6 +50,10 @@ class CfgWeapons {
             };
         };
     };
+};
+
+class CfgVehicles {
+    class B_AssaultPack_Base;
     class rhs_medic_bag: B_AssaultPack_Base {};
     class rhs_medic_bag_XL: rhs_medic_bag {
         author = "RHS & AChesheireCat";

--- a/addons/miscFixes/patchRHSAFRF/config.cpp
+++ b/addons/miscFixes/patchRHSAFRF/config.cpp
@@ -17,6 +17,7 @@ class CfgPatches {
 
 class CfgWeapons {
     class ItemCore;
+    class B_AssaultPack_Base;
     class Vest_Camo_Base: ItemCore {
         class ItemInfo;
     };
@@ -49,5 +50,11 @@ class CfgWeapons {
                 };
             };
         };
+    };
+    class rhs_medic_bag: B_AssaultPack_Base {};
+    class rhs_medic_bag_XL: rhs_medic_bag {
+        author = "RHS & AChesheireCat";
+        displayName = "Medic Bag (Large)";
+        maximumLoad = 240; 
     };
 };


### PR DESCRIPTION
Adds a large version of the RHS Medic Bag that is sized to fit our medic's standard amount of supplies.