### PR TITLE
Zeus Utils - FIx define not being properly analyzed

### DIFF
--- a/addons/zeusUtils/script_component.hpp
+++ b/addons/zeusUtils/script_component.hpp
@@ -13,4 +13,4 @@
 
 #define ZEUSUTILS_IDC_DISPLAYFPSBUTTON 241119
 
-#define INFORM_USER(var1) systemChat "[POTATO][zeusUtils] var1"
+#define INFORM_USER(var1) systemChat QUOTE([POTATO][zeusUtils] var1)


### PR DESCRIPTION
I used quotes instead of the QUOTE macro with a variable inside the quotes in a macro.