### PR TITLE
Add ability to create larger supply boxes with smaller resupply boxes inside them

### DIFF
--- a/addons/assignGear/XEH_PREP.hpp
+++ b/addons/assignGear/XEH_PREP.hpp
@@ -15,4 +15,5 @@ PREP(getLoadoutFromConfig);
 PREP(getWeaponArray);
 PREP(isOpticMagnified);
 PREP(requestPlayerGear);
+PREP(setBoxContentsFromConfig);
 PREP(setWeaponAttachment);

--- a/addons/assignGear/XEH_PREP.hpp
+++ b/addons/assignGear/XEH_PREP.hpp
@@ -1,6 +1,7 @@
 TRACE_1("",QUOTE(ADDON));
 
 PREP(addItemsToContainer);
+PREP(addSupplyBoxActions);
 PREP(assignGearMan);
 PREP(assignGearSupplyBox);
 PREP(assignGearPotatoBox);

--- a/addons/assignGear/XEH_clientPostInit.sqf
+++ b/addons/assignGear/XEH_clientPostInit.sqf
@@ -36,4 +36,6 @@ if (GVAR(usePotato) && hasInterface) then {
             _baseAction, true
         ] call ACEFUNC(interact_menu,addActionToClass);
     };
+
+    [QGVAR(resupplyBoxAddActions), LINKFUNC(addSupplyBoxActions)] call CBA_fnc_addEventHandler;
 };

