### PR TITLE
missileGuidanceCompat - Temporarily Disable Milan and Malyutka

### DIFF
--- a/addons/missileGuidanceCompat/patchCUP/config.cpp
+++ b/addons/missileGuidanceCompat/patchCUP/config.cpp
@@ -49,7 +49,7 @@ class CfgAmmo {
 
     class CUP_M_9M17P_AT3_Sagger_AT: MissileBase {
         maneuvrability = 0;
-        ACE_MISSILE(Fleyta);
+        //ACE_MISSILE(Fleyta);
     };
 
     class CUP_M_9M113_AT5_Spandrel_AT: M_Titan_AT {

--- a/addons/missileGuidanceCompat/patchGM/config.cpp
+++ b/addons/missileGuidanceCompat/patchGM/config.cpp
@@ -85,7 +85,7 @@ class CfgAmmo {
         };
     };
     // Malyutka
-    class gm_missile_maljutka_base: gm_missile_saclos_base {
+    /*class gm_missile_maljutka_base: gm_missile_saclos_base {
         maneuvrability = 0;
         ACE_MISSILE(Malyutka);
     };
@@ -100,24 +100,24 @@ class CfgAmmo {
             enabled = 1;
             showTrail = 1;
         };
-    };
+    };*/
     // Milan
-    class gm_missile_milan_base: gm_missile_saclos_base {
+   /* class gm_missile_milan_base: gm_missile_saclos_base {
         maneuvrability = 0;
         ACE_MISSILE(Milan);
     };
     class gm_missile_milan_heat_dm82: gm_missile_milan_base {
         class ace_missileguidance: ace_missileguidance {
-            enabled = 1;
+            enabled = 0;
             initialPitch = 0.4;
         };
     };
     class gm_missile_milan_heat_dm92: gm_missile_milan_base {
         class ace_missileguidance: ace_missileguidance {
-            enabled = 1;
+            enabled = 0;
             initialPitch = 0.4;
         };
-    };
+    };*/
     // AA Missiles
     class gm_rocket_72mm_HE_9m32m_base;
     class gm_rocket_72mm_HE_9m32m: gm_rocket_72mm_HE_9m32m_base {

--- a/addons/missileGuidanceCompat/patchRHSAFRF/config.cpp
+++ b/addons/missileGuidanceCompat/patchRHSAFRF/config.cpp
@@ -217,7 +217,7 @@ class CfgAmmo {
     };
     class rhs_ammo_9m14: rhs_ammo_atgmBase_base {
         maneuvrability = 0;
-        ACE_MISSILE(Malyutka);
+        //ACE_MISSILE(Malyutka);
         class EventHandlers: EventHandlers {
             class RHS_Guidance {};
         };


### PR DESCRIPTION
This PR will disable Advanced Missile Guidance on Milans and Malyutkas.