### PR TITLE
Add CSW for GM MG3 tripod, Fagot, and MILAN.

### DIFF
--- a/addons/cswCompat/patchGM/ACE_CSW_Groups.hpp
+++ b/addons/cswCompat/patchGM/ACE_CSW_Groups.hpp
@@ -1,0 +1,26 @@
+class ACE_CSW_Groups {
+    //// MILAN
+    class gm_1Rnd_milan_heat_dm82_csw {
+        gm_1Rnd_milan_heat_dm82 = 1;
+    };
+    class gm_1Rnd_milan_heat_dm92_csw { // Same name as the carryable magazine
+        gm_1Rnd_milan_heat_dm92 = 1;    // Vehicle magazine that will be loaded when loading this magazine
+    };
+
+    //// Fagot
+    class gm_1Rnd_fagot_heat_9m111_csw {
+      gm_1Rnd_fagot_heat_9m111 = 1;
+    };
+
+    //// MG3
+    class gm_120Rnd_762x51mm_b_t_DM21_mg3_grn {
+        gm_120Rnd_762x51mm_b_t_DM21_mg3_grn = 1;
+    };
+    class gm_120Rnd_762x51mm_b_t_DM21A1_mg3_grn {
+        gm_120Rnd_762x51mm_b_t_DM21A1_mg3_grn = 1;
+    };
+    class gm_120Rnd_762x51mm_b_t_DM21A2_mg3_grn {
+        gm_120Rnd_762x51mm_b_t_DM21A2_mg3_grn = 1;
+    };
+
+};

--- a/addons/cswCompat/patchGM/CfgMagazines.hpp
+++ b/addons/cswCompat/patchGM/CfgMagazines.hpp
@@ -1,0 +1,38 @@
+class CfgMagazines {
+    //// MILAN
+    class gm_1Rnd_milan_heat_dm82;
+    class gm_1Rnd_milan_heat_dm82_csw: gm_1Rnd_milan_heat_dm82 {
+        displayName = "[CSW] HEAT DM82 (MILAN-1)";
+        scope = 2;
+        scopeArsenal = 2;
+        type = 256;
+        count = 1;
+        model = "\gm\gm_weapons\gm_launchers\gm_milan\gm_1rnd_milan_heat_dm92.p3d";
+        ACE_isBelt = 0;
+        mass = 159;
+    };
+
+    class gm_1Rnd_milan_heat_dm92;
+    class gm_1Rnd_milan_heat_dm92_csw: gm_1Rnd_milan_heat_dm92 {
+        displayName = "[CSW] HEAT DM92 (MILAN-2)";
+        scope = 2;
+        scopeArsenal = 2;
+        type = 256;
+        count = 1;
+        model = "\gm\gm_weapons\gm_launchers\gm_milan\gm_1rnd_milan_heat_dm92.p3d";
+        ACE_isBelt = 0;
+        mass = 168;
+    };
+
+    //// Fagot
+    class gm_1Rnd_fagot_heat_9m111;
+    class gm_1Rnd_fagot_heat_9m111_csw: gm_1Rnd_fagot_heat_9m111 {
+        displayName = "[CSW] HEAT 9M111 (Fagot)";
+        scope = 2;
+        scopeArsenal = 2;
+        type = 256;
+        picture = ACE_CSW_PATH(UI\StaticAT_Icon.paa);
+        ACE_isBelt = 0;
+        mass = 276;
+    };
+};

