### PR TITLE
ORBAT Improvements (courtesy of SIA/McKendrick)

### DIFF
--- a/addons/briefing/functions/fnc_addOrbat.sqf
+++ b/addons/briefing/functions/fnc_addOrbat.sqf
@@ -1,48 +1,66 @@
 /*
- * Author: PabstMirror
- * Function used to add the order of battle to player's diary
- *
- * Arguments:
- * 0: Unit to add to the OrBat to <OBJECT>
- *
- * Examples:
- * [player] call potato_briefing_fnc_addOrbat;
+ * Author: McKendrick @ SIA 
+ * Adds "ORBAT" tab to briefing that displays a list of players by their squad and roles.  Execute locally.
  *
  * Public: Yes
  */
 
-#include "script_component.hpp"
+ #include "script_component.hpp"
 
-TRACE_1("params",_this);
+if (!hasInterface) exitWith {}; // Exit if not a player.
 
-_this spawn {
-    uiSleep 10;
 
-    params ["_unit"];
-    TRACE_1("",_unit);
+if (!isNil "orbat") then { player removeDiaryRecord ["Diary", orbat] }; // If diary entry already exists, then erase it.
 
-    private _diaryBuilder = [];
-    _diaryBuilder pushBack "<font size='8'>Only accurate at mission start.</font>";
+private _allGroupsWithPlayers = [];
+{ if (side _x == side player) then { _allGroupsWithPlayers pushBackUnique group _x } } forEach (call BIS_fnc_listPlayers); // Create array with all player groups matching the player's side
+//{ if (side _x == side player) then { _allGroupsWithPlayers pushBackUnique _x } } forEach allGroups; // DEBUG FOR SINGLEPLAYER
+_allGroupsWithPlayers = [_allGroupsWithPlayers, [], { groupId _x }] call BIS_fnc_sortBy; // Sort array by group callsigns in alphabetical order
 
-    {
-        if (({isPlayer _x} count (units _x)) > 0) then {
-            if (((side _x) getFriend playerSide) >= 0.6) then {
-                private _color = switch (side _x) do {
-                    case (west): { "#0088EE" }; // use profile colors here
-                    case (east): { "#DD0000" };
-                    case (resistance): { "#00DD00" };
-                    case (civilian): { "#880099" };
-                    default { "#FFFFFF" };
-                };
-                _diaryBuilder pushBack format ["<font color='%1' size='16'>%2</font>", _color, (groupId _x)];
-                {
-                    private _xIcon = getText (configFile >> "CfgVehicles" >> typeOf (vehicle _x) >> "icon");
-                    private _image = getText (configFile >> "CfgVehicleIcons" >> _xIcon);
-                    _diaryBuilder pushBack format ["<img image='%1' width='16' height='16'/><font size='14'>%2</font>", _image, (name _x)];
-                } forEach (units _x);
-            };
-        };
-    } forEach allGroups;
+// Init variables
+private _str = ""; 
+private _teamColor = '';
+private _roleColor = '';
 
-    _unit createDiaryRecord ["diary", ["ORBAT", _diaryBuilder joinString "<br/>"]];
-};
+{
+	private _sideColor = [side  _x] call BIS_fnc_sideColor; // Get RGBA color value of group's side.
+	_sideColor = (_sideColor apply { _x * 2 }) call BIS_fnc_colorRGBAtoHTML; // Brighten the color and convert it to HEX/HTML.
+	_str = _str + format ["<font face='PuristaMedium' size='16' color='%2'>%1</font>", groupId _x, _sideColor] + "<br />"; // Format group callsign with side color.
+
+	{
+		private _role = roleDescription _x;
+		if (_role == "") then { // If roleDescription is set, then truncate. Else use config name.
+			_role = (getText(configFile >> "CfgVehicles" >> (typeOf vehicle _x) >> "displayName"));
+		} else {
+			_role = (_role splitString "@") select 0;
+		};
+
+		if (_x == player) then { _roleColor = '#B21A00' /* red */ } else { _roleColor = '#ffffff' /* white */ }; // Set color of player's name to red
+
+		// Get unit's team and associated color
+		if (group _x == group player) then {
+			_teamColor = switch (assignedTeam _x) do {
+				case "RED": {"#FEAAAA"}; // pink
+				case "GREEN": {"#AAFEAA"}; // light-green
+				case "BLUE": {"#AAAAFE"}; // purple-blue
+				case "YELLOW": {"#FEFEAA"}; // beige-yellow
+				default {"#FFFFFF"}; // white
+			};
+		} else {
+			_teamColor = '#FFB84C'; // If unit not in player's group, then set color to Koromiko (yellow/orange)
+		};
+
+		_roleIcon = format ["<img color='%1' image='\A3\Ui_F\Data\Map\VehicleIcons\"+ (getText(configFile >> "CfgVehicles" >> (typeOf _x) >> "icon")) + "_ca.paa' width='15' height='15'/>", _teamColor]; // Get icon of units' role from config.
+		_str = _str +
+			"  " +
+			_roleIcon +
+			"  " +
+			format ["<font color='%2' face='%3'>%1: </font>", _role, _roleColor, 'PuristaBold'] +
+			format ["<font  color='%2' face='%3'>%1</font>", (name _x), _teamColor, 'PuristaLight'] +
+			"  " +
+			"  <br />"; // Combine images, role, and name into one string.
+	} forEach ([leader _x] + (units _x - [leader _x])); // Do for all units in group, starting with the group lead.
+	_str = _str + "<br />" // Add extra line break after each group.
+} forEach _allGroupsWithPlayers;
+
+orbat = player createDiaryRecord ["Diary", ["ORBAT", "<execute expression='call potato_briefing_fnc_addOrbat;'>Refresh</execute><br></br><br></br>" + _str]]; // Add ORBAT text to diary along with "Refresh" button.


### PR DESCRIPTION
Borrowed code with permission, plenty of tweaks to make it work with BW framework/POTATO along with customization

Adds "Refresh" button that will update ORBAT to current state 
- May be problematic as it could be a game-ified way to check which members of the player side are dead - could add check to only run during SafeStart? This feature is great for JIPs but not if it will be abused

Updated look and style with role labels (along with the existing icons), player color highlight to find yourself, team colors

TODO

- [ ] Team colors don't work (?)
- [ ] Add SafeStart check for refresh button if desired