### PR TITLE
Misc Fixed - Fix CUP Gunner ACRE Attenuation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-	"files.exclude": {
-		"**/.hemttout": true,
-		"**/include": true
-  }
+    "files.exclude": {
+        "**/.hemttout": true,
+        "**/include": true
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
 	"files.exclude": {
-		"**/.hemttout": true
+		"**/.hemttout": true,
 		"**/include": true
+  }
 }

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -84,11 +84,11 @@ class CfgVehicles {
         brakeIdleSpeed = 1.78; // was 0
         maxFordingDepth = 1.0; // was 1.5
         class Wheels {
-			class wheel_1_1 {
-				maxBrakeTorque = 20000; // was 12500
-				maxHandBrakeTorque = 30000; // was 25000
-			};
-		};
+            class wheel_1_1 {
+                maxBrakeTorque = 20000; // was 12500
+                maxHandBrakeTorque = 30000; // was 25000
+            };
+        };
         class AnimationSources: AnimationSources {
             class main_gun_muzzle_rot {
                 weapon = "CUP_Vhmg_M3P_veh";

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -62,7 +62,7 @@ class CfgVehicles {
         };
     };
     class CUP_nM1038_Base: CUP_nHMMWV_Base {
-        class Turrets: Turrets {
+        class Turrets {
             class CargoTurret_01: CargoTurret {
                 gunnerAction = "CUP_HMMWV_bench_gunner_1";
             };

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -15,7 +15,18 @@ class CfgPatches {
     };
 };
 
+#define CUP_MAINTURRET_DISABLE_ATTENUATE class Turrets: Turrets {\
+class MainTurret: MainTurret {\
+    disableSoundAttenuation = 1;\
+    };\
+}
+
 class CfgVehicles {
+    // Base classes
+    class Car;
+    class Car_F: Car {
+        class Turrets;
+    };
     // Fix broken artillery computer on FV432 Mortar (shows artillery computer for 7.62mg)
     class CUP_B_FV432_Bulldog_GB_D;
     class CUP_B_FV432_Base: CUP_B_FV432_Bulldog_GB_D {
@@ -43,17 +54,34 @@ class CfgVehicles {
         };
         class UserActions {}; // clear all user actions (not a big deal)
     };
-    // Fix the M1038 back seat
-    class Car_F;
+    // Fix the M1038 back seat and attenuation
     class CUP_nHMMWV_Base: Car_F {
         class CargoTurret;
+        class Turrets: Turrets {
+            class MainTurret;
+        };
     };
     class CUP_nM1038_Base: CUP_nHMMWV_Base {
-        class Turrets {
+        class Turrets: Turrets {
             class CargoTurret_01: CargoTurret {
                 gunnerAction = "CUP_HMMWV_bench_gunner_1";
             };
         };
+    };
+    class CUP_nM1025_M2_Base: CUP_nHMMWV_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
+    };
+    class CUP_nM1025_Mk19_Base: CUP_nHMMWV_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
+    };
+    class CUP_nM1025_M240_Base: CUP_nHMMWV_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
+    };
+    class CUP_nM1036_TOW_Base: CUP_nHMMWV_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
+    };
+    class CUP_nM1025_SOV_Base: CUP_nHMMWV_Base {
+        attenuationEffectType = "OpenCarAttenuation";
     };
     // Tweaks to the GTK Boxer's handling (accel/braking) + HMG swap to M3M + countermeasures move to gunner
     class Wheeled_APC_F: Car_F {
@@ -116,6 +144,36 @@ class CfgVehicles {
                 magazines[] = {}; // was "SmokeLauncherMag"
             };
         };
+    };
+    // CUP Frag7 Humvees
+    class CUP_ECVHMMWV_Base: Car_F {
+        class Turrets: Turrets {
+            class MainTurret;
+        };
+    };
+    class CUP_ECVHMMWV_m2_Base: CUP_ECVHMMWV_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
+    };
+    class CUP_ECVHMMWV_m240_Base: CUP_ECVHMMWV_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
+    };
+    class CUP_ECVHMMWV_mk19_Base: CUP_ECVHMMWV_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
+    };
+    // CUP Tigrs
+    class CUP_Tigr_Base: Car_F {
+        class Turrets: Turrets {
+            class MainTurret;
+        };
+    };
+    class CUP_Tigr_M_PK_Base: CUP_Tigr_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
+    };
+    class CUP_Tigr_STS_PK_Base: CUP_Tigr_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
+    };
+    class CUP_Tigr_M_KORD_Base: CUP_Tigr_Base {
+        CUP_MAINTURRET_DISABLE_ATTENUATE;
     };
 };
 


### PR DESCRIPTION
This PR fixes gunners audio being attenuated on

- HMMWVs
  - Normal HMMWVs
  - SOV HMMWVs
  - FRAG7 HMMWVs
- Tigr - All armed variants