### PR TITLE
Misc Fixes - W35

### DIFF
--- a/addons/miscFixes/patchW35/config.cpp
+++ b/addons/miscFixes/patchW35/config.cpp
@@ -1,6 +1,6 @@
 #include "\z\potato\addons\miscFixes\script_component.hpp"
 #undef COMPONENT
-#define COMPONENT miscFixes_patchWW35
+#define COMPONENT miscFixes_patchW35
 
 class CfgPatches {
     class ADDON {

--- a/addons/miscFixes/patchW35/config.cpp
+++ b/addons/miscFixes/patchW35/config.cpp
@@ -1,0 +1,25 @@
+#include "\z\potato\addons\miscFixes\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT miscFixes_patchWW35
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"potato_core", "tweed_aegis_21_units"};
+        skipWhenMissingDependencies = 1;
+        author = "Bourbon Warfare";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+class CfgVehicles {
+    class SoldierWB;
+    class B_Soldier_base_F: SoldierWB {
+        backpack = "";
+        accuracy = 2.3;
+        modelSides[] = {3, 1};
+    };
+};


### PR DESCRIPTION
W35 introduces a few changes to `B_Soldier_base_f`, some of which propagate to all (including BW) west units. The important one is the `accuracy` decrease making it harder for AI to spot players, but the other two are just things I would like reverted as well.