### PR TITLE
Briefing - Make ORBAT Updatable and Trigger a Update on Safe Start Ending

### DIFF
--- a/addons/briefing/XEH_postInit.sqf
+++ b/addons/briefing/XEH_postInit.sqf
@@ -10,6 +10,9 @@ if (hasInterface) then {
         if (isNull _unit || {!local _unit}) exitWith {};
         [_unit] call FUNC(addIntentToZeus);
     }] call CBA_fnc_addEventHandler;
+    ["potato_safeStartOff", {
+        [player, 0] call FUNC(addOrbat);
+    }] call CBA_fnc_addEventHandler;
 };
 ["CBA_settingsInitialized", {
     INFO_2("Briefing Settings: Credits: [%1] Orbat: [%2]",GVAR(brief_addCredits),GVAR(brief_addOrbat)); // Remove Me if no problems found
@@ -27,7 +30,7 @@ if (hasInterface) then {
             } forEach allGroups;
         }, []] call CBA_fnc_execNextFrame;
     };
-    
+
     ["unit", {
         TRACE_1("playerChanged eh",ace_player);
         [

--- a/addons/briefing/functions/fnc_addOrbat.sqf
+++ b/addons/briefing/functions/fnc_addOrbat.sqf
@@ -1,6 +1,7 @@
 /*
  * Author: PabstMirror
- * Function used to add the order of battle to player's diary
+ * Function used to add the order of battle to player's diary, or update a
+ * previously added orbat.
  *
  * Arguments:
  * 0: Unit to add to the OrBat to <OBJECT>
@@ -51,7 +52,7 @@ _this spawn {
     };
 
     private _diaryEntries = _unit allDiaryRecords "diary";
-
+    // find and replace existing orbat pages
     private _newDiaryEntryText = _diaryBuilder joinString "<br/>";
     private _noOrbatFound = true;
     {
@@ -61,6 +62,8 @@ _this spawn {
             _noOrbatFound = false;
         };
     } forEach _diaryEntries;
+
+    // if we didn't find and replace, add one
     if (_noOrbatFound) then {
         _unit createDiaryRecord ["diary", ["ORBAT", _newDiaryEntryText]];
     };

--- a/addons/briefing/functions/fnc_addOrbat.sqf
+++ b/addons/briefing/functions/fnc_addOrbat.sqf
@@ -16,9 +16,9 @@
 TRACE_1("params",_this);
 
 _this spawn {
-    uiSleep 10;
+    params ["_unit", ["_delay", 10, [123]]];
+    uiSleep _delay;
 
-    params ["_unit"];
     TRACE_1("",_unit);
 
     private _diaryBuilder = [];
@@ -44,6 +44,20 @@ _this spawn {
             };
         };
     } forEach allGroups;
+
+    private _orbatDiary = _unit getVariable [QGVAR(orbatDiary), []];
+    if (_orbatDiary isEqualType diaryRecordNull) then {
+        _unit removeDiaryRecord _orbatDiary;
+    };
+
+    private _diaryEntries = _unit allDiaryRecords "diary";
+
+    {
+        _x params ["_idx", "_title"];
+        if (_title == "ORBAT") then {
+            _unit removeDiaryRecord ["diary", _x];
+        };
+    } forEach _diaryEntries;
 
     _unit createDiaryRecord ["diary", ["ORBAT", _diaryBuilder joinString "<br/>"]];
 };

--- a/addons/briefing/functions/fnc_addOrbat.sqf
+++ b/addons/briefing/functions/fnc_addOrbat.sqf
@@ -52,12 +52,16 @@ _this spawn {
 
     private _diaryEntries = _unit allDiaryRecords "diary";
 
+    private _newDiaryEntryText = _diaryBuilder joinString "<br/>";
+    private _noOrbatFound = true;
     {
-        _x params ["_idx", "_title"];
+        _x params ["_idx", "_title", "", "", "", "", "", "", "_record"];
         if (_title == "ORBAT") then {
-            _unit removeDiaryRecord ["diary", _x];
+            _unit setDiaryRecordText [["diary", _record], ["ORBAT", _newDiaryEntryText]];
+            _noOrbatFound = false;
         };
     } forEach _diaryEntries;
-
-    _unit createDiaryRecord ["diary", ["ORBAT", _diaryBuilder joinString "<br/>"]];
+    if (_noOrbatFound) then {
+        _unit createDiaryRecord ["diary", ["ORBAT", _newDiaryEntryText]];
+    };
 };


### PR DESCRIPTION
This PR does what the name says, it finds the orbat diary entry if a unit has it and replaces it, or adds one if a unit doesn't. This also allows the `uiSleep` time to be variable.