### PR TITLE
Add GM's German voice set to "Set AI Identity (Voices)" module

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -32,7 +32,7 @@ exclude = [
 workshop = [
     "450814997", # CBA_A3's Workshop ID
     "2987524550", # BW ACE
-    "2987528956", # BW ACRE
+    "751965892", # ACRE
 ]
 parameters = [
     "-skipIntro",           # These parameters are passed to the Arma 3 executable
@@ -52,7 +52,7 @@ presets = [
 workshop = [
     "450814997", # CBA_A3's Workshop ID
     "2987524550", # BW ACE
-    "2987528956", # BW ACRE
+    "751965892", # ACRE
 ]
 parameters = [
     "-skipIntro",           # These parameters are passed to the Arma 3 executable

--- a/addons/missionModules/CfgVehicles.hpp
+++ b/addons/missionModules/CfgVehicles.hpp
@@ -239,6 +239,12 @@ class CfgVehicles {
                         picture = "\A3\ui_f\data\map\markers\flags\CzechRepublic_ca.paa";
                         data[] = {"CUP_D_Male01_CZ","CUP_D_Male02_CZ","CUP_D_Male03_CZ","CUP_D_Male04_CZ","CUP_D_Male05_CZ", "CUP_D_Male01_CZ_ACR","CUP_D_Male02_CZ_ACR","CUP_D_Male03_CZ_ACR","CUP_D_Male04_CZ_ACR","CUP_D_Male05_CZ_ACR"};
                     };
+                    class gm_language_deu_male {
+                        name = "German [GM]";
+                        value = "gm_language_deu_male";
+                        picture = "\A3\Ui_f\data\Map\Markers\Flags\germany_ca.paa" ;
+                        data[] = {"gm_voice_male_deu_01","gm_voice_male_deu_02","gm_voice_male_deu_03","gm_voice_male_deu_04","gm_voice_male_deu_05","gm_voice_male_deu_06","gm_voice_male_deu_07","gm_voice_male_deu_08","gm_voice_male_deu_09"};
+                    };
                 };
             };
         };

--- a/addons/missionModules/CfgVehicles.hpp
+++ b/addons/missionModules/CfgVehicles.hpp
@@ -242,7 +242,7 @@ class CfgVehicles {
                     class gm_language_deu_male {
                         name = "German [GM]";
                         value = "gm_language_deu_male";
-                        picture = "\A3\Ui_f\data\Map\Markers\Flags\germany_ca.paa" ;
+                        picture = "\A3\Ui_f\data\Map\Markers\Flags\germany_ca.paa";
                         data[] = {"gm_voice_male_deu_01","gm_voice_male_deu_02","gm_voice_male_deu_03","gm_voice_male_deu_04","gm_voice_male_deu_05","gm_voice_male_deu_06","gm_voice_male_deu_07","gm_voice_male_deu_08","gm_voice_male_deu_09"};
                     };
                 };


### PR DESCRIPTION
Adds GM's German voice to the "Set AI Identity (Voices)" mission module. Let me know if that should be in a optional compat as part of the missionModules addon instead.