### PR TITLE
aceEdits - Add Ability to Retrieve Primary/Secondary from dead units from their Body 

### DIFF
--- a/addons/aceEdits/$PBOPREFIX$
+++ b/addons/aceEdits/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\potato\addons\aceedits

--- a/addons/aceEdits/CfgEventHandlers.hpp
+++ b/addons/aceEdits/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};

--- a/addons/aceEdits/CfgVehicles.hpp
+++ b/addons/aceEdits/CfgVehicles.hpp
@@ -1,0 +1,24 @@
+class CfgVehicles {
+    class Man;
+    class CAManBase: Man {
+        class ACE_Actions {
+            class ACE_MainActions {
+                class ACEGVAR(interaction,Gear) {
+                    class GVAR(pickupPrimaryWeapon) {
+                        displayName = "Take Primary";
+                        condition = QUOTE([true] call FUNC(actionPickupWeapon_condition));
+                        statement = QUOTE([true] call FUNC(actionPickupWeapon_statement));
+                        modifierFunction = QUOTE([ARR_2(_this,true)] call FUNC(actionPickupWeapon_modifier));
+                        icon = "\A3\ui_f\data\igui\cfg\actions\take_ca.paa";
+                    };
+                    class GVAR(pickupSecondaryWeapon): GVAR(pickupPrimaryWeapon) {
+                        displayName = "Take Secondary";
+                        condition = QUOTE([false] call FUNC(actionPickupWeapon_condition));
+                        statement = QUOTE([false] call FUNC(actionPickupWeapon_statement));
+                        modifierFunction = QUOTE([ARR_2(_this,false)] call FUNC(actionPickupWeapon_modifier));
+                    };
+                };
+            };
+        };
+    };
+};

--- a/addons/aceEdits/XEH_PREP.hpp
+++ b/addons/aceEdits/XEH_PREP.hpp
@@ -1,0 +1,5 @@
+TRACE_1("",QUOTE(ADDON));
+
+PREP(actionPickupWeapon_condition);
+PREP(actionPickupWeapon_modifier);
+PREP(actionPickupWeapon_statement);

--- a/addons/aceEdits/XEH_preInit.sqf
+++ b/addons/aceEdits/XEH_preInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+ADDON = true;

--- a/addons/aceEdits/XEH_preStart.sqf
+++ b/addons/aceEdits/XEH_preStart.sqf
@@ -1,0 +1,4 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"
+

--- a/addons/aceEdits/config.cpp
+++ b/addons/aceEdits/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_interaction"};
+        author = "Potato";
+        authors[] = {"Lambda.Tiger"};
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/aceEdits/functions/fnc_actionPickupWeapon_condition.sqf
+++ b/addons/aceEdits/functions/fnc_actionPickupWeapon_condition.sqf
@@ -1,0 +1,27 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * This function is checks whether the unit is dead and the weapon holders
+ * exist before the action to retrieve either a primary or secondary weapon
+ * is shown to the player.
+ *
+ * Arguments:
+ * 0: Whether the weapon is a primary or not (BOOL)
+ *
+ * Return Value:
+ * Whether to show the action or not (BOOL)
+ *
+ * Examples:
+ * [(modifierFunction Args), true] call potato_aceEdits_actionPickupWeapon_condition;
+ *
+ * Public: No
+ */
+TRACE_3("",_this,_target,_player);
+// _player and _target are provided on call by the ace interact menu
+params ["_isPrimaryWeapon"];
+
+private _weaponIndex = [1, 0] select _isPrimaryWeapon;
+private _weaponHolder = (getCorpseWeaponholders _target)#_weaponIndex;
+!alive _target &&
+{count weaponCargo _weaponHolder == 1} &&
+{_player distance _weaponHolder < 5}

--- a/addons/aceEdits/functions/fnc_actionPickupWeapon_modifier.sqf
+++ b/addons/aceEdits/functions/fnc_actionPickupWeapon_modifier.sqf
@@ -1,0 +1,33 @@
+#include "..\script_component.hpp"
+/*
+ * Funcion inspired by Johnb432's ACE action for everything mod
+ * Author: Lambda.Tiger
+ * This function is used to modify an action name to be <take weapon gun name>.
+ * It takes the default modifierFunction arguments and whether the weapon is a
+ * primary or not and uses them to change the name of the action (boolean).
+ *
+ * Arguments:
+ * 0: (ACE Interact Framework modifierFunction ARGS) (ARRAY)
+ * 1: Whether the weapon is a primary or not (BOOL)
+ *
+ * Return Value:
+ * None
+ *
+ * Examples:
+ * [(modifierFunction Args), true] call potato_aceEdits_actionPickupWeapon_modifer;
+ *
+ * Public: No
+ */
+TRACE_1("",_this);
+
+params ["_actionArgs", "_isPrimaryWeapon"];
+_actionArgs params ["_target", "", "", "_actionData"];
+
+private _weaponIndex = [1, 0] select _isPrimaryWeapon;
+
+private _weaponHolder = getCorpseWeaponholders _target#_weaponIndex;
+_actionData set [1,
+    format [
+        localize "STR_ACTION_TAKE_BAG",
+        getText (configFile >> "CfgWeapons" >> (weaponCargo _weaponHolder#0) >> "displayName")
+]];

--- a/addons/aceEdits/functions/fnc_actionPickupWeapon_statement.sqf
+++ b/addons/aceEdits/functions/fnc_actionPickupWeapon_statement.sqf
@@ -1,0 +1,26 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * This function is used to make the player take a weapon from a specific
+ * weapon holder. The function is passed a boolean of whether the weapon
+ * is a primary (not a seoconday).
+ *
+ * Arguments:
+ * 0: Whether the weapon is a primary or not (BOOL)
+ *
+ * Return Value:
+ * None
+ *
+ * Examples:
+ * [true] call potato_aceEdits_actionPickupWeapon_statement;
+ *
+ * Public: No
+ */
+TRACE_3("",_this,_target,_player);
+// _player and _target are provided on call by the ace interact menu
+params ["_isPrimaryWeapon"];
+
+private _weaponIndex = [1, 0] select _isPrimaryWeapon;
+
+private _weaponHolder = getCorpseWeaponholders _target#_weaponIndex;
+_player action ["TakeWeapon", _weaponHolder, weaponCargo _weaponHolder#0];

--- a/addons/aceEdits/script_component.hpp
+++ b/addons/aceEdits/script_component.hpp
@@ -1,0 +1,12 @@
+#define COMPONENT aceEdits
+#include "\z\potato\addons\core\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_ADMINCOMS
+    #define DEBUG_MODE_FULL
+#endif
+
+#include "\z\potato\addons\core\script_macros.hpp"


### PR DESCRIPTION
I've struggled with and seen other struggle to pickup weapons that are dropped when a unit dies. Often times the weapon holder ends up underground or in some way inaccessible leaving a player spending time spinning around trying to get to the weapon, for example [here](https://www.youtube.com/live/W2Ccboq4iJA?si=Dut9YGHOjDUtWLM3&t=9154). This PR
- Adds an ACE interact on bodies that lets a player pickup a weapon if it's within 5 meters of the body
- Adds a context sensitive action name for each weapon/launcher