### PR TITLE
filledSmoke - Fix Smoke not leaving the ground and add GM compat

### DIFF
--- a/addons/filledSmoke/compatGM/CfgAmmo.hpp
+++ b/addons/filledSmoke/compatGM/CfgAmmo.hpp
@@ -1,0 +1,9 @@
+class CfgAmmo {
+    class gm_SmokeShell_wht;
+    class gm_smokeshell_wht_dm25: gm_SmokeShell_wht {
+        effectsSmoke = QEGVAR(filledSmoke,bigSmoke_GM);
+    };
+    class gm_smokeshell_wht_gc: gm_SmokeShell_wht {
+        effectsSmoke = QEGVAR(filledSmoke,bigSmoke_GM);
+    };
+};

--- a/addons/filledSmoke/compatGM/CfgCloudlets.hpp
+++ b/addons/filledSmoke/compatGM/CfgCloudlets.hpp
@@ -1,0 +1,25 @@
+class CfgCloudlets {
+    class EGVAR(filledSmoke,SmokeShellWhiteFilled);
+    class EGVAR(filledSmoke,SmokeShellWhiteFilled_GM): EGVAR(filledSmoke,SmokeShellWhiteFilled) {
+        animationSpeedCoef = 0.75; //default 1
+        colorCoef[] = {"colorR", "colorG", "colorB", 3}; //default 1.8
+        sizeCoef = 2; //default 1
+        interval = 0.13; //default 0.2
+        lifeTime = 22; //default 14
+        moveVelocity[] = {0,0.2,0}; //default {0,0.3,0}
+        weight = 3.2; //default 1.26
+        volume = 2.5; //default 1
+        destroyAfterCrossing = 1;
+        destroyOnWaterSurfaceOffset = 0.1;
+    };
+};
+
+class EGVAR(filledSmoke,bigSmoke_GM) {
+    class SmokeShellWhite {
+        simulation = "particles";
+        type = QEGVAR(filledSmoke,SmokeShellWhiteFilled);
+        position[] = {0,0,0};
+        intensity = 5;
+        interval = 0.333;
+    };
+};

--- a/addons/filledSmoke/compatGM/config.cpp
+++ b/addons/filledSmoke/compatGM/config.cpp
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        weapons[] = {};
+        units[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "potato_core",
+            "potato_filledSmoke",
+            "gm_core_weapons",
+            "gm_weapons_throw"
+        };
+        skipWhenMissingDependencies = 1;
+        author = "Potato";
+        authors[] = {"AACO", "Lambda.Tiger"};
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgAmmo.hpp"
+#include "CfgCloudlets.hpp"

--- a/addons/filledSmoke/compatGM/script_component.hpp
+++ b/addons/filledSmoke/compatGM/script_component.hpp
@@ -1,0 +1,12 @@
+#define COMPONENT filledSmoke_compatGM
+#include "\z\potato\addons\core\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_FAUXMG5
+    #define DEBUG_MODE_FULL
+#endif
+
+#include "\z\potato\addons\core\script_macros.hpp"

--- a/addons/filledSmoke/config.cpp
+++ b/addons/filledSmoke/config.cpp
@@ -16,8 +16,7 @@ class CfgPatches {
 class CfgCloudlets {
     class SmokeShellWhiteSmall;
     class GVAR(SmokeShellWhiteFilled): SmokeShellWhiteSmall {
-        circleRadius=0.5;
-        animationSpeedCoef=0.75; //default 1
+        animationSpeedCoef = 0.75; //default 1
         colorCoef[] = {"colorR", "colorG", "colorB", 3}; //default 1.8
         sizeCoef = 2; //default 1
         interval = 0.13; //default 0.2
@@ -25,8 +24,8 @@ class CfgCloudlets {
         moveVelocity[] = {0,0.1,0}; //default {0,0.3,0}
         weight = 6.4; //default 1.26
         volume = 5; //default 1
-        destroyAfterCrossing=1;
-		destroyOnWaterSurfaceOffset=0.1;
+        destroyAfterCrossing = 1;
+        destroyOnWaterSurfaceOffset = 0.1;
     };
 };
 


### PR DESCRIPTION
Smoke grenades previously had their particles only drop on the ground, I was able to trouble shoot this to being related to having a `circleRadius` defined.
