### PR TITLE
Replace CBA Namespaces with Hash Maps

### DIFF
--- a/addons/aiVehicleBail/XEH_postInit.sqf
+++ b/addons/aiVehicleBail/XEH_postInit.sqf
@@ -1,10 +1,10 @@
 #include "script_component.hpp"
 
-GVAR(hitpointTypes) = [false] call CBA_fnc_createNamespace;
+GVAR(hitpointTypes) = createHashMap;
 {
     _x params ["_hitpoints", "_type"];
     {
-        GVAR(hitpointTypes) setVariable [_x, _type];
+        GVAR(hitpointTypes) set [_x, _type];
     } forEach _hitpoints;
 } forEach [ENGINE_HITPOINTS, HULL_HITPOINTS, TURRET_HITPOINTS, TRACK_HITPOINTS, WHEEL_HITPOINTS];
 

--- a/addons/aiVehicleBail/functions/fnc_handleVehicleDamage.sqf
+++ b/addons/aiVehicleBail/functions/fnc_handleVehicleDamage.sqf
@@ -30,7 +30,7 @@ if !(alive _vehicle) exitWith {
 };
 
 _hitPoint = toLower _hitPoint;
-private _type = GVAR(hitpointTypes) getVariable [_hitPoint, "exit"];
+private _type = GVAR(hitpointTypes) getOrDefault [_hitPoint, "exit"];
 if (_type == "exit") exitWith {};
 
 private _canMove = _vehicle getVariable[QGVAR(can_move), true];

