### PR TITLE
Fix missing fauxMG5

### DIFF
--- a/addons/customGear/config.cpp
+++ b/addons/customGear/config.cpp
@@ -5,7 +5,10 @@ class CfgPatches {
         units[] = {};
         weapons[] = { "potato_fauxMG5_MG5" };
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "potato_core" };
+        requiredAddons[] = {
+            "A3_Weapons_F_Mark_Machineguns_MMG_01",
+            "potato_core"
+        };
         skipWhenMissingDependencies = 1;
         author = "Potato";
         authorUrl = "https://github.com/BourbonWarfare/POTATO";

--- a/addons/customGear/config.cpp
+++ b/addons/customGear/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = { "potato_fauxMG5_MG5" };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "potato_core" };
+        skipWhenMissingDependencies = 1;
         author = "Potato";
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
         VERSION_CONFIG;
@@ -13,4 +14,3 @@ class CfgPatches {
 };
 
 #include "CfgWeapons.hpp"
-#include "CfgVehicles.hpp"

--- a/addons/customGear/config.cpp
+++ b/addons/customGear/config.cpp
@@ -11,6 +11,7 @@ class CfgPatches {
         };
         skipWhenMissingDependencies = 1;
         author = "Potato";
+        authors[] = {"AChesheireCat"};
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
         VERSION_CONFIG;
     };


### PR DESCRIPTION
This PR fixes a misnamed `config.cpp` and cleans up unnecessary includes, addressing https://github.com/BourbonWarfare/POTATO/issues/609.