--- a/addons/cswCompat/patchGM/CfgMagazines.hpp
+++ b/addons/cswCompat/patchGM/CfgMagazines.hpp
@@ -2,7 +2,7 @@ class CfgMagazines {
     //// MILAN
     class gm_1Rnd_milan_heat_dm82;
     class gm_1Rnd_milan_heat_dm82_csw: gm_1Rnd_milan_heat_dm82 {
-        displayName = "[CSW] HEAT DM82 (MILAN-1)";
+        displayName = "[CSW] HEAT DM82 (MILAN 1)";
         scope = 2;
         scopeArsenal = 2;
         type = 256;
@@ -14,7 +14,7 @@ class CfgMagazines {
 
     class gm_1Rnd_milan_heat_dm92;
     class gm_1Rnd_milan_heat_dm92_csw: gm_1Rnd_milan_heat_dm92 {
-        displayName = "[CSW] HEAT DM92 (MILAN-2)";
+        displayName = "[CSW] HEAT DM92 (MILAN 2)";
         scope = 2;
         scopeArsenal = 2;
         type = 256;

--- a/addons/cswCompat/patchGM/CfgMagazines.hpp
+++ b/addons/cswCompat/patchGM/CfgMagazines.hpp
@@ -35,4 +35,16 @@ class CfgMagazines {
         ACE_isBelt = 0;
         mass = 276;
     };
+
+    //// MG3
+    class gm_120rnd_762x51mm_mg3_grn;
+    class gm_120Rnd_762x51mm_b_t_DM21_mg3_grn: gm_120rnd_762x51mm_mg3_grn {
+        ACE_isBelt = 0;
+    };
+    class gm_120Rnd_762x51mm_b_t_DM21A1_mg3_grn: gm_120rnd_762x51mm_mg3_grn {
+        ACE_isBelt = 0;
+    };
+    class gm_120Rnd_762x51mm_b_t_DM21A2_mg3_grn: gm_120rnd_762x51mm_mg3_grn {
+        ACE_isBelt = 0;
+    };
 };

--- a/addons/cswCompat/patchGM/CfgVehicles.hpp
+++ b/addons/cswCompat/patchGM/CfgVehicles.hpp
@@ -197,31 +197,68 @@ class CfgVehicles {
     };
 
     //// MG3 AA
-    class gm_staticMG_base;
-    class gm_mg3_aatripod_base: gm_staticMG_base {
-      class ACE_Actions;
+    // MG3 Tripod
+    class StaticWeapon;
+    class gm_staticWeapon_base: StaticWeapon {
+        class ACE_Actions;
     };
-    class gm_ge_army_mg3_aatripod_base: gm_mg3_aatripod_base {
+    class gm_staticMG_base: gm_staticWeapon_base {
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions;
         };
     };
-    class gm_ge_army_mg3_aatripod: gm_ge_army_mg3_aatripod_base {
+    class gm_mg3_aatripod_base: gm_staticMG_base {
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 selection = "machinegunturret_01_elev";
             };
         };
+    };
+    class gm_ge_army_mg3_aatripod_base: gm_mg3_aatripod_base {
+        class ACE_Actions: ACE_Actions;
+    };
+    class gm_ge_army_mg3_aatripod: gm_ge_army_mg3_aatripod_base {
+        class ACE_Actions: ACE_Actions;
+    };
+    class gm_ge_army_mg3_aatripod_csw: gm_ge_army_mg3_aatripod {
+        class ACE_Actions: ACE_Actions;
         class ACE_CSW {
             enabled = 1; // Enables ACE CSW for this weaponmmo handling interaction point location (custom pos)
             ammoLoadTime = 0.1 ;   // How long it takes in
             proxyWeapon = ""; // The proxy weapon created above. This can also be a function name that returns a proxy weapon - passed [_vehicle, _turret, _currentWeapon, _needed, _emptyWeapon]
             disassembleWeapon = "gm_mg3_blk";  // Carryable weapon created above
-            disassembleTurret = "ace_csw_m3CarryTripod"; // Which static tripod will appear when weapon is disassembled
+            disassembleTurret = QGVAR(gm_MG3Tripod); // Which static tripod will appear when weapon is disassembled
             magazineLocation = "_target selectionPosition 'machinegunturret_01_magazine'"; // Aseconds to load ammo into the weapon
             ammoUnloadTime = 5; // How long it takes in seconds to unload ammo from the weapon
             desiredAmmo = 120;  // When the weapon is reloaded it will try and reload to this ammo capacity
         };
+        displayName = "[CSW] MG3 - Anti Air Tripod";
+    };
+
+    // MG3 Tripod
+    class ThingX;
+    class ace_csw_baseTripod: ThingX {
+        class ACE_Actions;
+    };
+    class ace_csw_m3Tripod: ace_csw_baseTripod {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions;
+        };
+    };
+    class GVAR(gm_MG3Tripod): ace_csw_m3Tripod {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                selection = "machinegunturret_01_mounthide";
+            };
+        };
+        class ACE_CSW {
+            disassembleTo = QGVAR(gm_MG3TripodCarry);
+        };
+        displayName = "[CSW] MG3 AA Tripod (GM)";
+        editorPreview = "gm\gm_weapons\gm_machineguns\gm_mg3\data\ui\preview_gm_mg3_aatripod_base.jpg";
+        icon = "\gm\gm_weapons\gm_machineguns\gm_mg3\data\ui\map_gm_mg3_aatripod_ca";
+        model = "\gm\gm_weapons\gm_machineguns\gm_mg3\gm_mg3_aatripod";
+        picture = "\gm\gm_weapons\gm_machineguns\gm_mg3\data\ui\picture_gm_mg3_aatripod_ca";
     };
 };
 // spg9 model location selectionName: "mainturret_rear"