--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -9,9 +9,9 @@ PREP_RECOMPILE_END;
 GVAR(usePotato) = [missionConfigFile >> "CfgLoadouts" >> "usePotato"] call CFUNC(getBool);
 
 if (GVAR(usePotato)) then {
-    GVAR(loadoutCache) = call CBA_fnc_createNamespace;
-    GVAR(classnameCache) = call CBA_fnc_createNamespace;
-    GVAR(magnifiedOpticCache) = call CBA_fnc_createNamespace;
+    GVAR(loadoutCache) = createHashMap;
+    GVAR(classnameCache) = createHashMap;
+    GVAR(magnifiedOpticCache) = createHashMap;
 
     GVAR(allowMagnifiedOptics) = [missionConfigFile >> "CfgLoadouts" >> "allowMagnifiedOptics"] call CFUNC(getBool);
     GVAR(allowChangeableOptics) = [missionConfigFile >> "CfgLoadouts" >> "allowChangeableOptics"] call CFUNC(getBool);

--- a/addons/assignGear/functions/fnc_assignGearMan.sqf
+++ b/addons/assignGear/functions/fnc_assignGearMan.sqf
@@ -131,16 +131,14 @@ if (!isClass(_path)) exitWith {
 private _randomIndex = floor (random GVAR(maxRandomization));
 private _loadoutKey = format ["%1:%2", _path, _randomIndex];
 
-private _loadoutArray = GVAR(loadoutCache) getVariable _loadoutKey;
-
-if (isNil "_loadoutArray") then {
+private _loadoutArray = GVAR(loadoutCache) getOrDefaultCall [_loadoutKey, {
     TRACE_1("compiling new",_loadoutKey);
     BEGIN_COUNTER(getLoadoutFromConfig);
     _loadoutArray = [_path, _unit] call FUNC(getLoadoutFromConfig);
     END_COUNTER(getLoadoutFromConfig);
     TRACE_1("",_loadoutArray);
-    GVAR(loadoutCache) setVariable [_loadoutKey, _loadoutArray];
-};
+    _loadoutArray
+}, true];
 
 // set unit loadout overrides our sick shades :(
 _loadoutArray set [LA_FACEWARE_INDEX, goggles _unit];

--- a/addons/assignGear/functions/fnc_cleanPrefix.sqf
+++ b/addons/assignGear/functions/fnc_cleanPrefix.sqf
@@ -21,8 +21,7 @@ TRACE_1("cleanPrefix",_unitClassname);
 
 if (_unitClassname == "") exitWith {ERROR("_unitClassname is empty string"); _unitClassname };
 
-private _cleanedClassname = GVAR(classnameCache) getVariable _unitClassname;
-if (isNil "_cleanedClassname") then { // cache classname lookups
+private _cleanedClassname = GVAR(classnameCache) getOrDefaultCall [_unitClassname, {
     _cleanedClassname = _unitClassname;
     {
         private _prefixLength = count _x;
@@ -32,7 +31,7 @@ if (isNil "_cleanedClassname") then { // cache classname lookups
         nil
     } count GVAR(prefixes);  // count used here for speed, make sure nil is above this line
 
-    GVAR(classnameCache) setVariable [_unitClassname, _cleanedClassname];
-};
+    _cleanedClassname;
+}, true];
 
 _cleanedClassname

--- a/addons/assignGear/functions/fnc_isOpticMagnified.sqf
+++ b/addons/assignGear/functions/fnc_isOpticMagnified.sqf
@@ -18,8 +18,7 @@ params [["_opticClassname", "", [""]]];
 
 if (_opticClassname == "") exitWith { ERROR("No optic classname provided"); false };
 
-private _isMagnified = GVAR(magnifiedOpticCache) getVariable _opticClassname;
-if (isNil "_isMagnified") then { // cache magnification check
+private _isMagnified = GVAR(magnifiedOpticCache) getOrDefaultCall [_opticClassname, {
     TRACE_1("Looking up key: ",_opticClassname);
     private _minZoom = 999; //FOV, so smaller is more zoomed in
 
@@ -33,7 +32,7 @@ if (isNil "_isMagnified") then { // cache magnification check
     } count configProperties [configFile >> "CfgWeapons" >> _opticClassname >> "ItemInfo" >> "OpticsModes"]; // count used here for speed, make sure nil is above this line
 
     _isMagnified = _minZoom < MAG_OPTIC_ZOOM_THRESHOLD;
-    GVAR(magnifiedOpticCache) setVariable [_opticClassname, _isMagnified];
-};
+    _isMagnified;
+}, true];
 
 _isMagnified

--- a/addons/respawn/functions/fnc_addGroup.sqf
+++ b/addons/respawn/functions/fnc_addGroup.sqf
@@ -41,14 +41,14 @@ if (!isNil QGVAR(currentFaction) && {GVAR(currentFaction) != _factionData}) then
 };
 GVAR(currentFaction) = _factionData;
 
-(GVAR(factionsToInfo) getVariable _factionData) params [
+(GVAR(factionsToInfo) get _factionData) params [
     "_factionDisplayName",
     "",
     "",
     "_factionPrefix"
 ];
 
-(GVAR(groupsToInfo) getVariable _groupData) params [
+(GVAR(groupsToInfo) get _groupData) params [
     "_groupDisplayName",
     "_unitsArray"
 ];

--- a/addons/respawn/functions/fnc_readConfigToVariables.sqf
+++ b/addons/respawn/functions/fnc_readConfigToVariables.sqf
@@ -19,7 +19,7 @@
 TRACE_1("params",_this);
 
 // parse faction info
-GVAR(factionsToInfo) = [] call CBA_fnc_createNamespace;
+GVAR(factionsToInfo) = createHashMap;
 {
     private _infoArray = [];
 
@@ -30,14 +30,14 @@ GVAR(factionsToInfo) = [] call CBA_fnc_createNamespace;
     _infoArray pushBack ([_x >> "groups"] call CFUNC(getArray));
 
     TRACE_2("Faction info",configName _x,_infoArray);
-    GVAR(factionsToInfo) setVariable [configName _x, _infoArray]; // possible to override mission side
+    GVAR(factionsToInfo) set [configName _x, _infoArray]; // possible to override mission side
 } forEach (
     ("true" configClasses (configFile >> "CfgRespawnFactions")) +
     ("true" configClasses (missionConfigFile >> "CfgRespawnFactions"))
 );
 
 // parse group info
-GVAR(groupsToInfo) = [] call CBA_fnc_createNamespace;
+GVAR(groupsToInfo) = createHashMap;
 {
     private _infoArray = [];
 
@@ -104,7 +104,7 @@ GVAR(groupsToInfo) = [] call CBA_fnc_createNamespace;
 
 
     TRACE_2("Group info",configName _x,_infoArray);
-    GVAR(groupsToInfo) setVariable [configName _x, _infoArray]; // possible to override mission side
+    GVAR(groupsToInfo) set [configName _x, _infoArray]; // possible to override mission side
 } forEach (
     ("isClass (_x >> 'Units') && isClass (_x >> 'Configurations')" configClasses (configFile >> "CfgRespawnGroups")) +
     ("isClass (_x >> 'Units') && isClass (_x >> 'Configurations')" configClasses (missionConfigFile >> "CfgRespawnGroups"))

--- a/addons/respawn/functions/fnc_triggerRespawn.sqf
+++ b/addons/respawn/functions/fnc_triggerRespawn.sqf
@@ -49,7 +49,7 @@ private _delay = 0;
     private _unitCount = { !isNull (_x select 3) } count _newUnits;
 
     if (_unitCount > 0) then {
-        (GVAR(factionsToInfo) getVariable _factionData) params [
+        (GVAR(factionsToInfo) get _factionData) params [
             "",
             "_callsignPrefix",
             "_factionClassname",
@@ -58,7 +58,7 @@ private _delay = 0;
 
         private _factionSide = [getNumber (configFile >> "CfgFactionClasses" >> _factionClassname >> "side")] call EFUNC(core,toSide);
 
-        (GVAR(groupsToInfo) getVariable _groupData) params [
+        (GVAR(groupsToInfo) get _groupData) params [
             "_groupDisplayName",
             "_unitsArray",
             "_configsArray"

--- a/addons/respawn/functions/fnc_ui_handleAdminLoad.sqf
+++ b/addons/respawn/functions/fnc_ui_handleAdminLoad.sqf
@@ -68,16 +68,16 @@ ctrlShow [ADMIN_MAP_IDC, false];
 [] call FUNC(updateOpenButton);
 
 // get count of players on each faction so we don't respawn on the wrong side
-private _allFactions = createHashMap; 
-{ 
-    if (isPlayer _x) then { 
-        private _faction = faction _x; 
-        _allFactions set [_faction, 1 + (_allFactions getOrDefault [_faction, 0])]; 
-    }; 
+private _allFactions = createHashMap;
+{
+    if (isPlayer _x) then {
+        private _faction = faction _x;
+        _allFactions set [_faction, 1 + (_allFactions getOrDefault [_faction, 0])];
+    };
 } forEach allUnits;
 
 {
-    (GVAR(factionsToInfo) getVariable _x) params ["_displayName", "", "_factionClassname"];
+    (GVAR(factionsToInfo) get _x) params ["_displayName", "", "_factionClassname"];
     private _count = _allFactions getOrDefault [_factionClassname, 0];
     if (_count > 0) then { _displayName = _displayName + format [" [%1]", _count]; };
 
@@ -86,7 +86,7 @@ private _allFactions = createHashMap;
         lbSetPicture [ADMIN_FACTION_COMBO_IDC, _index, getText (configFile >> "CfgFactionClasses" >> _factionClassname >> "icon")];
     };
     lbSetData [ADMIN_FACTION_COMBO_IDC, _index, _x];
-} forEach (allVariables GVAR(factionsToInfo));
+} forEach (keys GVAR(factionsToInfo));
 
 private _factionIndex = if (isNil QGVAR(lastFactionIndex)) then {
     0

--- a/addons/respawn/functions/fnc_ui_handleFactionChange.sqf
+++ b/addons/respawn/functions/fnc_ui_handleFactionChange.sqf
@@ -26,9 +26,9 @@ GVAR(setupFaction) = _lookUp;
 lbClear ADMIN_GROUP_COMBO_IDC;
 
 {
-    private _index = lbAdd [ADMIN_GROUP_COMBO_IDC, (GVAR(groupsToInfo) getVariable _x) select 0];
+    private _index = lbAdd [ADMIN_GROUP_COMBO_IDC, (GVAR(groupsToInfo) get _x) select 0];
     lbSetData [ADMIN_GROUP_COMBO_IDC, _index, _x];
-} forEach ((GVAR(factionsToInfo) getVariable _lookUp) select 4);
+} forEach ((GVAR(factionsToInfo) get _lookUp) select 4);
 
 lbSetCurSel [ADMIN_GROUP_COMBO_IDC, 0];
 [ADMIN_GROUP_COMBO, 0] call FUNC(ui_handleGroupChange);

--- a/addons/respawn/functions/fnc_ui_handleGroupChange.sqf
+++ b/addons/respawn/functions/fnc_ui_handleGroupChange.sqf
@@ -21,7 +21,7 @@ TRACE_1("params",_this);
 params ["", "_index"];
 
 private _lookUp = lbData [ADMIN_GROUP_COMBO_IDC, _index];
-(GVAR(groupsToInfo) getVariable _lookUp) params ["", "_units", "_configurations"];
+(GVAR(groupsToInfo) get _lookUp) params ["", "_units", "_configurations"];
 
 // agressively look ahead into the units for a leader marker/color
 private _unitMarkerColor = [0,0,0,0];

--- a/addons/spectate/XEH_postClientInit.sqf
+++ b/addons/spectate/XEH_postClientInit.sqf
@@ -5,14 +5,8 @@ if (GVAR(enabled) && hasInterface) then {
     GVAR(availableLanguages) = (missionNamespace getVariable [QEGVAR(radios,availableLanguages), []]) apply {_x select 0};
     GVAR(classEHInstalled) = false;
 
-    GVAR(boundingBoxCache) = call CBA_fnc_createNamespace;
-    GVAR(groupIconCache) = call CBA_fnc_createNamespace;
-
-    // populate group icon cache
-    {
-        _x params ["_key", "_value"];
-        GVAR(groupIconCache) setVariable [_key, _value];
-    } forEach [
+    GVAR(boundingBoxCache) = createHashMap;
+    GVAR(groupIconCache) = createHashMapFromArray [
         [QPATHTOEF(markers,data\armor.paa), QPATHTOF(data\armor.paa)],
         [QPATHTOEF(markers,data\artillery.paa), QPATHTOF(data\artillery.paa)],
         [QPATHTOEF(markers,data\attack_fixed_wing.paa), QPATHTOF(data\attack_fixed_wing.paa)],

--- a/addons/spectate/functions/fnc_getBoundingBox.sqf
+++ b/addons/spectate/functions/fnc_getBoundingBox.sqf
@@ -22,9 +22,7 @@ params [["_object", objNull, [objNull]]];
 if (isNull _object) exitWith { [1,1,1] };
 
 private _objectType = typeOf _object;
-private _cachedValue = GVAR(boundingBoxCache) getVariable _objectType;
-
-if (isNil "_cachedValue") then {
+private _cachedValue = GVAR(boundingBoxCache) getOrDefaultCall [_objectType, {
     (boundingBoxReal _object) params ["_p1", "_p2"];
     _cachedValue = [
         abs ((_p2 select 0) - (_p1 select 0)), // max width
@@ -32,7 +30,7 @@ if (isNil "_cachedValue") then {
         abs ((_p2 select 2) - (_p1 select 2)) // max height
     ];
 
-    GVAR(boundingBoxCache) setVariable [_objectType, _cachedValue];
-};
+    _cachedValue;
+}, true];
 
 _cachedValue

--- a/addons/spectate/functions/fnc_getGroupIcon.sqf
+++ b/addons/spectate/functions/fnc_getGroupIcon.sqf
@@ -36,10 +36,7 @@ if (isNil "_cachedValue") then {
         }
     };
 
-    _cachedValue = GVAR(groupIconCache) getVariable _lookup;
-    if (isNil "_cachedValue") then {
-        _cachedValue = DEFAULT_TEXTURE;
-    };
+    _cachedValue = GVAR(groupIconCache) getOrDefault [_lookup, DEFAULT_TEXTURE, true];
 
     _group setVariable [QGVAR(markerTexture), _cachedValue];
 };


### PR DESCRIPTION
This replaces all CBA namespaces with hash maps. This doesn't clear up much overhead, but should create fewer objects & locations. There could be a issues with case sensitive keys, but during testing I did not run into any issues.