### PR TITLE
Update AMA Handle Damage to match changes in ACE Handle Damage

### DIFF
--- a/addons/armor_modifier_ace/functions/fnc_handleDamage.sqf
+++ b/addons/armor_modifier_ace/functions/fnc_handleDamage.sqf
@@ -37,9 +37,9 @@ if (_structuralDamage) then {
 if !(isDamageAllowed _unit && {_unit getVariable ["ace_medical_allowDamage", true] || _ignoreAllowDamageACE}) exitWith {_oldDamage};
 
 // Killing units via End key is an edge case (#10375)
-if (_structuralDamage && {_damage == 1 && _ammo == "" && isNull _shooter && isNull _instigator}) exitWith {_damage};
-
 private _newDamage = _damage - _oldDamage;
+if (_structuralDamage && {(abs (_newDamage - 1)) < 0.001 && _ammo == "" && isNull _shooter && isNull _instigator}) exitWith {_damage};
+
 
 // _newDamage == 0 happens occasionally for vehiclehit events (see line 80 onwards), just exit early to save some frametime
 // context 4 is engine "bleeding". For us, it's just a duplicate event for #structural which we can ignore without any issues

--- a/addons/armor_modifier_ace/functions/fnc_handleDamage.sqf
+++ b/addons/armor_modifier_ace/functions/fnc_handleDamage.sqf
@@ -1,7 +1,6 @@
 #include "..\script_component.hpp"
-
 /*
- * Author: commy2, kymckay, modified by johnb43 & Lambda.Tiger
+ * Author: commy2, kymckay, LinkIsGrim modified by johnb43 & Lambda.Tiger
  * Original:
  * HandleDamage EH where wound events are raised based on incoming damage.
  * Be aware that for each source of damage, the EH can fire multiple times (once for each hitpoint).
@@ -17,7 +16,6 @@
  *
  * Public: No
  */
-
 params ["_args", ["_ignoreAllowDamageACE", false]];
 _args params ["_unit", "_selection", "_damage", "_shooter", "_ammo", "_hitPointIndex", "_instigator", "_hitpoint", "_directHit", "_context"];
 
@@ -28,7 +26,7 @@ if !(local _unit) exitWith {nil};
 private _oldDamage = 0;
 private _structuralDamage = _context == 0;
 
-if (_hitPoint isEqualTo "") then {
+if (_structuralDamage) then {
     _hitPoint = "#structural";
     _oldDamage = damage _unit;
 } else {
@@ -37,6 +35,9 @@ if (_hitPoint isEqualTo "") then {
 
 // Damage can be disabled with old variable or via sqf command allowDamage
 if !(isDamageAllowed _unit && {_unit getVariable ["ace_medical_allowDamage", true] || _ignoreAllowDamageACE}) exitWith {_oldDamage};
+
+// Killing units via End key is an edge case (#10375)
+if (_structuralDamage && {_damage == 1 && _ammo == "" && isNull _shooter && isNull _instigator}) exitWith {_damage};
 
 private _newDamage = _damage - _oldDamage;
 
@@ -206,7 +207,11 @@ if (_context == 2) then {
     if (_environmentDamage) then {
         // Any collision with terrain/vehicle/object has a shooter
         // Check this first because burning can happen at any velocity
-        if !(isNull _shooter) then {
+        if (isNull _shooter) then {
+            // Anything else is almost guaranteed to be fire damage
+            _ammo = "fire";
+            TRACE_5("Fire Damage",_unit,_shooter,_instigator,_damage,_allDamages);
+        } else {
             /*
               If shooter != unit then they hit unit, otherwise it could be:
                - Unit hitting anything at speed
@@ -221,10 +226,6 @@ if (_context == 2) then {
                 _ammo = "collision";
                 TRACE_5("Collision",_unit,_shooter,_instigator,_damage,_allDamages);
             };
-        } else {
-            // Anything else is almost guaranteed to be fire damage
-            _ammo = "fire";
-            TRACE_5("Fire Damage",_unit,_shooter,_instigator,_damage,_allDamages);
         };
     };
 


### PR DESCRIPTION
Updated `potato_armor_modifier_ace_fnc_handleDamage` to match changes made in current [`ace_medical_engine_fnc_handleDamage`.](https://github.com/acemod/ACE3/blob/631db9d6037ebe22219cdef3f2bad10b6f95507d/addons/medical_engine/functions/fnc_handleDamage.sqf)