--- a/addons/cswCompat/patchGM/CfgVehicles.hpp
+++ b/addons/cswCompat/patchGM/CfgVehicles.hpp
@@ -1,0 +1,227 @@
+class CfgVehicles {
+    class gm_staticATGM_base;
+    //// MILAN
+    class gm_milan_launcher_tripod_base: gm_staticATGM_base {
+        class ACE_Actions;
+        class Turrets;
+    };
+    class gm_ge_army_milan_launcher_tripod_base: gm_milan_launcher_tripod_base {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions;
+        };
+        class AnimationSources;
+        class Turrets: Turrets {
+            class MainTurret;
+        };
+    };
+    class gm_ge_army_milan_launcher_tripod: gm_ge_army_milan_launcher_tripod_base {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                selection = "mainturret_elev";
+            };
+        };
+        class AnimationSources: AnimationSources {
+            class MainTurret_realodMagazine_source;
+            class MainTurret_revolving_source;
+        };
+        class assembleInfo;
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                class Components;
+                class GunClouds;
+                class GunFire;
+                class HitPoints;
+                class MGunClouds;
+                class Reflectors;
+                class TurnIn;
+                class TurnOut;
+                class Turrets;
+                class TurretSpec;
+                class ViewGunner;
+                class ViewOptics;
+            };
+        };
+    };
+    class gm_ge_army_milan_launcher_tripod_csw: gm_ge_army_milan_launcher_tripod {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                class ACE_csw_pickUp {
+                    displayName = "Disassemble";
+                    condition = "call ace_csw_fnc_canPickupTripod";
+                    statement = "call ace_csw_fnc_assemble_pickupTripod";
+                };
+            };
+        };
+        class ACE_CSW {
+            enabled = 1; // Enables ACE CSW for this weaponmmo handling interaction point location (custom pos)
+            ammoLoadTime = 10 ;   // How long it takes in
+            proxyWeapon = ""; // The proxy weapon created above. This can also be a function name that returns a proxy weapon - passed [_vehicle, _turret, _currentWeapon, _needed, _emptyWeapon]
+            disassembleWeapon = "";  // Carryable weapon created above
+            disassembleTurret = ""; // Which static tripod will appear when weapon is disassembled
+            disassembleTo = QGVAR(gm_milan_backpack); // Abuse the tripods
+            magazineLocation = "[0.204429,0.696469,-0.680236]"; // Aseconds to load ammo into the weapon
+            ammoUnloadTime = 10; // How long it takes in seconds to unload ammo from the weapon
+            desiredAmmo = 1;  // When the weapon is reloaded it will try and reload to this ammo capacity
+        };
+        class AnimationSources: AnimationSources {
+            class MainTurret_realodMagazine_source: MainTurret_realodMagazine_source {
+                source = "reloadmagazine";
+                weapon = QGVAR(gm_milan_launcher_proxy);
+            };
+            class MainTurret_revolving_source: MainTurret_revolving_source {
+                source = "revolving";
+                weapon = QGVAR(gm_milan_launcher_proxy);
+            };
+        };
+        class assembleInfo: assembleInfo {
+            dissasembleTo[] = {};
+        };
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                class Components: Components;
+                class GunClouds: GunClouds;
+                class GunFire: GunFire;
+                class HitPoints: HitPoints;
+                class MGunClouds: MGunClouds;
+                class Reflectors: Reflectors;
+                class TurnIn: TurnIn;
+                class TurnOut: TurnOut;
+                class Turrets: Turrets;
+                class TurretSpec: TurretSpec;
+                class ViewGunner: ViewGunner;
+                class ViewOptics: ViewOptics;
+                weapons[] = {QGVAR(gm_milan_launcher_proxy)};
+                magazines[] = {};
+            };
+        };
+        displayName = "[CSW] MILAN";
+        displayNameShort = "MILAN";
+    };
+
+    //// Fagot
+    class gm_fagot_launcher_tripod_base: gm_staticATGM_base {
+        class ACE_Actions;
+        class Turrets;
+    };
+    class gm_gc_army_fagot_launcher_tripod_base: gm_fagot_launcher_tripod_base {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions;
+        };
+        class AnimationSources;
+        class Turrets: Turrets {
+            class MainTurret;
+        };
+    };
+    class gm_gc_army_fagot_launcher_tripod: gm_gc_army_fagot_launcher_tripod_base {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                selection = "mainturret_elev";
+            };
+        };
+        class AnimationSources: AnimationSources {
+            class MainTurret_realodMagazine_source;
+            class MainTurret_revolving_source;
+        };
+        class assembleInfo;
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                class Components;
+                class GunClouds;
+                class GunFire;
+                class HitPoints;
+                class MGunClouds;
+                class Reflectors;
+                class TurnIn;
+                class TurnOut;
+                class Turrets;
+                class TurretSpec;
+                class ViewGunner;
+                class ViewOptics;
+            };
+        };
+    };
+    class gm_gc_army_fagot_launcher_tripod_csw: gm_gc_army_fagot_launcher_tripod {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                class ACE_csw_pickUp {
+                    displayName = "Disassemble";
+                    condition = "call ace_csw_fnc_canPickupTripod";
+                    statement = "call ace_csw_fnc_assemble_pickupTripod";
+                };
+            };
+        };
+        class ACE_CSW {
+            enabled = 1; // Enables ACE CSW for this weaponmmo handling interaction point location (custom pos)
+            ammoLoadTime = 10 ;   // How long it takes in
+            proxyWeapon = ""; // The proxy weapon created above. This can also be a function name that returns a proxy weapon - passed [_vehicle, _turret, _currentWeapon, _needed, _emptyWeapon]
+            disassembleWeapon = "";  // Carryable weapon created above
+            disassembleTurret = ""; // Which static tripod will appear when weapon is disassembled
+            disassembleTo = QGVAR(gm_fagot_backpack); // Abuse the tripods
+            magazineLocation = "[0,0.4,-0.7]"; // Aseconds to load ammo into the weapon
+            ammoUnloadTime = 10; // How long it takes in seconds to unload ammo from the weapon
+            desiredAmmo = 1;  // When the weapon is reloaded it will try and reload to this ammo capacity
+        };
+        class AnimationSources: AnimationSources {
+            class MainTurret_realodMagazine_source: MainTurret_realodMagazine_source {
+                source = "reloadmagazine";
+                weapon = QGVAR(gm_fagot_launcher_proxy);
+            };
+            class MainTurret_revolving_source: MainTurret_revolving_source {
+                source = "revolving";
+                weapon = QGVAR(gm_fagot_launcher_proxy);
+            };
+        };
+        class assembleInfo: assembleInfo {
+            dissasembleTo[] = {};
+        };
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                class Components: Components;
+                class GunClouds: GunClouds;
+                class GunFire: GunFire;
+                class HitPoints: HitPoints;
+                class MGunClouds: MGunClouds;
+                class Reflectors: Reflectors;
+                class TurnIn: TurnIn;
+                class TurnOut: TurnOut;
+                class Turrets: Turrets;
+                class TurretSpec: TurretSpec;
+                class ViewGunner: ViewGunner;
+                class ViewOptics: ViewOptics;
+                weapons[] = {QGVAR(gm_fagot_launcher_proxy)};
+                magazines[] = {};
+            };
+        };
+        displayName = "[CSW] Fagot";
+        displayNameShort = "Fagot";
+    };
+
+    //// MG3 AA
+    class gm_staticMG_base;
+    class gm_mg3_aatripod_base: gm_staticMG_base {
+      class ACE_Actions;
+    };
+    class gm_ge_army_mg3_aatripod_base: gm_mg3_aatripod_base {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions;
+        };
+    };
+    class gm_ge_army_mg3_aatripod: gm_ge_army_mg3_aatripod_base {
+        class ACE_Actions: ACE_Actions {
+            class ACE_MainActions: ACE_MainActions {
+                selection = "machinegunturret_01_elev";
+            };
+        };
+        class ACE_CSW {
+            enabled = 1; // Enables ACE CSW for this weaponmmo handling interaction point location (custom pos)
+            ammoLoadTime = 0.1 ;   // How long it takes in
+            proxyWeapon = ""; // The proxy weapon created above. This can also be a function name that returns a proxy weapon - passed [_vehicle, _turret, _currentWeapon, _needed, _emptyWeapon]
+            disassembleWeapon = "gm_mg3_blk";  // Carryable weapon created above
+            disassembleTurret = "ace_csw_m3CarryTripod"; // Which static tripod will appear when weapon is disassembled
+            magazineLocation = "_target selectionPosition 'machinegunturret_01_magazine'"; // Aseconds to load ammo into the weapon
+            ammoUnloadTime = 5; // How long it takes in seconds to unload ammo from the weapon
+            desiredAmmo = 120;  // When the weapon is reloaded it will try and reload to this ammo capacity
+        };
+    };
+};
+// spg9 model location selectionName: "mainturret_rear"

