### PR TITLE
ACE Wake Up for Non-stable Patients

### DIFF
--- a/addons/aceWakeup/config.cpp
+++ b/addons/aceWakeup/config.cpp
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+
+class CfgFunctions {
+    class overwrite_ace_medical_status {
+        tag = "ace_medical_status";
+        class ace_medical_status {
+            class hasStableVitals {
+                file = "\potato_ace_wakeup\functions\fnc_hasStableVitals.sqf";
+            };
+        };
+    };
+};
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = { "potato_core", "ace_medical" };\
+        author = "Potato";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};

--- a/addons/aceWakeup/functions/fnc_hasStableVitals.sqf
+++ b/addons/aceWakeup/functions/fnc_hasStableVitals.sqf
@@ -1,0 +1,18 @@
+#include "\z\ace\addons\medical_engine\script_macros_medical.hpp"
+#include "\z\ace\addons\medical_engine\script_macros_config.hpp"
+#include "\z\ace\addons\main\script_mod.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
+
+params ["_unit"];
+
+if (GET_BLOOD_VOLUME(_unit) > BLOOD_VOLUME_CLASS_2_HEMORRHAGE) exitwith {true};
+
+if ((GET_BLOOD_VOLUME(_unit) <= BLOOD_VOLUME_CLASS_2_HEMORRHAGE) && {random 3 < 1}) exitwith {true};
+
+if ((GET_BLOOD_VOLUME(_unit) <= BLOOD_VOLUME_CLASS_4_HEMORRHAGE) && {random 6 < 1}) exitwith {true}; // Maybe up to 5?
+
+// The below code is intended to add a mechanic wherein if players are not stable but woke up, they have a %chance to go back uncon so as to simulate a fade-in fade-out mechanic
+
+// if ((GET_BLOOD_VOLUME(_unit) <= BLOOD_VOLUME_CLASS_2_HEMORRHAGE) && {random 2 < 1} && (IS_UNCONSCIOUS(_unit) == true)) exitwith {false};
+
+// if ((GET_BLOOD_VOLUME(_unit) <= BLOOD_VOLUME_CLASS_4_HEMORRHAGE) && {random 2 < 1} && (IS_UNCONSCIOUS(_unit) == true)) exitwith {false};


### PR DESCRIPTION
Adds a flat, non-adjustable wake-up chance for unconscious and non-stable player patients. This is intended to decrease the brutality of going uncon and having to wait for your teammates to check on you.

Wants for this feature:

- Add a %chance to go back unconscious if the patient is not stable and/or has low blood volume. This will highly incentivize players to receive medical attention before running off despite stabilizing themselves.

I've written some pseudo-code so as to show what the above concept might look like.