### PR TITLE
Respawn - Change text from "Respawn" to "Reinforcement" in user facing locations

### DIFF
--- a/addons/adminMenu/Interrupt_adminMenu.hpp
+++ b/addons/adminMenu/Interrupt_adminMenu.hpp
@@ -80,7 +80,7 @@ class POTATO_EscapeButton_Base2: RscShortcutButton {
     shadow = 0;
     style = "0x02 + 0xC0";
     text = "R";
-    tooltip = "Respawn";
+    tooltip = "Reinforcements";
     x = "14.5 * (((safezoneW / safezoneH) min 1.2) / 40) + (safezoneX)";
     y = "2.3 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) + safezoneY";
     w = "1.5 * (((safezoneW / safezoneH) min 1.2) / 40)";

--- a/addons/respawn/CfgFactionClasses.hpp
+++ b/addons/respawn/CfgFactionClasses.hpp
@@ -1,6 +1,6 @@
 class CfgFactionClasses {
     class PREFIX;
     class GVAR(respawnFaction): PREFIX {
-        displayName = "POTATO: Respawn";
+        displayName = "POTATO: Reinforcements";
     };
 };

--- a/addons/respawn/CfgVehicles.hpp
+++ b/addons/respawn/CfgVehicles.hpp
@@ -6,7 +6,7 @@ class CfgVehicles {
     // placeable respawn point to aide respawning
     class GVAR(placeRespawnPoint): Module_F {
         author = QUOTE(PREFIX);
-        displayName = "Respawn Point";
+        displayName = "Reinforcement Point";
         category = QGVAR(respawnFaction);
         icon = QPATHTOF(data\respawn_point);
         portrait = QPATHTOF(data\respawn_point);
@@ -31,7 +31,7 @@ class CfgVehicles {
 
     // zeus module to open respawn
     class GVAR(openRespawnMenu): GVAR(placeRespawnPoint) {
-        displayName = "Open Respawn";
+        displayName = "Open Reinforcement Slotting";
         icon = QPATHTOF(data\respawn_tool);
         portrait = QPATHTOF(data\respawn_tool);
         scope = 1;

--- a/addons/respawn/Displays.hpp
+++ b/addons/respawn/Displays.hpp
@@ -30,7 +30,7 @@ class GVAR(adminRespawn) {
         };
         class BackGroundFrame: RscFrame {
             idc = ADMIN_BGF_IDC;
-            text = "Wave Respawn Tool";
+            text = "Wave Reinforcement Tool";
             x = QUOTE(0.275 * safezoneW + safezoneX);
             y = QUOTE(0.24 * safezoneH + safezoneY);
             w = QUOTE(0.45 * safezoneW);
@@ -216,7 +216,7 @@ class GVAR(adminRespawn) {
         class OpenRespawnButton: RscButton {
             idc = ADMIN_OPEN_RESPAWN_BUTTON_IDC;
             onButtonClick = QUOTE(_this call FUNC(ui_handleRespawnStateClick));
-            text = "Open Respawn";
+            text = "Open Reinforcements";
             x = QUOTE(0.6 * safezoneW + safezoneX);
             y = QUOTE(0.52 * safezoneH + safezoneY);
             w = QUOTE(0.1 * safezoneW);
@@ -225,21 +225,21 @@ class GVAR(adminRespawn) {
             colorBackground[] = {COLOR_GREEN_INACTIVE};
             colorBackgroundActive[] = {COLOR_GREEN_ACTIVE};
             colorBackgroundDisabled[] = {COLOR_BLACK};
-            tooltip = "Open respawn to current spectators";
-            sizeEx = QUOTE(0.75 * TEXT_SIZE_FACTOR);
+            tooltip = "Open reinforcement wave to current spectators";
+            sizeEx = QUOTE(0.6 * TEXT_SIZE_FACTOR);
         };
         class CloseRespawnButton: OpenRespawnButton {
             idc = ADMIN_CLOSE_RESPAWN_BUTTON_IDC;
-            text = "Close Respawn";
+            text = "Close Reinforcements";
             colorFocused[] = {COLOR_RED_INACTIVE};
             colorBackground[] = {COLOR_RED_INACTIVE};
             colorBackgroundActive[] = {COLOR_RED_ACTIVE};
-            tooltip = "Close respawn to current spectators";
+            tooltip = "Close reinforcement slotting to current spectators";
         };
         class TriggerButton: RscButton {
             idc = ADMIN_TRIGGER_BUTTON_IDC;
             onButtonClick = QUOTE(_this call FUNC(ui_handleTriggerClick));
-            text = "Trigger Respawn";
+            text = "Trigger Reinforcements";
             x = QUOTE(0.6 * safezoneW + safezoneX);
             y = QUOTE(0.58 * safezoneH + safezoneY);
             w = QUOTE(0.1 * safezoneW);
@@ -248,13 +248,13 @@ class GVAR(adminRespawn) {
             colorBackground[] = {COLOR_BLUE_INACTIVE};
             colorBackgroundActive[] = {COLOR_BLUE_ACTIVE};
             colorBackgroundDisabled[] = {COLOR_BLACK};
-            tooltip = "Trigger respawn with the players in the active groups";
-            sizeEx = QUOTE(0.75 * TEXT_SIZE_FACTOR);
+            tooltip = "Trigger reinforcement wave with the players in the active groups";
+            sizeEx = QUOTE(0.6 * TEXT_SIZE_FACTOR);
         };
         class CancelButton: RscButton {
             idc = ADMIN_CANCEL_BUTTON_IDC;
             onButtonClick = QUOTE(_this call FUNC(ui_handleCancelClick));
-            text = "Cancel Respawn";
+            text = "Cancel Reinforcements";
             x = QUOTE(0.6 * safezoneW + safezoneX);
             y = QUOTE(0.64 * safezoneH + safezoneY);
             w = QUOTE(0.1 * safezoneW);
@@ -263,8 +263,8 @@ class GVAR(adminRespawn) {
             colorBackground[] = {COLOR_RED_INACTIVE};
             colorBackgroundActive[] = {COLOR_RED_ACTIVE};
             colorBackgroundDisabled[] = {COLOR_BLACK};
-            tooltip = "Cancels the currently configured respawn";
-            sizeEx = QUOTE(0.75 * TEXT_SIZE_FACTOR);
+            tooltip = "Cancels the currently configured reinforcements";
+            sizeEx = QUOTE(0.6 * TEXT_SIZE_FACTOR);
         };
         class ChatButtonOn: RscButton {
             idc = ADMIN_CHAT_BUTTON_ON_IDC;
@@ -332,7 +332,7 @@ class GVAR(respawnEula) {
         };
         class BackGroundFrame: RscFrame {
             idc = EULA_BGF_IDC;
-            text = "Wave Respawn Tool End User License Agreement";
+            text = "Wave Reinforcement Tool End User License Agreement";
             x = QUOTE(0.425 * safezoneW + safezoneX);
             y = QUOTE(0.36 * safezoneH + safezoneY);
             w = QUOTE(0.125 * safezoneW);
@@ -363,7 +363,7 @@ class GVAR(respawnEula) {
             colorBackground[] = {COLOR_GREEN_INACTIVE};
             colorBackgroundActive[] = {COLOR_GREEN_ACTIVE};
             colorBackgroundDisabled[] = {COLOR_BLACK};
-            tooltip = "Agree to the EULA as described above, and open the respawn tool";
+            tooltip = "Agree to the EULA as described above, and open the Reinforcement tool";
             sizeEx = QUOTE(0.7 * TEXT_SIZE_FACTOR);
         };
         class DeclineButton: RscButton {
@@ -402,7 +402,7 @@ class GVAR(clientRespawn) {
         };
         class BackGroundFrame: RscFrame {
             idc = CLIENT_BGF_IDC;
-            text = "Client Respawn Tool";
+            text = "Client Reinforcement Tool";
             x = QUOTE(0.375 * safezoneW + safezoneX);
             y = QUOTE(0.36 * safezoneH + safezoneY);
             w = QUOTE(0.225 * safezoneW);

--- a/addons/spectate/Displays.hpp
+++ b/addons/spectate/Displays.hpp
@@ -495,12 +495,12 @@ class GVAR(overlay) {
 
             onButtonClick = QUOTE([] spawn EFUNC(respawn,openClientRespawn));
 
-            x = QUOTE(safezoneX + safezoneW - 0.2);
+            x = QUOTE(safezoneX + safezoneW - 0.25);
             y = QUOTE(safezoneY + safezoneH - 0.08);
-            w = 0.2;
+            w = 0.25;
             h = 0.08;
 
-            text = "Open Respawn";
+            text = "Reinforcement Slots";
             colorBackground[] = {0,0,0,0.5};
             sizeEx = QUOTE(1.0 * YFACTOR);
         };


### PR DESCRIPTION
Per the response in the internal suggestions thread, this PR:
- Changes the spectator "Open Respawn" button to a "Reinforcement Slots" button
- Changes all of the `Wave Respawn Tool` text from "Respawn" to "Reinforcement"
- Change admin menu button
- Change Zeus Module names and category to transfer terminology from "Respawn" to "Reinforcement"