### PR TITLE
assignGear bug fixes

### DIFF
--- a/addons/assignGear/functions/fnc_assignGearSupplyBox.sqf
+++ b/addons/assignGear/functions/fnc_assignGearSupplyBox.sqf
@@ -42,7 +42,7 @@ if (!isClass _path) exitWith {
 };
 
 private _subBoxes = "true" configClasses _path;
-if (_subBoxes isNotEqualTo []) then {
+if (_subBoxes isNotEqualTo [] && GVAR(setSupplyBoxLoadouts) == 2) then {
     private _boxName = getText (_path >> "boxCustomName");
     if (_boxName isNotEqualTo "") then {
         _theBox setVariable [QACEGVAR(cargo,customName), _boxName, true];

--- a/addons/assignGear/functions/fnc_assignGearVehicle.sqf
+++ b/addons/assignGear/functions/fnc_assignGearVehicle.sqf
@@ -97,6 +97,9 @@ switch (GVAR(setVehicleLoadouts)) do {
         clearItemCargoGlobal _theVehicle;
         clearBackpackCargoGlobal _theVehicle;
         private _boxes = "true" configClasses _path;
+        if (_boxes isEqualTo []) exitWith {
+            [_theVehicle, _path] call FUNC(setContainerContentsFromConfig);
+        };
         private _vehicleSpace = getNumber (_path >> "minVehicleBoxSpace");
         if (_vehicleSpace > 0) then {
             private _currentVehicleSpace = _theVehicle getVariable [

--- a/addons/assignGear/functions/fnc_assignGearVehicle_asBoxes.sqf
+++ b/addons/assignGear/functions/fnc_assignGearVehicle_asBoxes.sqf
@@ -208,7 +208,7 @@ while {
             _box addItemCargoGlobal _x;
         } forEach _toAdd;
     };
-
+    _box setVariable [QGVAR(initialized), true, true];
     _box setVariable [QACEGVAR(cargo,customName), _name joinString ",", true];
 };
 


### PR DESCRIPTION
Current problem:
With `setSupplyBoxLoadouts = -1`, the boxes are cleared after they're set in `fnc_assignGearVehicle_asBoxes`. I had handled this for other settings using [a variable on the box](https://github.com/BourbonWarfare/POTATO/blob/8625ee16b4f5cd897fe433ef2f653146e1903fba/addons/assignGear/functions/fnc_assignGearSupplyBox.sqf#L27), but this slipped through when I was testing #539.

Fix is simple though.