### PR TITLE
Settings - Revert change to terraingradientfactor

### DIFF
--- a/addons/settings/BW_Settings.inc.sqf
+++ b/addons/settings/BW_Settings.inc.sqf
@@ -42,7 +42,7 @@ _settings = [
 
 [QACEGVAR(advanced_fatigue,performanceFactor), 1.4],
 [QACEGVAR(advanced_fatigue,recoveryFactor), 1.6],
-[QACEGVAR(advanced_fatigue,terraingradientfactor), 0.4],
+[QACEGVAR(advanced_fatigue,terraingradientfactor), 1.0],
 [QACEGVAR(advanced_fatigue,loadfactor), 0.5],
 [QACEGVAR(cookoff,ammoCookoffDuration), 0.15],
 [QACEGVAR(dragging,weightCoefficient), 0.25], // allows carry/drag 4x the normal weight


### PR DESCRIPTION
ace changed the default to 0.1 from what it had been  https://github.com/acemod/ACE3/pull/10361/files
so we no longer need this, but only merge if we are going to update our ace copy 