### PR TITLE
Faux MG5

### DIFF
--- a/addons/miscFixes/fauxMG5/CfgWeapons.hpp
+++ b/addons/miscFixes/fauxMG5/CfgWeapons.hpp
@@ -1,0 +1,17 @@
+class CfgWeapons {
+    class MMG_01_tan_F;
+    class GVAR(MG5): MMG_01_tan_F {
+        author = "Potato";
+        displayName = "H&K MG5";
+        descriptionShort = "General Purpose Machine Gun<br />Caliber: 7.62x51 mm";
+        baseWeapon = QGVAR(MG5);
+        recoil = "CUP_MG3_recoil";
+        magazineWell[] = {"CBA_762x51_LINKS"};
+        magazines[] = {
+            "CUP_120Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M",
+            "CUP_120Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M",
+            "CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M",
+            "CUP_120Rnd_TE4_LRT4_Yellow_Tracer_762x51_Belt_M"
+        };
+    };
+};

--- a/addons/miscFixes/fauxMG5/config.cpp
+++ b/addons/miscFixes/fauxMG5/config.cpp
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        weapons[] = {
+            QGVAR(MG5)
+        };
+        units[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"potato_core", "CUP_Weapons_LoadOrder"};
+        skipWhenMissingDependencies = 1;
+        author = "Potato";
+        authors[] = {"AChesheireCat"};
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/addons/miscFixes/fauxMG5/script_component.hpp
+++ b/addons/miscFixes/fauxMG5/script_component.hpp
@@ -1,0 +1,12 @@
+#define COMPONENT fauxMG5
+#include "\z\potato\addons\core\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_FAUXMG5
+    #define DEBUG_MODE_FULL
+#endif
+
+#include "\z\potato\addons\core\script_macros.hpp"


### PR DESCRIPTION
Adds a "faux" MG5 that inherits from the Marksman DLC HK121.