--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -22,6 +22,7 @@ if (GVAR(usePotato)) then {
     GVAR(alwaysAddToolkits) = [missionConfigFile >> "CfgLoadouts" >> "alwaysAddToolkits", true] call CFUNC(getBool);
     GVAR(alwaysAddLandRopes) = [missionConfigFile >> "CfgLoadouts" >> "alwaysAddLandRopes", true] call CFUNC(getBool);
     GVAR(prefixes) = [missionConfigFile >> "CfgLoadouts" >> "prefixes"] call CFUNC(getArray);
+    GVAR(resupplyBoxMarkerIndex) = 0;
 
     if (isServer) then {
         if (is3DEN) then {

--- a/addons/assignGear/functions/fnc_addSupplyBoxActions.sqf
+++ b/addons/assignGear/functions/fnc_addSupplyBoxActions.sqf
@@ -52,8 +52,8 @@ _action = [
     "markBoxGlowstick",
     "Glow Stick",
     "\a3\Modules_F_Curator\Data\portraitChemlight_ca.paa", {
-    private _smoke = createVehicle ["ACE_G_Chemlight_HiYellow", ASLToAGL getPosASL _target, [], 0, "CAN_COLLIDE"];
-    _smoke attachTo [_target, [0, 0, 0]];
+    private _glowstick = createVehicle ["ACE_G_Chemlight_HiYellow", ASLToAGL getPosASL _target, [], 0, "CAN_COLLIDE"];
+    _glowstick attachTo [_target, [0, 0, 0]];
     _target setVariable [QGVAR(glowStickAvailable), false];
     },
     {_target getVariable [QGVAR(glowStickAvailable), true]}
@@ -83,7 +83,7 @@ _action = [
             _marker setMarkerColorLocal "ColorYellow";
             private _boxName = _target getVariable [QACEGVAR(cargo,customName), "Resupply Box"];
             _marker setMarkerTextLocal _boxName;
-            _marker setMarkerTypeLocal "loc_rearm";
+            _marker setMarkerType "loc_rearm";
             _target setVariable [QGVAR(boxMarker), _marker, true];
         } else {
             _marker setMarkerPos (getPosATL _target);

--- a/addons/assignGear/functions/fnc_addSupplyBoxActions.sqf
+++ b/addons/assignGear/functions/fnc_addSupplyBoxActions.sqf
@@ -1,0 +1,94 @@
+#include "script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * Adds actions to allow a client to mark a supply box using smoke, glow sticks
+ * and or map markers. Smoke and glow sticks are enabled with a marking level
+ * of 1 or greater, and map markers at level 2 or greater.
+ *
+ * Arguments:
+ * 0: Box <OBJECT>
+ * 1: Marking level <SCALAR>
+ *    >=1 allows smoke and chem lights to be added
+ *    >=2 allows for a map marker to be placed/updated
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [cursorObject, 2] call potato_assignGear_fnc_addSupplyBoxActions.sqf
+ *
+ * Public: No
+ */
+#define LARGE_UNIQUE_MARKER_INDEX 934648
+params ["_theBox", "_markingLevel"];
+
+if (_markingLevel < 1 || !hasInterface) exitWith {};
+
+private _action = [
+    "markBoxBase",
+    "Mark Box",
+    "\a3\ui_f\data\igui\cfg\simpletasks\types\move_ca.paa", {
+        private _marker = _target getVariable [QGVAR(boxMarker), ""];
+        if (getMarkerPos _marker isNotEqualTo [0, 0, 0]) then {
+            _marker setMarkerPos (getPosATL _target);
+        };
+    },
+    {true}
+] call ACEFUNC(interact_menu,createAction);
+[_theBox, 0, ["ACE_MainActions"], _action] call ACEFUNC(interact_menu,addActionToObject);
+
+_action = [
+    "markBoxSmoke",
+    "Smoke",
+    "\a3\Modules_F_Curator\Data\portraitSmoke_ca.paa", {
+    private _smoke = createVehicle ["SmokeShellYellow", ASLToAGL getPosASL _target, [], 0, "CAN_COLLIDE"];
+    _smoke attachTo [_target, [0, 0, 0]];
+    _target setVariable [QGVAR(smokeAvailable), false];
+    },
+    {_target getVariable [QGVAR(smokeAvailable), true]}
+] call ACEFUNC(interact_menu,createAction);
+[_theBox, 0, ["ACE_MainActions","markBoxBase"], _action] call ACEFUNC(interact_menu,addActionToObject);
+_action = [
+    "markBoxGlowstick",
+    "Glow Stick",
+    "\a3\Modules_F_Curator\Data\portraitChemlight_ca.paa", {
+    private _smoke = createVehicle ["ACE_G_Chemlight_HiYellow", ASLToAGL getPosASL _target, [], 0, "CAN_COLLIDE"];
+    _smoke attachTo [_target, [0, 0, 0]];
+    _target setVariable [QGVAR(glowStickAvailable), false];
+    },
+    {_target getVariable [QGVAR(glowStickAvailable), true]}
+] call ACEFUNC(interact_menu,createAction);
+[_theBox, 0, ["ACE_MainActions","markBoxBase"], _action] call ACEFUNC(interact_menu,addActionToObject);
+
+if (_markingLevel < 2) exitWith {};
+_action = [
+    "markBoxMapMarker",
+    "Map Marker",
+    "\a3\ui_f\data\igui\cfg\simpletasks\types\rearm_ca.paa", {
+        private _marker = _target getVariable [QGVAR(boxMarker), ""];
+        // when a marker name/values are edit, the marker is re-created so it's possible to lose it (often)
+        if (getMarkerPos _marker isEqualTo [0, 0, 0]) then {
+            _marker = createMarkerLocal [
+                format ["_USER_DEFINED #%1/%2/%3ResupplyBoxMarker_%4",
+                    clientOwner,
+                    LARGE_UNIQUE_MARKER_INDEX,
+                    1,
+                    GVAR(resupplyBoxMarkerIndex)
+                ],
+                getPosATL _target,
+                1,
+                player
+            ];
+            GVAR(resupplyBoxMarkerIndex) = GVAR(resupplyBoxMarkerIndex) + 1;
+            _marker setMarkerColorLocal "ColorYellow";
+            private _boxName = _target getVariable [QACEGVAR(cargo,customName), "Resupply Box"];
+            _marker setMarkerTextLocal _boxName;
+            _marker setMarkerTypeLocal "loc_rearm";
+            _target setVariable [QGVAR(boxMarker), _marker, true];
+        } else {
+            _marker setMarkerPos (getPosATL _target);
+        };
+    },
+    {true}
+] call ACEFUNC(interact_menu,createAction);
+[_theBox, 0, ["ACE_MainActions","markBoxBase"], _action] call ACEFUNC(interact_menu,addActionToObject);

--- a/addons/assignGear/functions/fnc_assignGearSupplyBox.sqf
+++ b/addons/assignGear/functions/fnc_assignGearSupplyBox.sqf
@@ -38,38 +38,48 @@ if (GVAR(setSupplyBoxLoadouts) == -1) exitWith {
 private _path = missionConfigFile >> "CfgLoadouts" >> "SupplyBoxes" >> typeOf _theBox;
 
 if (!isClass _path) exitWith {
-    diag_log text format ["[POTATO-assignGear] - No loadout found for %1 (typeOf %2)", _theBox, typeOf _theBox];
+    diag_log formatText ["[POTATO-assignGear] - No loadout found for %1 (typeOf %2)", _theBox, typeOf _theBox];
 };
 
 private _subBoxes = "true" configClasses _path;
 if (_subBoxes isNotEqualTo []) then {
     private _boxName = getText (_path >> "boxCustomName");
     if (_boxName isNotEqualTo "") then {
-        _theBox setVariable ["ace_cargo_customName", _boxName, true];
+        _theBox setVariable [QACEGVAR(cargo,customName), _boxName, true];
     };
     clearWeaponCargoGlobal _theBox;
     clearMagazineCargoGlobal _theBox;
     clearItemCargoGlobal _theBox;
     clearBackpackCargoGlobal _theBox;
     private _boxSpace = getNumber (_path >> "boxSpace");
-    [_theBox, [_boxSpace, 4] select (_boxSpace == 0)] call ace_cargo_fnc_setSpace;
+    [_theBox, [_boxSpace, 4] select (_boxSpace == 0)] call ACEFUNC(cargo,setSpace);
     {
         private _subBoxType = configName _x;
         private _boxCount = (getNumber (_x >> "boxCount")) max 1;
         for "_i" from 1 to _boxCount do {
-            private _subBox = createVehicle [_subBoxType, [23,54,975], [], 0, "CAN_COLLIDE"];
+            private _subBox = createVehicle [_subBoxType, [0, 0, 0], [], 0, "CAN_COLLIDE"];
             [_subBox, _x, ["%1", "%1 " + str _i] select (_boxCount > 1)] call FUNC(setBoxContentsFromConfig);
-            [_subBox, 1] call ace_cargo_fnc_setSize;
+            [_subBox, 1] call ACEFUNC(cargo,setSize);
             if !([_subBox, _theBox, true] call ace_cargo_fnc_loadItem) exitWith {
-                diag_log text format ["[POTATO-assignGear] - Failed to create %1 supply box(es) for %2 - out of space ", _subBoxType, typeOf _theBox];
+                diag_log formatText [
+                    "[POTATO-assignGear] - Failed to create %1 %2 supply box(es) for %3 - out of space ",
+                    _subBoxType,
+                    "x" + str (_boxCount - _i + 1),
+                    typeOf _theBox
+                ];
                 deleteVehicle _subBox;
             };
             _subBox setVariable [QGVAR(initialized), true];
         };
     } forEach _subBoxes;
-    [_theBox, 4] call ace_cargo_fnc_setSize;
-    [_theBox, true, [0, 1, 1], 0, true, true] call ace_dragging_fnc_setCarryable;
-    [_theBox, true, [0, 1.5, 0], 0, true, true] call ace_dragging_fnc_setDraggable;
+    [_theBox, 2] call ACEFUNC(cargo,setSize);
+    [_theBox, true, [0, 1, 1], 0, true, true] call ACEFUNC(dragging,setCarryable);
+    [_theBox, true, [0, 1.5, 0], 0, true, true] call ACEFUNC(dragging,setDraggable);
 } else {
     [_theBox, _path] call FUNC(setBoxContentsFromConfig);
+};
+
+private _addMarkingActions = getNumber (_path >> "addMarkingActions");
+if (_addMarkingActions >= 1) then {
+    [QGVAR(resupplyBoxAddActions), [_theBox, _addMarkingActions]] call CBA_fnc_globalEventJIP;
 };

--- a/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
+++ b/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
@@ -1,0 +1,68 @@
+#include "script_component.hpp"
+/*
+ * Author: Bailey
+ * Fills box with gear from a config
+ * Edited by Lambda.Tiger to add box names
+ *
+ * Arguments:
+ * 0: Box <OBJECT>
+ * 1: missionConfigFile path for the box's loadout <STRING>
+ * 2: Optional format string for box name, must contain "%1" <STRING>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [cursorObject] call potato_assignGear_fnc_assignGearSupplyBox
+ *
+ * Public: No
+ */
+
+params ["_theBox", "_path", ["_nameFormatString", "%1", [""]]];
+
+clearWeaponCargoGlobal _theBox;
+clearMagazineCargoGlobal _theBox;
+clearItemCargoGlobal _theBox;
+clearBackpackCargoGlobal _theBox;
+
+private _transportMagazines = getArray(_path >> "TransportMagazines");
+private _transportItems = getArray(_path >> "TransportItems");
+private _transportWeapons = getArray(_path >> "TransportWeapons");
+private _transportBackpacks = getArray(_path >> "TransportBackpacks");
+
+// transportMagazines
+{
+    (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
+    _theBox addMagazineCargoGlobal [_classname, parseNumber _amount];
+    nil
+} count _transportMagazines; // count used here for speed, make sure nil is above this line
+
+// transportItems
+{
+    (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
+    _theBox addItemCargoGlobal [_classname, parseNumber _amount];
+    nil
+} count _transportItems; // count used here for speed, make sure nil is above this line
+
+// transportWeapons
+{
+    (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
+    private _disposableName = [cba_disposable_LoadedLaunchers, _classname, "get", ""] call potato_assignGear_fnc_getDisposableInfo;
+    if (_disposableName != "") then {
+        _classname = _disposableName;
+    };
+    _theBox addWeaponCargoGlobal [_classname, parseNumber _amount];
+    nil
+} count _transportWeapons; // count used here for speed, make sure nil is above this line
+
+// transportBackpacks
+{
+    (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
+    _theBox addBackpackCargoGlobal [_classname, parseNumber _amount];
+    nil
+} count _transportBackpacks; // count used here for speed, make sure nil is above this line
+
+private _boxName = getText (_path >> "boxCustomName");
+if (_boxName isNotEqualTo "") then {
+    _theBox setVariable ["ace_cargo_customName", format [_nameFormatString, _boxName], true];
+};

--- a/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
+++ b/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
@@ -66,3 +66,8 @@ private _boxName = getText (_path >> "boxCustomName");
 if (_boxName isNotEqualTo "") then {
     _theBox setVariable ["ace_cargo_customName", format [_nameFormatString, _boxName], true];
 };
+
+private _overrideCarryWeight = 1 == (getNumber (_path >> "forceAllowCarry"));
+private _overrideDragWeight = 1 == (getNumber (_path >> "forceAllowDrag"));
+_theBox setVariable ["ace_cargo_ignoreWeightCarry", _overrideCarryWeight, true];
+_theBox setVariable ["ace_cargo_ignoreWeightDrag", _overrideCarryWeight || _overrideDragWeight, true];

--- a/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
+++ b/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
@@ -13,7 +13,7 @@
  * None
  *
  * Example:
- * [cursorObject] call potato_assignGear_fnc_assignGearSupplyBox
+ * [cursorObject, missionConfigFile >> "CfgLoadouts" >> "SupplyBoxes" >> (typeOf cursorObject)] call potato_assignGear_fnc_setBoxContentsFromConfig
  *
  * Public: No
  */
@@ -47,7 +47,7 @@ private _transportBackpacks = getArray(_path >> "TransportBackpacks");
 // transportWeapons
 {
     (_x splitString ":") params ["_classname", ["_amount", "1", [""]]];
-    private _disposableName = [cba_disposable_LoadedLaunchers, _classname, "get", ""] call potato_assignGear_fnc_getDisposableInfo;
+    private _disposableName = [cba_disposable_LoadedLaunchers, _classname, "get", ""] call FUNC(getDisposableInfo);
     if (_disposableName != "") then {
         _classname = _disposableName;
     };
@@ -64,10 +64,10 @@ private _transportBackpacks = getArray(_path >> "TransportBackpacks");
 
 private _boxName = getText (_path >> "boxCustomName");
 if (_boxName isNotEqualTo "") then {
-    _theBox setVariable ["ace_cargo_customName", format [_nameFormatString, _boxName], true];
+    _theBox setVariable [QACEGVAR(cargo,customName), format [_nameFormatString, _boxName], true];
 };
 
 private _overrideCarryWeight = 1 == (getNumber (_path >> "forceAllowCarry"));
 private _overrideDragWeight = 1 == (getNumber (_path >> "forceAllowDrag"));
-_theBox setVariable ["ace_cargo_ignoreWeightCarry", _overrideCarryWeight, true];
-_theBox setVariable ["ace_cargo_ignoreWeightDrag", _overrideCarryWeight || _overrideDragWeight, true];
+_theBox setVariable [QACEGVAR(cargo,ignoreWeightCarry), _overrideCarryWeight, true];
+_theBox setVariable [QACEGVAR(cargo,ignoreWeightDrag), _overrideCarryWeight || _overrideDragWeight, true];


### PR DESCRIPTION
This adds an idea kilo had/stole in the [resupply boxes suggestion on BW's discord](https://discord.com/channels/204621032428929025/1281258900728975382/1281672958061838498). It allows a mission maker to use the `CfgLoadouts` `SupplyBoxes` class to make larger boxes with multiple smaller resupply boxes inside them. See this example
```cpp
class CfgLoadouts {
  // other code before or after
  // Do Supply Box Loadouts
  // (1 will run normaly, 0 will leave them to vanilla defaults, -1 will clear and leave empty)
  setSupplyBoxLoadouts = 1;
  class SupplyBoxes {
    class ACE_medicalSupplyCrate {
      boxCustomName = "Wild Medical Box";
      TransportItems[] = {
        "ACE_elasticBandage:40",
        "ACE_packingBandage:20",
        "ACE_epinephrine:15",
        "ACE_morphine:15",
        "ACE_adenosine:15",
        "ACE_tourniquet:10",
        "ACE_splint:10",
        "ACE_salineIV:4",
        "ACE_salineIV_500:4",
        "ACE_salineIV_250:10"
      };
    };
    class I_E_CargoNet_01_ammo_F {
       // Add ability to mark the larger supply boxes
       // 0 for no actions
       // 1 for 1x smoke and 1x glow stick
       // 2 for 1x smoke and 1x glow stick, and a quick map marker based off of box name
      addMarkingActions = 2;
      // number of boxes that can be put in the crate, default is four,
      // but should be more than the number of sub boxes desired
      boxCustomName = "Multi Box Drifting";
      boxSpace = 4;
      class Box_NATO_Ammo_F { // doesn't affect configuration (or lack thereof) for this box elsewhere
        boxCount = 2; // default is 1 box
        boxCustomName = "Resupply Box";
        TransportWeapons[] = {"gm_m72a3_oli:2"};
        TransportMagazines[] = {
          "CUP_30Rnd_556x45_Stanag:30",
          "CUP_30Rnd_556x45_Stanag_Tracer_Red:6",
          "CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M:8",
          "CUP_1Rnd_HE_M203:6",
          "CUP_1Rnd_HEDP_M203:4",
          "HandGrenade:8",
          "SmokeShell:5",
          "SmokeShellGreen:1",
          "gm_1Rnd_66mm_heat_m72a3:2"
        };
        TransportItems[] = {
          "ACE_elasticBandage:25",
          "ACE_packingBandage:15",
          "ACE_tourniquet:5",
          "ACE_splint:5"
        };
      };
      // inherit the normal boxes
      class ACE_medicalSupplyCrate: ACE_medicalSupplyCrate {
        boxCustomName = "Tame Medical Box";
      };
    };
  };
};
```
### TODO
- [x] 4x ACE Cargo Slots (customizable)
- [x] Can be carried by a human
- [x] Takes up minimal Cargo slots in a truck (1-2 ACE Cargo - aka yes, you can fit more on the inside. Idk how to deal with that yet)
- [x] Can be ACE interacted with to open a submenu "Marking" > options to activate a chemlight, flare, smoke, and/or mark itself on the map with a label
 