### PR TITLE
Fixed error with Weapon Lowering Shortcut

### DIFF
--- a/addons/miscFixes/XEH_preInit.sqf
+++ b/addons/miscFixes/XEH_preInit.sqf
@@ -27,8 +27,8 @@ if (["WBK_ZombieCreatures"] call ACEFUNC(common,isModLoaded)) then {
 addUserActionEventHandler ["toggleRaiseWeapon","Activate",{
 	private _lAnim = animationState ace_player;
 	if ("stp" in _lAnim || "non" in _lAnim || !alive ace_player) exitWith {};
-	_lAnim = _lAnim splitString "";
-	private _state = [_lAnim #13,_lAnim #14,_lAnim #15] joinString "";
+	private _state = _lAnim select [13, 2];
+    _lAnim = _lAnim splitString "";
 	switch(_state)do{
 		case "ras": {
 			_lAnim set [13,"l"];

--- a/addons/miscFixes/XEH_preInit.sqf
+++ b/addons/miscFixes/XEH_preInit.sqf
@@ -27,7 +27,7 @@ if (["WBK_ZombieCreatures"] call ACEFUNC(common,isModLoaded)) then {
 addUserActionEventHandler ["toggleRaiseWeapon","Activate",{
 	private _lAnim = animationState ace_player;
 	if ("stp" in _lAnim || "non" in _lAnim || !alive ace_player) exitWith {};
-	private _state = _lAnim select [13, 2];
+	private _state = _lAnim select [13, 3];
     _lAnim = _lAnim splitString "";
 	switch(_state)do{
 		case "ras": {

--- a/addons/miscFixes/XEH_preInit.sqf
+++ b/addons/miscFixes/XEH_preInit.sqf
@@ -24,9 +24,9 @@ if (["WBK_ZombieCreatures"] call ACEFUNC(common,isModLoaded)) then {
 };
 
 //add EH to fix weapon lowering while walking fix
-addUserActionEventHandler ["toggleRaiseWeapon","Activate",{ 
+addUserActionEventHandler ["toggleRaiseWeapon","Activate",{
 	private _lAnim = animationState ace_player;
-	if ("stp" in _lAnim || "non" in _lAnim) exitWith {};
+	if ("stp" in _lAnim || "non" in _lAnim || !alive ace_player) exitWith {};
 	_lAnim = _lAnim splitString "";
 	private _state = [_lAnim #13,_lAnim #14,_lAnim #15] joinString "";
 	switch(_state)do{


### PR DESCRIPTION
Fixed an error would be thrown if `ace_player` was not defined and the weapon lower shortcut was pressed.
![image](https://github.com/user-attachments/assets/a050883d-e13d-42f9-9ccc-77e7580d812a)
Checking for `!alive` will handle both dead and `nullObject` settings for `ace_player`.