### PR TITLE
CUP Weapons Reanim

### DIFF
--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -129,4 +129,37 @@ class CfgWeapons {
     class CUP_smg_MP7: Rifle_Short_Base_F { // Applies the APEX dlc MP5 recoil to the CUP MP7
         recoil = "recoil_smg_05";
     };
+    class CUP_arifle_ACR_BASE_556: Rifle_Base_F {
+        reloadAction = "ptv_GestureReloadHK433";
+        magazineReloadSwitchPhase = 0.3;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+    };
+    class CUP_arifle_ACR_BASE_68: Rifle_Base_F {
+        reloadAction = "ptv_GestureReloadHK433";
+        magazineReloadSwitchPhase = 0.3;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+    };
+    class CUP_arifle_M16_Base: Rifle_Base_f {};
+    class CUP_arifle_M4_Base: CUP_arifle_M16_Base {};
+    class CUP_arifle_M4A1_BUIS_Base: CUP_arifle_M4_Base {};
+    class CUP_arifle_M4A1_MOE_black: CUP_arifle_M4A1_BUIS_Base{
+		reloadAction = "GestureReloadSPAR_01";
+        magazineReloadSwitchPhase = 0.1829;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+	};
+    class CUP_arifle_M4A1_MOE_short_black: CUP_arifle_M4A1_BUIS_Base {
+        reloadAction = "GestureReloadSPAR_01";
+        magazineReloadSwitchPhase = 0.1829;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+	};
+    class CUP_arifle_M4A1_standard_black: CUP_arifle_M4A1_BUIS_Base {
+		reloadAction = "GestureReloadSPAR_01";
+        magazineReloadSwitchPhase = 0.1829;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+	};
+    class CUP_arifle_M4A1_standard_short_black: CUP_arifle_M4A1_BUIS_Base {
+        reloadAction = "GestureReloadSPAR_01";
+        magazineReloadSwitchPhase = 0.1829;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+    };
 };

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -129,37 +129,4 @@ class CfgWeapons {
     class CUP_smg_MP7: Rifle_Short_Base_F { // Applies the APEX dlc MP5 recoil to the CUP MP7
         recoil = "recoil_smg_05";
     };
-    class CUP_arifle_ACR_BASE_556: Rifle_Base_F {
-        reloadAction = "ptv_GestureReloadHK433";
-        magazineReloadSwitchPhase = 0.3;
-        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
-    };
-    class CUP_arifle_ACR_BASE_68: Rifle_Base_F {
-        reloadAction = "ptv_GestureReloadHK433";
-        magazineReloadSwitchPhase = 0.3;
-        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
-    };
-    class CUP_arifle_M16_Base: Rifle_Base_f {};
-    class CUP_arifle_M4_Base: CUP_arifle_M16_Base {};
-    class CUP_arifle_M4A1_BUIS_Base: CUP_arifle_M4_Base {};
-    class CUP_arifle_M4A1_MOE_black: CUP_arifle_M4A1_BUIS_Base{
-		reloadAction = "GestureReloadSPAR_01";
-        magazineReloadSwitchPhase = 0.1829;
-        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
-	};
-    class CUP_arifle_M4A1_MOE_short_black: CUP_arifle_M4A1_BUIS_Base {
-        reloadAction = "GestureReloadSPAR_01";
-        magazineReloadSwitchPhase = 0.1829;
-        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
-	};
-    class CUP_arifle_M4A1_standard_black: CUP_arifle_M4A1_BUIS_Base {
-		reloadAction = "GestureReloadSPAR_01";
-        magazineReloadSwitchPhase = 0.1829;
-        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
-	};
-    class CUP_arifle_M4A1_standard_short_black: CUP_arifle_M4A1_BUIS_Base {
-        reloadAction = "GestureReloadSPAR_01";
-        magazineReloadSwitchPhase = 0.1829;
-        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
-    };
 };

--- a/addons/miscFixes/patchCUPPTV/config.cpp
+++ b/addons/miscFixes/patchCUPPTV/config.cpp
@@ -1,0 +1,53 @@
+#include "\z\potato\addons\miscFixes\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT miscFixes_patchCUPPTV
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = { "potato_core", "ptv_characters_cfg", "CUP_Weapons_LoadOrder" };
+        skipWhenMissingDependencies = 1;
+        author = "Bourbon Warfare";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+class CfgWeapons {
+    class Rifle_Base_F;
+    class CUP_arifle_ACR_BASE_556: Rifle_Base_F {
+        reloadAction = "ptv_GestureReloadHK433";
+        magazineReloadSwitchPhase = 0.3;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+    };
+    class CUP_arifle_ACR_BASE_68: Rifle_Base_F {
+        reloadAction = "ptv_GestureReloadHK433";
+        magazineReloadSwitchPhase = 0.3;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+    };
+    class CUP_arifle_M16_Base: Rifle_Base_F {};
+    class CUP_arifle_M4_Base: CUP_arifle_M16_Base {};
+    class CUP_arifle_M4A1_BUIS_Base: CUP_arifle_M4_Base {};
+    class CUP_arifle_M4A1_MOE_black: CUP_arifle_M4A1_BUIS_Base{
+		reloadAction = "GestureReloadSPAR_01";
+        magazineReloadSwitchPhase = 0.1829;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+	};
+    class CUP_arifle_M4A1_MOE_short_black: CUP_arifle_M4A1_BUIS_Base {
+        reloadAction = "GestureReloadSPAR_01";
+        magazineReloadSwitchPhase = 0.1829;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+	};
+    class CUP_arifle_M4A1_standard_black: CUP_arifle_M4A1_BUIS_Base {
+		reloadAction = "GestureReloadSPAR_01";
+        magazineReloadSwitchPhase = 0.1829;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+	};
+    class CUP_arifle_M4A1_standard_short_black: CUP_arifle_M4A1_BUIS_Base {
+        reloadAction = "GestureReloadSPAR_01";
+        magazineReloadSwitchPhase = 0.1829;
+        reloadMagazineSound[] = {"CUP\Weapons\CUP_Weapons_M16\data\sfx\M16_Reload",1,1,10};
+    };
+};


### PR DESCRIPTION
Updates a few CUP weapons to have newer/better animations. Specifically, the ACR has been changed to use the PTV HK433 animation while the old M4A1s have been updated to use the same animation as the "new" CUP M4A1s.

Weapons updated:

- ACR (5.56)
- ACR-C (5.56)
- ACR (6.8 SPC)
- ACR-C (6.8 SPC)
- M4A1 (11.3 MOE + RAS)
- M4A1 (14.5 MOE + RAS)