### PR TITLE
Fixes Crash-To-Lobby bug caused by PLA

### DIFF
--- a/addons/miscFixes/patchPLA/config.cpp
+++ b/addons/miscFixes/patchPLA/config.cpp
@@ -291,7 +291,7 @@ class CfgVehicles {
                 class Turrets: Turrets {
                     class CommanderOptics: CommanderOptics {
                         class HitPoints {
-                            class HitTurret {
+                            class HitComTurret {
                                 armor = 0.3;
                                 passThrough = 0;
                                 minimalHit = 0.03;
@@ -554,13 +554,6 @@ class CfgVehicles {
                                 minimalHit = 0.1;
                                 explosionShielding = 1;
                                 isTurret = 1;
-                            };
-                            class HitComGun {
-                                armor = 0.04;
-                                passThrough = 0;
-                                minimalHit = 0.1;
-                                explosionShielding = 1;
-                                isGun = 1;
                             };
                         };
                     };


### PR DESCRIPTION
PLA updated their config syntax/class names recently which broke this patch and caused a Crash-to-Lobby when the ZTL-11 and ZTD-05 were present in a mission.

This *should* resolve that issue.