### PR TITLE
Kimi's HMD 20mm Cannon Fix

### DIFF
--- a/addons/miscFixes/patchHMD/config.cpp
+++ b/addons/miscFixes/patchHMD/config.cpp
@@ -15,7 +15,7 @@ class CfgPatches {
     };
 };
 
-class cfgWeapons {
+class CfgWeapons {
     class Default;
     class CannonCore: Default {};
     class gatling_20mm: CannonCore {

--- a/addons/miscFixes/patchHMD/config.cpp
+++ b/addons/miscFixes/patchHMD/config.cpp
@@ -1,0 +1,29 @@
+#include "\z\potato\addons\miscFixes\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT miscFixes_patchHMD
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = { "Kimi_Weapons_Helos" };
+        skipWhenMissingDependencies = 1;
+        author = "Bourbon Warfare";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+class Mode_SemiAuto;
+class Mode_Burst;
+class Mode_FullAuto;
+class cfgWeapons {
+    class Default;
+    class CannonCore: Default {};
+    class gatling_20mm: CannonCore {
+        cursorAim = "mg";
+        ballisticsComputer = "1 + 2 + 16";
+        magazines[] = {"2000Rnd_20mm_shells","1000Rnd_20mm_shells","300Rnd_20mm_shells","PylonWeapon_300Rnd_20mm_shells","ACE_500Rnd_20mm_shells_Comanche"};
+    };
+};

--- a/addons/miscFixes/patchHMD/config.cpp
+++ b/addons/miscFixes/patchHMD/config.cpp
@@ -15,9 +15,6 @@ class CfgPatches {
     };
 };
 
-class Mode_SemiAuto;
-class Mode_Burst;
-class Mode_FullAuto;
 class cfgWeapons {
     class Default;
     class CannonCore: Default {};


### PR DESCRIPTION
Kimi's HMD mod broke the inheritance for the "gatling_20mm" cannon, breaking it on any dynamic pylon vehicle.

I also updated the cursorAim, ballisticsComputer, and magazines to be in-line with other, similar weapons, and to include ACE ammunition.

I haven't taken a look at the Fixed Wing PBO to see if the same thing is happening, but this at least fixed it on the vehicles that I mentioned in https://github.com/BourbonWarfare/POTATO/issues/593#issue-2634620810. This specifically includes the Tucano as being able to use the 20mm cannons now.