--- a/addons/cswCompat/patchGM/CfgWeapons.hpp
+++ b/addons/cswCompat/patchGM/CfgWeapons.hpp
@@ -6,7 +6,7 @@ class CfgWeapons {
         class WeaponSlotsInfo;
     };
 
-    // Milan
+    /// Milan
     class GVAR(gm_milan_backpack): Launcher_Base_F {
         class ACE_CSW {
             type = "mount";
@@ -29,7 +29,7 @@ class CfgWeapons {
         picture = "\gm\gm_weapons\gm_launchers\gm_milan\data\ui\picture_gm_milan_launcher_weaponBag_ca";
     };
 
-    // Fagot
+    /// Fagot
     class GVAR(gm_fagot_backpack): Launcher_Base_F {
         class ACE_CSW {
             type = "mount";
@@ -52,7 +52,8 @@ class CfgWeapons {
         picture = "\gm\gm_weapons\gm_launchers\gm_fagot\data\ui\picture_gm_fagot_launcher_weaponBag_ca";
     };
 
-    // MG3
+    /// MG3
+    // Weapon
     class gm_mg3_base;
     class gm_mg3_blk: gm_mg3_base {
         class ACE_CSW {
@@ -60,9 +61,28 @@ class CfgWeapons {
             deployTime = 4;
             pickupTime = 4;
             class assembleTo {
-                ace_csw_m3Tripod = "gm_ge_army_mg3_aatripod";
+                GVAR(gm_MG3Tripod) = "gm_ge_army_mg3_aatripod_csw";
             };
         };
+    };
+
+    // Tripod
+    class ace_csw_m3CarryTripod: Launcher_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo;
+    };
+    class GVAR(gm_MG3TripodCarry): ace_csw_m3CarryTripod {
+        class ACE_CSW {
+            type = "mount";
+            deployTime = 4;
+            pickupTime = 4;
+            deploy = QGVAR(gm_MG3Tripod);
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 256; // fun number
+        };
+        displayName = "[CSW] MG3 AA Tripod";
+        icon = "\gm\gm_weapons\gm_machineguns\gm_mg3\data\ui\map_gm_mg3_aatripod_ca";
+        picture = "\gm\gm_weapons\gm_machineguns\gm_mg3\data\ui\picture_gm_mg3_aatripod_weaponBag_ca";
     };
 
     //// Proxy Weapons

--- a/addons/cswCompat/patchGM/CfgWeapons.hpp
+++ b/addons/cswCompat/patchGM/CfgWeapons.hpp
@@ -1,0 +1,78 @@
+class CfgWeapons {
+
+    //// Carryable weapons
+    class Launcher;
+    class Launcher_Base_F: Launcher {
+        class WeaponSlotsInfo;
+    };
+
+    // Milan
+    class GVAR(gm_milan_backpack): Launcher_Base_F {
+        class ACE_CSW {
+            type = "mount";
+            deployTime = 4;
+            pickupTime = 4;
+            deploy = "gm_ge_army_milan_launcher_tripod_csw";
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+            mass = 362; // 16.4 kg
+        };
+        displayName = "[CSW] MILAN (GM)";
+        author = "Lambda.Tiger";
+        scope = 2;
+        scopeArsenal = 2;
+        model = ACE_APL_PATH(ACE_CSW_Bag.p3d);
+        modes[] = {};
+        picture = "\gm\gm_weapons\gm_launchers\gm_milan\data\ui\picture_gm_milan_launcher_weaponBag_ca";
+    };
+
+    // Fagot
+    class GVAR(gm_fagot_backpack): Launcher_Base_F {
+        class ACE_CSW {
+            type = "mount";
+            deployTime = 4;
+            pickupTime = 4;
+            deploy = "gm_gc_army_fagot_launcher_tripod_csw";
+        };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class MuzzleSlot {
+                iconScale = 0.1;
+            };
+            mass = 496; // 22.5 kg
+        };
+        displayName = "[CSW] Fagot (GM)";
+        author = "Lambda.Tiger";
+        scope = 2;
+        scopeArsenal = 2;
+        model = ACE_APL_PATH(ACE_CSW_Bag.p3d);
+        modes[] = {};
+        picture = "\gm\gm_weapons\gm_launchers\gm_fagot\data\ui\picture_gm_fagot_launcher_weaponBag_ca";
+    };
+
+    // MG3
+    class gm_mg3_base;
+    class gm_mg3_blk: gm_mg3_base {
+        class ACE_CSW {
+            type = "weapon";
+            deployTime = 4;
+            pickupTime = 4;
+            class assembleTo {
+                ace_csw_m3Tripod = "gm_ge_army_mg3_aatripod";
+            };
+        };
+    };
+
+    //// Proxy Weapons
+    class gm_milan_launcher;
+    class GVAR(gm_milan_launcher_proxy): gm_milan_launcher {
+        magazineReloadTime = 0.5;
+    };
+
+    class gm_fagot_launcher;
+    class GVAR(gm_fagot_launcher_proxy): gm_fagot_launcher {
+        magazineReloadTime = 0.5;
+    };
+};

--- a/addons/cswCompat/patchGM/config.cpp
+++ b/addons/cswCompat/patchGM/config.cpp
@@ -7,10 +7,17 @@
 class CfgPatches {
     class ADDON {
         units[] = {
-          "gm_ge_army_milan_launcher_tripod_csw"
+          "gm_ge_army_milan_launcher_tripod_csw",
+          "gm_gc_army_fagot_launcher_tripod_csw",
+          "gm_ge_army_mg3_aatripod_csw",
+          QGVAR(gm_MG3Tripod)
         };
         weapons[] = {
-          QGVAR(gm_milan)
+          QGVAR(gm_milan_backpack),
+          QGVAR(gm_fagot_backpack),
+          QGVAR(gm_MG3TripodCarry),
+          QGVAR(gm_milan_launcher_proxy),
+          QGVAR(gm_fagot_launcher_proxy)
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
@@ -18,10 +25,8 @@ class CfgPatches {
             "gm_weapons_ammo",
             "gm_weapons_launchers_milan",
             "gm_weapons_launchers_fagot",
-            "gm_weapons_machineguns_dshkm_gm_gc_army_dshkm",
             "gm_weapons_machineguns_mg3_gm_ge_army_mg3",
-            "gm_weapons_launchers_fagot_gm_gc_army_fagot",
-            "gm_weapons_launchers_spg9_gm_gc_army_spg9"
+            "gm_weapons_launchers_fagot_gm_gc_army_fagot"
         };
         skipWhenMissingDependencies = 0;
         author = "Bourbon Warfare";

--- a/addons/cswCompat/patchGM/config.cpp
+++ b/addons/cswCompat/patchGM/config.cpp
@@ -1,0 +1,36 @@
+// "\gm\gm_weapons\gm_launchers\gm_milan\gm_milan_heat_dm92.p3d"
+// "\gm\gm_weapons\gm_launchers\gm_fagot\gm_fagot_heat_9m111.p3d"
+#include "\z\potato\addons\cswCompatCUP\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT cswCompatCUP_patchGM
+
+class CfgPatches {
+    class ADDON {
+        units[] = {
+          "gm_ge_army_milan_launcher_tripod_csw"
+        };
+        weapons[] = {
+          QGVAR(gm_milan)
+        };
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "potato_cswCompatCUP",
+            "gm_weapons_ammo",
+            "gm_weapons_launchers_milan",
+            "gm_weapons_launchers_fagot",
+            "gm_weapons_machineguns_dshkm_gm_gc_army_dshkm",
+            "gm_weapons_machineguns_mg3_gm_ge_army_mg3",
+            "gm_weapons_launchers_fagot_gm_gc_army_fagot",
+            "gm_weapons_launchers_spg9_gm_gc_army_spg9"
+        };
+        skipWhenMissingDependencies = 0;
+        author = "Bourbon Warfare";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "ACE_CSW_Groups.hpp"
+#include "CfgMagazines.hpp"
+#include "CfgWeapons.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/cswCompat/patchGM/config.cpp
+++ b/addons/cswCompat/patchGM/config.cpp
@@ -28,7 +28,7 @@ class CfgPatches {
             "gm_weapons_machineguns_mg3_gm_ge_army_mg3",
             "gm_weapons_launchers_fagot_gm_gc_army_fagot"
         };
-        skipWhenMissingDependencies = 0;
+        skipWhenMissingDependencies = 1;
         author = "Bourbon Warfare";
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
         VERSION_CONFIG;


### PR DESCRIPTION
This PR adds CSW version of GM static weapons including:
- MG3 AA tripod
- MILAN
- Fagot

To add the MILAN and Fagot, there is some abuse of the system by treating them as "tripods." The MG3 uses current ACE master functionality to allow primary weapons to be mounted. Video on discord.