### PR TITLE
Core - Add last group hint when player re-jips in

### DIFF
--- a/addons/adminComs/functions/fnc_mouseCatch.sqf
+++ b/addons/adminComs/functions/fnc_mouseCatch.sqf
@@ -27,18 +27,20 @@ private _index = -1;
 {
     _x params ["_time", "_msg", "_from", "_to"];
     TRACE_1("log:",_x);
-
     private _log = format [
-        "%1:%2 [%3>%4] %5",
-        [floor (_time / 60)] call CFUNC(zeroPadNumber),
-        [floor (_time % 60)] call CFUNC(zeroPadNumber),
+        "[%1>%2] %3",
         _from,
         _to,
         _msg
     ];
+    private _tooltip = format ["%1: %2\n%3",
+        [floor (_time / 60)] call CFUNC(zeroPadNumber),
+        [floor (_time % 60)] call CFUNC(zeroPadNumber),
+        _msg
+    ];
 
     _index = _chatList lbAdd _log;
-    _chatList lbSetTooltip [_index, _msg];
+    _chatList lbSetTooltip [_index, _tooltip];
 } forEach GVAR(logs);
 
 if (_index != -1) then {

--- a/addons/adminMenu/functions/fnc_uihook_teleportButton.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_teleportButton.sqf
@@ -40,6 +40,13 @@ private _return = if (_vehicle == _leader) then {
         ["Teleporting to position", "No empty position for teleport"] select _success
     }
 } else {
+    [{ // hint if TP-to-Vic fails
+        params ["_selectedUnit"];
+        if (isNull objectParent _selectedUnit) then {
+            systemChat format ["%1 - failed to move into vic", name _selectedUnit];
+        };
+    }, [_selectedUnit], 2] call CBA_fnc_waitAndExecute;
+
     private _fullCrewCount = 0;
     private _aliveCrewCount = {
         _fullCrewCount = _fullCrewCount + 1;

--- a/addons/adminMenu/functions/fnc_uihook_teleportButton.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_teleportButton.sqf
@@ -41,11 +41,11 @@ private _return = if (_vehicle == _leader) then {
     }
 } else {
     [{ // hint if TP-to-Vic fails
-        params ["_selectedUnit"];
-        if (isNull objectParent _selectedUnit) then {
+        params ["_selectedUnit", "_vehicle"];
+        if (_vehicle != vehicle _selectedUnit) then {
             systemChat format ["%1 - failed to move into vic", name _selectedUnit];
         };
-    }, [_selectedUnit], 2] call CBA_fnc_waitAndExecute;
+    }, [_selectedUnit, _vehicle], 2] call CBA_fnc_waitAndExecute;
 
     private _fullCrewCount = 0;
     private _aliveCrewCount = {

--- a/addons/core/XEH_PREP.hpp
+++ b/addons/core/XEH_PREP.hpp
@@ -15,6 +15,7 @@ PREP(getTimeText);
 PREP(isAuthorized);
 PREP(isTech);
 PREP(parseBool);
+PREP(playerJipHint);
 PREP(setControlFade);
 PREP(stringArrayToSideArray);
 PREP(zeroPadNumber);

--- a/addons/core/XEH_postInit.sqf
+++ b/addons/core/XEH_postInit.sqf
@@ -92,3 +92,5 @@ if (hasInterface) then {
         diag_log text format ["[POTATO] potato_missionHint EH: %1", _this];
     };
 }] call CBA_fnc_addEventHandler;
+
+call FUNC(playerJipHint);

--- a/addons/core/functions/fnc_playerJipHint.sqf
+++ b/addons/core/functions/fnc_playerJipHint.sqf
@@ -11,7 +11,13 @@ if (isServer) then {
         params ["_player", "_profileName"];
         private _msg = if (_profileName in GVAR(playerMap)) then {
             (GVAR(playerMap) get _profileName) params ["_lastSide", "_lastGroup"];
-            private _sideText = ["?", "B", "O", "I"] select ([blufor, opfor, independent] find _lastSide);
+            private _sideText = switch (_lastSide) do {
+                case blufor: { "B" };
+                case opfor: { "O" };
+                case independent: { "I" };
+                case civilian: { "C" };
+                default { "?" };
+            };
             format ["has JIPed; last in [%1-%2]", _sideText, _lastGroup]
         } else {
             private _lastSide = side group _player;

--- a/addons/core/functions/fnc_playerJipHint.sqf
+++ b/addons/core/functions/fnc_playerJipHint.sqf
@@ -12,7 +12,7 @@ if (isServer) then {
         private _msg = if (_profileName in GVAR(playerMap)) then {
             (GVAR(playerMap) get _profileName) params ["_lastSide", "_lastGroup"];
             private _sideText = ["?", "B", "O", "I"] select ([blufor, opfor, independent] find _lastSide);
-            format ["has JIPed; last in [%2-%3]", _sideText, _lastGroup]
+            format ["has JIPed; last in [%1-%2]", _sideText, _lastGroup]
         } else {
             private _lastSide = side group _player;
             private _lastGroup = groupId group _player;

--- a/addons/core/functions/fnc_playerJipHint.sqf
+++ b/addons/core/functions/fnc_playerJipHint.sqf
@@ -1,0 +1,40 @@
+#include "script_component.hpp"
+/*
+ * Author: PabstMirror
+ * Handles player jipping, sends hint on last group
+ */
+
+
+if (isServer) then {
+    GVAR(playerMap) = createHashMap;
+    [QGVAR(playerConnected), {
+        params ["_player", "_profileName"];
+        private _msg = if (_profileName in GVAR(playerMap)) then {
+            (GVAR(playerMap) get _profileName) params ["_lastSide", "_lastGroup"];
+            private _sideText = ["?", "B", "O", "I"] select ([blufor, opfor, independent] find _lastSide);
+            format ["has JIPed; last in [%2-%3]", _sideText, _lastGroup]
+        } else {
+            private _lastSide = side group _player;
+            private _lastGroup = groupId group _player;
+            GVAR(playerMap) set [_profileName, [_lastSide, _lastGroup]];
+            format ["has JIPed"];
+        };
+        INFO_2("playerConnected: %1: [%2]",_profileName,_msg);
+        if (CBA_missionTime < 60) exitWith {};
+        ["potato_adminMsg", [_msg, _profileName]] call CBA_fnc_globalEvent;
+    }] call CBA_fnc_addEventHandler;
+};
+
+
+if (hasInterface) then {
+    [{
+        ["unit", {
+            params ["_player"];
+            if ((!alive _player) || {_player isKindOf "VirtualMan_F"}) exitWith {};
+            if (missionNamespace getVariable [QGVAR(playerConnectedSent), false]) exitWith {};
+            GVAR(playerConnectedSent) = true;
+            TRACE_2("playerConnected",_player,profileName);
+            [QGVAR(playerConnected), [_player, profileName]] call CBA_fnc_serverEvent;
+        }, true] call CBA_fnc_addPlayerEventHandler;
+    }, [], 1] call CBA_fnc_waitAndExecute;
+};


### PR DESCRIPTION
Adds hint for player's last group when the jip in to make it faster and easier to get them back to where they should be
Remove time from admin log and moves it to tooltip