### PR TITLE
miscFixes - Revert SOG and CWR3 Main Menu Cutscene Changes

### DIFF
--- a/addons/miscFixes/patchCWR/config.cpp
+++ b/addons/miscFixes/patchCWR/config.cpp
@@ -51,3 +51,10 @@ class CfgVehicles {
         ACEGVAR(vehicle_damage,canHaveFireRing) = 1;
     };
 };
+
+class CfgWorlds {
+    class CAWorld;
+    class Malden: CAWorld {
+        cutscenes[] = {"Malden_intro"};
+    };
+};

--- a/addons/miscFixes/patchSOG/config.cpp
+++ b/addons/miscFixes/patchSOG/config.cpp
@@ -15,6 +15,27 @@ class CfgPatches {
     };
 };
 
+class Cutscenes { // restore the load menus
+    class Stratis_intro1 {
+        directory = "a3\map_stratis_scenes_f\scenes\introExp.Stratis";
+    };
+    class Altis_intro1 {
+        directory = "a3\missions_f_orange\scenes\introOrange.Altis";
+    };
+    class Credits {
+        directory = "A3\missions_f\data\scenes\credits1.Altis";
+    };
+    class Malden_intro {
+        directory = "a3\Map_Malden_Scenes_F\scenes\Malden_intro.Malden";
+    };
+    class Tanoa_intro1 {
+        directory = "a3\map_tanoa_scenes_f\scenes\tanoa_intro1.tanoa";
+    };
+    class Enoch_intro1 {
+        directory = "a3\Map_Enoch_Scenes_F\Scenes\Enoch_intro1.Enoch";
+    };
+};
+
 class CfgMagazines {
     class vn_22mm_lume_mag;
     class vn_22mm_m22_smoke_mag: vn_22mm_lume_mag {

--- a/addons/miscFixes/patchSOG/config.cpp
+++ b/addons/miscFixes/patchSOG/config.cpp
@@ -15,24 +15,26 @@ class CfgPatches {
     };
 };
 
-class Cutscenes { // restore the load menus
-    class Stratis_intro1 {
-        directory = "a3\map_stratis_scenes_f\scenes\introExp.Stratis";
-    };
-    class Altis_intro1 {
-        directory = "a3\missions_f_orange\scenes\introOrange.Altis";
-    };
-    class Credits {
-        directory = "A3\missions_f\data\scenes\credits1.Altis";
-    };
-    class Malden_intro {
-        directory = "a3\Map_Malden_Scenes_F\scenes\Malden_intro.Malden";
-    };
-    class Tanoa_intro1 {
-        directory = "a3\map_tanoa_scenes_f\scenes\tanoa_intro1.tanoa";
-    };
-    class Enoch_intro1 {
-        directory = "a3\Map_Enoch_Scenes_F\Scenes\Enoch_intro1.Enoch";
+class CfgMissions {
+  class Cutscenes { // restore the load menus
+        class Stratis_intro1 {
+            directory = "a3\map_stratis_scenes_f\scenes\introExp.Stratis";
+        };
+        class Altis_intro1 {
+            directory = "a3\missions_f_orange\scenes\introOrange.Altis";
+        };
+        class Credits {
+            directory = "A3\missions_f\data\scenes\credits1.Altis";
+        };
+        class Malden_intro {
+            directory = "a3\Map_Malden_Scenes_F\scenes\Malden_intro.Malden";
+        };
+        class Tanoa_intro1 {
+            directory = "a3\map_tanoa_scenes_f\scenes\tanoa_intro1.tanoa";
+        };
+        class Enoch_intro1 {
+            directory = "a3\Map_Enoch_Scenes_F\Scenes\Enoch_intro1.Enoch";
+        };
     };
 };
 


### PR DESCRIPTION
This PR:
- Reverts all the base terrains back to their original cutscene
- Removes the CWR3 intro from the pool of Malden cutscenes