### PR TITLE
Create Potato - Mission Maker - Zeus Utilities section

### DIFF
--- a/addons/zeusUtils/initSettings.inc.sqf
+++ b/addons/zeusUtils/initSettings.inc.sqf
@@ -28,7 +28,7 @@
 [
     QGVAR(missionFPSEnable), "CHECKBOX",
     ["Enable Zeus FPS counter", "Enable Zeus display of players FPS counters. Takes some network overhead."],
-    ["POTATO - Zeus", "Zeus Player FPS Display"],
+    ["POTATO - Mission Maker", "Zeus Utilities"],
     false,
     1,
     {},


### PR DESCRIPTION
This PR transfers the setting to enable Zeus FPS counter to "Potato - Mission Maker"