### PR TITLE
strongerFlashlights - Add 3x barely stronger flashlights and an intermediately brighter white flashlight

### DIFF
--- a/addons/strongerFlashlights/CfgWeapons.hpp
+++ b/addons/strongerFlashlights/CfgWeapons.hpp
@@ -268,13 +268,11 @@ class CfgWeapons {
                 ACE_Flashlight_Colour = "White";
                 ACE_Flashlight_Size = 2.75;
                 ACE_Flashlight_Sound = 1;
-                direction = "flash";
                 innerAngle = 3;
                 outerAngle = 5;
                 coneFadeCoef = 6;
-                dayLight = 0;
                 useFlare = 1;
-                irLight = 0;
+                dayLight = 0;
                 flareMaxDistance = 250;
                 flareSize = 2;
                 intensity = 120;
@@ -303,9 +301,8 @@ class CfgWeapons {
                 ACE_Flashlight_Sound = 1;
                 innerAngle = 5;
                 outerAngle = 40;
-                dayLight = 0;
                 useFlare = 1;
-                irLight = 0;
+                dayLight = 0;
                 flareMaxDistance = 80;
                 flareSize = 1.4;
                 intensity = 80;
@@ -333,9 +330,8 @@ class CfgWeapons {
                 ACE_Flashlight_Colour = "White";
                 ACE_Flashlight_Size = 2.75;
                 ACE_Flashlight_Sound = 1;
-                dayLight = 0;
                 useFlare = 1;
-                irLight = 0;
+                dayLight = 0;
                 flareMaxDistance = 60;
                 flareSize = 1;
                 intensity = 50;
@@ -360,14 +356,11 @@ class CfgWeapons {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_yellow_ca.paa";
                 ACE_Flashlight_Colour = "Yellow";
-                ACE_Flashlight_Size = 2.75;
-                ACE_Flashlight_Sound = 1;
+                ACE_Flashlight_Size = 1;
                 innerAngle = 3;
                 outerAngle = 5;
                 coneFadeCoef = 6;
-                dayLight = 0;
                 useFlare = 1;
-                irLight = 0;
                 flareMaxDistance = 200;
                 flareSize = 2;
                 intensity = 80;
@@ -389,13 +382,10 @@ class CfgWeapons {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_yellow_ca.paa";
                 ACE_Flashlight_Colour = "Yellow";
-                ACE_Flashlight_Size = 2.75;
-                ACE_Flashlight_Sound = 1;
+                ACE_Flashlight_Size = 1;
                 innerAngle = 5;
                 outerAngle = 40;
-                dayLight = 0;
                 useFlare = 1;
-                irLight = 0;
                 flareMaxDistance = 40;
                 flareSize = 0.7;
                 intensity = 40;
@@ -419,11 +409,8 @@ class CfgWeapons {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_yellow_ca.paa";
                 ACE_Flashlight_Colour = "Yellow";
-                ACE_Flashlight_Size = 2.75;
-                ACE_Flashlight_Sound = 1;
-                dayLight = 0;
+                ACE_Flashlight_Size = 1;
                 useFlare = 1;
-                irLight = 0;
                 flareMaxDistance = 40;
                 flareSize = 0.25;
                 intensity = 20;
@@ -447,14 +434,11 @@ class CfgWeapons {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_red_ca.paa";
                 ACE_Flashlight_Colour = "Red";
-                ACE_Flashlight_Size = 2.75;
-                ACE_Flashlight_Sound = 1;
+                ACE_Flashlight_Size = 1;
                 innerAngle = 3;
                 outerAngle = 5;
                 coneFadeCoef = 6;
-                dayLight = 0;
                 useFlare = 1;
-                irLight = 0;
                 flareMaxDistance = 200;
                 flareSize = 2;
                 intensity = 80;
@@ -476,13 +460,10 @@ class CfgWeapons {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_red_ca.paa";
                 ACE_Flashlight_Colour = "Red";
-                ACE_Flashlight_Size = 2.75;
-                ACE_Flashlight_Sound = 1;
+                ACE_Flashlight_Size = 1;
                 innerAngle = 5;
                 outerAngle = 40;
-                dayLight = 0;
                 useFlare = 0;
-                irLight = 0;
                 flareMaxDistance = 80;
                 flareSize = 1.4;
                 intensity = 40;
@@ -508,9 +489,7 @@ class CfgWeapons {
                 ACE_Flashlight_Colour = "Red";
                 ACE_Flashlight_Size = 2.75;
                 ACE_Flashlight_Sound = 1;
-                dayLight = 0;
                 useFlare = 0;
-                irLight = 0;
                 flareMaxDistance = 60;
                 flareSize = 1;
                 intensity = 20;
@@ -532,12 +511,11 @@ class CfgWeapons {
         baseWeapon = QGVAR(acc_cup_Flashlight_05);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
+                ACE_Flashlight_Size = 1;
                 innerAngle = 3;
                 outerAngle = 5;
                 coneFadeCoef = 6;
-                dayLight = 0;
                 useFlare = 1;
-                irLight = 0;
                 flareMaxDistance = 160;
                 flareSize = 2;
                 intensity = 80;
@@ -555,11 +533,10 @@ class CfgWeapons {
         MRT_switchItemHintText = "Flashlight (White)";
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
+                ACE_Flashlight_Size = 1;
                 innerAngle = 5;
                 outerAngle = 40;
-                dayLight = 0;
                 useFlare = 1;
-                irLight = 0;
                 flareMaxDistance = 80;
                 flareSize = 1.4;
                 intensity = 40;
@@ -578,9 +555,8 @@ class CfgWeapons {
         baseWeapon = QGVAR(acc_cup_Flashlight_05);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
-                dayLight = 0;
+                ACE_Flashlight_Size = 1;
                 useFlare = 1;
-                irLight = 0;
                 flareMaxDistance = 60;
                 flareSize = 1;
                 intensity = 20;

--- a/addons/strongerFlashlights/CfgWeapons.hpp
+++ b/addons/strongerFlashlights/CfgWeapons.hpp
@@ -1,17 +1,18 @@
 class CfgWeapons {
     class InventoryFlashLightItem_Base_F;
 
-    class cup_acc_flashlight; //CUP Flashlight -surefire
 
     class ItemCore;
+    class CUP_acc_Flashlight: ItemCore { //CUP Flashlight -surefire
+        class ItemInfo;
+    };
     class ACE_acc_pointer_green;
     class acc_flashlight_pistol;
 
 /////////////////////////////////////////
 //////////Multimode Flashlight///////////
 /////////////////////////////////////////
-
-    class GVAR(CUP_LED_flashlight_Beam): cup_acc_flashlight {
+    class GVAR(CUP_LED_flashlight_Beam): CUP_acc_Flashlight {
         author = "Potato";
         scope = 1;
         displayName = "Tactical LED Flashlight (Multi-Mode)";
@@ -49,7 +50,7 @@ class CfgWeapons {
             };
         };
     };
-    class GVAR(CUP_LED_flashlight): cup_acc_flashlight {
+    class GVAR(CUP_LED_flashlight): CUP_acc_Flashlight {
         author = "Potato";
         scope = 2;
         displayName = "Tactical LED Flashlight (Multi-Mode)";
@@ -87,7 +88,7 @@ class CfgWeapons {
             };
         };
     };
-    class GVAR(CUP_LED_flashlight_Flood): cup_acc_flashlight {
+    class GVAR(CUP_LED_flashlight_Flood): CUP_acc_Flashlight {
         author = "Potato";
         scope = 1;
         displayName = "Tactical LED Flashlight (Multi-Mode)";
@@ -245,11 +246,267 @@ class CfgWeapons {
             };
         };
     };
+
+//////////////////////////////////////////////////
+//////Medium A3 Vanilla Multimode Flashlight//////
+//////////////////////////////////////////////////
+    class GVAR(acc_Flashlight_Dummy): CUP_acc_Flashlight {
+        scope = 0;
+        class ItemInfo: ItemInfo {
+            class FlashLight;
+        };
+    };
+    class GVAR(acc_Flashlight_02_Spot): GVAR(acc_Flashlight_Dummy) {
+        scope = 1;
+        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_02_Wide);
+        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_02);
+        MRT_switchItemHintText = "Flashlight (Spot, White)";
+        baseWeapon = QGVAR(acc_Flashlight_02);
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_beam_white_ca.paa";
+                ACE_Flashlight_Colour = "White";
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
+                innerAngle = 5;
+                outerAngle = 8;
+                coneFadeCoef = 6;
+                dayLight = 0;
+                useFlare = 1;
+                irLight = 0;
+                flareMaxDistance = 300;
+                flareSize = 2;
+                intensity = 250;
+                class Attenuation {
+                    hardLimitStart = 325;
+                    hardLimitEnd = 400;
+                    start = 1;
+                    constant = 1;
+                    linear = 0;
+                    quadratic = 0.01;
+                };
+            };
+        };
+    };
+    class GVAR(acc_Flashlight_02): GVAR(acc_Flashlight_Dummy) {
+        scope = 2;
+        displayName="Flashlight (Multimode, White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_02_Spot);
+        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_02_Wide);
+        MRT_switchItemHintText = "Flashlight";
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_beam_white_ca.paa";
+                ACE_Flashlight_Colour = "White";
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
+                innerAngle = 5;
+                outerAngle = 40;
+                dayLight = 0;
+                useFlare = 1;
+                irLight = 0;
+                flareMaxDistance = 80;
+                flareSize = 1.4;
+                intensity = 125;
+                class Attenuation {
+                    hardLimitStart = 150;
+                    hardLimitEnd = 225;
+                    start = 0;
+                    constant = 1;
+                    linear = 0;
+                    quadratic = 0.03;
+                };
+            };
+        };
+    };
+    class GVAR(acc_Flashlight_02_Wide): GVAR(acc_Flashlight_Dummy) {
+        scope = 1;
+        displayName="Flashlight (Switchable, White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_02);
+        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_02_Spot);
+        MRT_switchItemHintText = "Flashlight (Flood)";
+        baseWeapon = QGVAR(acc_Flashlight_02);
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_beam_white_ca.paa";
+                ACE_Flashlight_Colour = "White";
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
+                dayLight = 0;
+                useFlare = 1;
+                irLight = 0;
+                flareMaxDistance = 60;
+                flareSize = 1;
+                intensity = 65;
+                class Attenuation {
+                    hardLimitStart = 50;
+                    hardLimitEnd = 125;
+                    start = 0;
+                    constant = 0.1;
+                    linear = 0.1;
+                    quadratic = 0.05;
+                };
+            };
+        };
+    };
+    class GVAR(acc_Flashlight_03_Spot): GVAR(acc_Flashlight_02_Spot) {
+        displayName="Flashlight (Spot, Yellow)";
+        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_03_Wide);
+        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_03);
+        MRT_switchItemHintText = "Flashlight (Spot, Yellow)";
+        baseWeapon = QGVAR(acc_Flashlight_03);
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_yellow_ca.paa";
+                ACE_Flashlight_Colour = "Yellow";
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
+                innerAngle = 5;
+                outerAngle = 8;
+                coneFadeCoef = 6;
+                dayLight = 0;
+                useFlare = 1;
+                irLight = 0;
+                flareMaxDistance = 300;
+                flareSize = 2;
+                intensity = 250;
+                ambient[] = {0.84, 0.86, 0.11};
+                color[] = {191, 196, 26};
+                class Attenuation: Attenuation {};
+            };
+        };
+    };
+    class GVAR(acc_Flashlight_03): GVAR(acc_Flashlight_02) {
+        displayName="Flashlight (Multimode, Yellow)";
+        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_03_Spot);
+        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_03_Wide);
+        MRT_switchItemHintText = "Flashlight (Yellow)";
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_yellow_ca.paa";
+                ACE_Flashlight_Colour = "Yellow";
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
+                innerAngle = 5;
+                outerAngle = 40;
+                dayLight = 0;
+                useFlare = 1;
+                irLight = 0;
+                flareMaxDistance = 80;
+                flareSize = 1.4;
+                intensity = 125;
+                ambient[] = {0.84, 0.86, 0.11};
+                color[] = {191, 196, 26};
+                class Attenuation: Attenuation {};
+            };
+        };
+    };
+    class GVAR(acc_Flashlight_03_Wide): GVAR(acc_Flashlight_02_Wide) {
+        displayName="Flashlight (Flood, Yellow)";
+        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_03);
+        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_03_Spot);
+        MRT_switchItemHintText = "Flashlight (Flood, Yellow)";
+        baseWeapon = QGVAR(acc_Flashlight_03);
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_yellow_ca.paa";
+                ACE_Flashlight_Colour = "Yellow";
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
+                dayLight = 0;
+                useFlare = 0;
+                irLight = 0;
+                flareMaxDistance = 60;
+                flareSize = 1;
+                intensity = 65;
+                ambient[] = {0.84, 0.86, 0.11};
+                color[] = {191, 196, 26};
+                class Attenuation: Attenuation {};
+            };
+        };
+    };
+    class GVAR(acc_Flashlight_04_Spot): GVAR(acc_Flashlight_02_Spot) {
+        displayName="Flashlight (Spot, Red)";
+        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_04_Wide);
+        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_04);
+        MRT_switchItemHintText = "Flashlight (Spot, Red)";
+        baseWeapon = QGVAR(acc_Flashlight_04);
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_red_ca.paa";
+                ACE_Flashlight_Colour = "Red";
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
+                innerAngle = 5;
+                outerAngle = 8;
+                coneFadeCoef = 6;
+                dayLight = 0;
+                useFlare = 1;
+                irLight = 0;
+                flareMaxDistance = 300;
+                flareSize = 2;
+                intensity = 250;
+                ambient[] = {0.8, 0.1, 0.1};
+                color[] = {242, 10, 5};
+                class Attenuation: Attenuation {};
+            };
+        };
+    };
+    class GVAR(acc_Flashlight_04): GVAR(acc_Flashlight_02) {
+        displayName="Flashlight (Multimode, Red)";
+        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_04_Spot);
+        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_04_Wide);
+        MRT_switchItemHintText = "Flashlight (Red)";
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_red_ca.paa";
+                ACE_Flashlight_Colour = "Red";
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
+                innerAngle = 5;
+                outerAngle = 40;
+                dayLight = 0;
+                useFlare = 0;
+                irLight = 0;
+                flareMaxDistance = 80;
+                flareSize = 1.4;
+                intensity = 50;
+                ambient[] = {0.8, 0.1, 0.1};
+                color[] = {242, 10, 5};
+            };
+        };
+    };
+    class GVAR(acc_Flashlight_04_Wide): GVAR(acc_Flashlight_02_Wide) {
+        displayName="Flashlight (Flood, Red)";
+        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_04);
+        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_04_Spot);
+        MRT_switchItemHintText = "Flashlight (Flood, Red)";
+        baseWeapon = QGVAR(acc_Flashlight_04);
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_red_ca.paa";
+                ACE_Flashlight_Colour = "Red";
+                ACE_Flashlight_Size = 2.75;
+                ACE_Flashlight_Sound = 1;
+                dayLight = 0;
+                useFlare = 0;
+                irLight = 0;
+                flareMaxDistance = 60;
+                flareSize = 1;
+                intensity = 40;
+                ambient[] = {0.8, 0.1, 0.1};
+                color[] = {242, 10, 5};
+            };
+        };
+    };
 };
 
 //////////////////////////////
 //////////////RAILS///////////
 //////////////////////////////
+#define ACC_FLASHLIGHT_TRIPLET_LMD(var1) DOUBLES(GVAR(acc_Flashlight),var1) = 1;\
+TRIPLES(GVAR(acc_Flashlight),var1,Wide) = 1;\
+TRIPLES(GVAR(acc_Flashlight),var1,Spot) = 1
 
 class SlotInfo;
 class asdg_SlotInfo;
@@ -258,6 +515,9 @@ class asdg_FrontSideRail: asdg_SlotInfo {
         GVAR(CUP_LED_flashlight_Flood) = 1;
         GVAR(CUP_LED_flashlight_Beam) = 1;
         GVAR(CUP_LED_flashlight) = 1;
+        ACC_FLASHLIGHT_TRIPLET_LMD(02);
+        ACC_FLASHLIGHT_TRIPLET_LMD(03);
+        ACC_FLASHLIGHT_TRIPLET_LMD(04);
     };
 };
 class PointerSlot;
@@ -282,5 +542,8 @@ class rhs_russian_ak_barrel_slot: SlotInfo {
         GVAR(CUP_LED_flashlight_Flood) = 1;
         GVAR(CUP_LED_flashlight_Beam) = 1;
         GVAR(CUP_LED_flashlight) = 1;
+        ACC_FLASHLIGHT_TRIPLET_LMD(02);
+        ACC_FLASHLIGHT_TRIPLET_LMD(03);
+        ACC_FLASHLIGHT_TRIPLET_LMD(04);
 	};
 };

--- a/addons/strongerFlashlights/CfgWeapons.hpp
+++ b/addons/strongerFlashlights/CfgWeapons.hpp
@@ -250,17 +250,17 @@ class CfgWeapons {
 //////////////////////////////////////////////////
 //////Medium A3 Vanilla Multimode Flashlight//////
 //////////////////////////////////////////////////
-    class GVAR(acc_Flashlight_Dummy): CUP_acc_Flashlight {
+    class GVAR(acc_cup_Flashlight_Dummy): CUP_acc_Flashlight {
         scope = 0;
         class ItemInfo: ItemInfo {
             class FlashLight;
         };
     };
-    class GVAR(acc_Flashlight_02_Spot): GVAR(acc_Flashlight_Dummy) {
+    class GVAR(acc_cup_Flashlight_02_Spot): GVAR(acc_cup_Flashlight_Dummy) {
         scope = 1;
-        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_02_Wide);
-        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_02);
-        MRT_switchItemHintText = "Flashlight (Spot, White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_02_Wide);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_02);
+        MRT_switchItemHintText = "Flashlight (Spot, Bright White)";
         baseWeapon = QGVAR(acc_Flashlight_02);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
@@ -268,18 +268,19 @@ class CfgWeapons {
                 ACE_Flashlight_Colour = "White";
                 ACE_Flashlight_Size = 2.75;
                 ACE_Flashlight_Sound = 1;
-                innerAngle = 5;
-                outerAngle = 8;
+                direction = "flash";
+                innerAngle = 3;
+                outerAngle = 5;
                 coneFadeCoef = 6;
                 dayLight = 0;
                 useFlare = 1;
                 irLight = 0;
-                flareMaxDistance = 300;
+                flareMaxDistance = 250;
                 flareSize = 2;
-                intensity = 250;
+                intensity = 120;
                 class Attenuation {
-                    hardLimitStart = 325;
-                    hardLimitEnd = 400;
+                    hardLimitStart = 225;
+                    hardLimitEnd = 300;
                     start = 1;
                     constant = 1;
                     linear = 0;
@@ -288,11 +289,11 @@ class CfgWeapons {
             };
         };
     };
-    class GVAR(acc_Flashlight_02): GVAR(acc_Flashlight_Dummy) {
+    class GVAR(acc_cup_Flashlight_02): GVAR(acc_cup_Flashlight_Dummy) {
         scope = 2;
-        displayName="Flashlight (Multimode, White)";
-        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_02_Spot);
-        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_02_Wide);
+        displayName="Flashlight (Multimode, Bright White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_02_Spot);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_02_Wide);
         MRT_switchItemHintText = "Flashlight";
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
@@ -307,7 +308,7 @@ class CfgWeapons {
                 irLight = 0;
                 flareMaxDistance = 80;
                 flareSize = 1.4;
-                intensity = 125;
+                intensity = 80;
                 class Attenuation {
                     hardLimitStart = 150;
                     hardLimitEnd = 225;
@@ -319,13 +320,13 @@ class CfgWeapons {
             };
         };
     };
-    class GVAR(acc_Flashlight_02_Wide): GVAR(acc_Flashlight_Dummy) {
+    class GVAR(acc_cup_Flashlight_02_Wide): GVAR(acc_cup_Flashlight_Dummy) {
         scope = 1;
-        displayName="Flashlight (Switchable, White)";
-        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_02);
-        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_02_Spot);
+        displayName="Flashlight (Wide, Bright White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_02);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_02_Spot);
         MRT_switchItemHintText = "Flashlight (Flood)";
-        baseWeapon = QGVAR(acc_Flashlight_02);
+        baseWeapon = QGVAR(acc_cup_Flashlight_02);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_beam_white_ca.paa";
@@ -337,9 +338,9 @@ class CfgWeapons {
                 irLight = 0;
                 flareMaxDistance = 60;
                 flareSize = 1;
-                intensity = 65;
+                intensity = 50;
                 class Attenuation {
-                    hardLimitStart = 50;
+                    hardLimitStart = 40;
                     hardLimitEnd = 125;
                     start = 0;
                     constant = 0.1;
@@ -349,37 +350,40 @@ class CfgWeapons {
             };
         };
     };
-    class GVAR(acc_Flashlight_03_Spot): GVAR(acc_Flashlight_02_Spot) {
+    class GVAR(acc_cup_Flashlight_03_Spot): GVAR(acc_cup_Flashlight_02_Spot) {
         displayName="Flashlight (Spot, Yellow)";
-        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_03_Wide);
-        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_03);
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_03_Wide);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_03);
         MRT_switchItemHintText = "Flashlight (Spot, Yellow)";
-        baseWeapon = QGVAR(acc_Flashlight_03);
+        baseWeapon = QGVAR(acc_cup_Flashlight_03);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_yellow_ca.paa";
                 ACE_Flashlight_Colour = "Yellow";
                 ACE_Flashlight_Size = 2.75;
                 ACE_Flashlight_Sound = 1;
-                innerAngle = 5;
-                outerAngle = 8;
+                innerAngle = 3;
+                outerAngle = 5;
                 coneFadeCoef = 6;
                 dayLight = 0;
                 useFlare = 1;
                 irLight = 0;
-                flareMaxDistance = 300;
+                flareMaxDistance = 200;
                 flareSize = 2;
-                intensity = 250;
+                intensity = 80;
                 ambient[] = {0.84, 0.86, 0.11};
                 color[] = {191, 196, 26};
-                class Attenuation: Attenuation {};
+                class Attenuation: Attenuation {
+                    hardLimitStart = 80;
+                    hardLimitEnd = 200;
+                };
             };
         };
     };
-    class GVAR(acc_Flashlight_03): GVAR(acc_Flashlight_02) {
+    class GVAR(acc_cup_Flashlight_03): GVAR(acc_cup_Flashlight_02) {
         displayName="Flashlight (Multimode, Yellow)";
-        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_03_Spot);
-        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_03_Wide);
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_03_Spot);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_03_Wide);
         MRT_switchItemHintText = "Flashlight (Yellow)";
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
@@ -392,21 +396,25 @@ class CfgWeapons {
                 dayLight = 0;
                 useFlare = 1;
                 irLight = 0;
-                flareMaxDistance = 80;
-                flareSize = 1.4;
-                intensity = 125;
+                flareMaxDistance = 40;
+                flareSize = 0.7;
+                intensity = 40;
                 ambient[] = {0.84, 0.86, 0.11};
                 color[] = {191, 196, 26};
-                class Attenuation: Attenuation {};
+                volumeShape = "";
+                class Attenuation: Attenuation {
+                    hardLimitStart = 50;
+                    hardLimitEnd = 100;
+                };
             };
         };
     };
-    class GVAR(acc_Flashlight_03_Wide): GVAR(acc_Flashlight_02_Wide) {
+    class GVAR(acc_cup_Flashlight_03_Wide): GVAR(acc_cup_Flashlight_02_Wide) {
         displayName="Flashlight (Flood, Yellow)";
-        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_03);
-        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_03_Spot);
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_03);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_03_Spot);
         MRT_switchItemHintText = "Flashlight (Flood, Yellow)";
-        baseWeapon = QGVAR(acc_Flashlight_03);
+        baseWeapon = QGVAR(acc_cup_Flashlight_03);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_yellow_ca.paa";
@@ -414,48 +422,55 @@ class CfgWeapons {
                 ACE_Flashlight_Size = 2.75;
                 ACE_Flashlight_Sound = 1;
                 dayLight = 0;
-                useFlare = 0;
+                useFlare = 1;
                 irLight = 0;
-                flareMaxDistance = 60;
-                flareSize = 1;
-                intensity = 65;
+                flareMaxDistance = 40;
+                flareSize = 0.25;
+                intensity = 20;
                 ambient[] = {0.84, 0.86, 0.11};
                 color[] = {191, 196, 26};
-                class Attenuation: Attenuation {};
+                volumeShape = "";
+                class Attenuation: Attenuation {
+                    hardLimitStart = 30;
+                    hardLimitEnd = 80;
+                };
             };
         };
     };
-    class GVAR(acc_Flashlight_04_Spot): GVAR(acc_Flashlight_02_Spot) {
+    class GVAR(acc_cup_Flashlight_04_Spot): GVAR(acc_cup_Flashlight_02_Spot) {
         displayName="Flashlight (Spot, Red)";
-        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_04_Wide);
-        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_04);
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_04_Wide);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_04);
         MRT_switchItemHintText = "Flashlight (Spot, Red)";
-        baseWeapon = QGVAR(acc_Flashlight_04);
+        baseWeapon = QGVAR(acc_cup_Flashlight_04);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_red_ca.paa";
                 ACE_Flashlight_Colour = "Red";
                 ACE_Flashlight_Size = 2.75;
                 ACE_Flashlight_Sound = 1;
-                innerAngle = 5;
-                outerAngle = 8;
+                innerAngle = 3;
+                outerAngle = 5;
                 coneFadeCoef = 6;
                 dayLight = 0;
                 useFlare = 1;
                 irLight = 0;
-                flareMaxDistance = 300;
+                flareMaxDistance = 200;
                 flareSize = 2;
-                intensity = 250;
-                ambient[] = {0.8, 0.1, 0.1};
+                intensity = 80;
+                ambient[] = {0.4, 0.05, 0.05};
                 color[] = {242, 10, 5};
-                class Attenuation: Attenuation {};
+                class Attenuation: Attenuation {
+                    hardLimitStart = 80;
+                    hardLimitEnd = 200;
+                };
             };
         };
     };
-    class GVAR(acc_Flashlight_04): GVAR(acc_Flashlight_02) {
+    class GVAR(acc_cup_Flashlight_04): GVAR(acc_cup_Flashlight_02) {
         displayName="Flashlight (Multimode, Red)";
-        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_04_Spot);
-        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_04_Wide);
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_04_Spot);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_04_Wide);
         MRT_switchItemHintText = "Flashlight (Red)";
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
@@ -470,18 +485,23 @@ class CfgWeapons {
                 irLight = 0;
                 flareMaxDistance = 80;
                 flareSize = 1.4;
-                intensity = 50;
-                ambient[] = {0.8, 0.1, 0.1};
+                intensity = 40;
+                ambient[] = {0.4, 0.05, 0.05};
                 color[] = {242, 10, 5};
+                volumeShape = "";
+                class Attenuation: Attenuation {
+                    hardLimitStart = 50;
+                    hardLimitEnd = 100;
+                };
             };
         };
     };
-    class GVAR(acc_Flashlight_04_Wide): GVAR(acc_Flashlight_02_Wide) {
+    class GVAR(acc_cup_Flashlight_04_Wide): GVAR(acc_cup_Flashlight_02_Wide) {
         displayName="Flashlight (Flood, Red)";
-        MRT_SwitchItemNextClass = QGVAR(acc_Flashlight_04);
-        MRT_SwitchItemPrevClass = QGVAR(acc_Flashlight_04_Spot);
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_04);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_04_Spot);
         MRT_switchItemHintText = "Flashlight (Flood, Red)";
-        baseWeapon = QGVAR(acc_Flashlight_04);
+        baseWeapon = QGVAR(acc_cup_Flashlight_04);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Beam = "\z\ace\addons\flashlights\UI\Flashlight_Beam_red_ca.paa";
@@ -493,9 +513,82 @@ class CfgWeapons {
                 irLight = 0;
                 flareMaxDistance = 60;
                 flareSize = 1;
-                intensity = 40;
-                ambient[] = {0.8, 0.1, 0.1};
+                intensity = 20;
+                ambient[] = {0.4, 0.05, 0.05};
                 color[] = {242, 10, 5};
+                volumeShape = "";
+                class Attenuation: Attenuation {
+                    hardLimitStart = 30;
+                    hardLimitEnd = 80;
+                };
+            };
+        };
+    };
+    class GVAR(acc_cup_Flashlight_05_Spot): GVAR(acc_cup_Flashlight_02_Spot) {
+        displayName="Flashlight (White, Red)";
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_045_Wide);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_05);
+        MRT_switchItemHintText = "Flashlight (White, Red)";
+        baseWeapon = QGVAR(acc_cup_Flashlight_05);
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                innerAngle = 3;
+                outerAngle = 5;
+                coneFadeCoef = 6;
+                dayLight = 0;
+                useFlare = 1;
+                irLight = 0;
+                flareMaxDistance = 160;
+                flareSize = 2;
+                intensity = 80;
+                class Attenuation: Attenuation {
+                    hardLimitStart = 80;
+                    hardLimitEnd = 200;
+                };
+            };
+        };
+    };
+    class GVAR(acc_cup_Flashlight_05): GVAR(acc_cup_Flashlight_02) {
+        displayName="Flashlight (Multimode, White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_05_Spot);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_05_Wide);
+        MRT_switchItemHintText = "Flashlight (White)";
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                innerAngle = 5;
+                outerAngle = 40;
+                dayLight = 0;
+                useFlare = 1;
+                irLight = 0;
+                flareMaxDistance = 80;
+                flareSize = 1.4;
+                intensity = 40;
+                class Attenuation: Attenuation {
+                    hardLimitStart = 50;
+                    hardLimitEnd = 100;
+                };
+            };
+        };
+    };
+    class GVAR(acc_cup_Flashlight_05_Wide): GVAR(acc_cup_Flashlight_02_Wide) {
+        displayName="Flashlight (Flood, White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_05);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_05_Spot);
+        MRT_switchItemHintText = "Flashlight (Flood, White)";
+        baseWeapon = QGVAR(acc_cup_Flashlight_05);
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                dayLight = 0;
+                useFlare = 1;
+                irLight = 0;
+                flareMaxDistance = 60;
+                flareSize = 1;
+                intensity = 20;
+                volumeShape = "";
+                class Attenuation: Attenuation {
+                    hardLimitStart = 30;
+                    hardLimitEnd = 80;
+                };
             };
         };
     };
@@ -504,9 +597,9 @@ class CfgWeapons {
 //////////////////////////////
 //////////////RAILS///////////
 //////////////////////////////
-#define ACC_FLASHLIGHT_TRIPLET_LMD(var1) DOUBLES(GVAR(acc_Flashlight),var1) = 1;\
-TRIPLES(GVAR(acc_Flashlight),var1,Wide) = 1;\
-TRIPLES(GVAR(acc_Flashlight),var1,Spot) = 1
+#define ACC_FLASHLIGHT_TRIPLET_LMD(var1) DOUBLES(GVAR(acc_cup_Flashlight),var1) = 1;\
+TRIPLES(GVAR(acc_cup_Flashlight),var1,Wide) = 1;\
+TRIPLES(GVAR(acc_cup_Flashlight),var1,Spot) = 1
 
 class SlotInfo;
 class asdg_SlotInfo;
@@ -518,6 +611,7 @@ class asdg_FrontSideRail: asdg_SlotInfo {
         ACC_FLASHLIGHT_TRIPLET_LMD(02);
         ACC_FLASHLIGHT_TRIPLET_LMD(03);
         ACC_FLASHLIGHT_TRIPLET_LMD(04);
+        ACC_FLASHLIGHT_TRIPLET_LMD(05);
     };
 };
 class PointerSlot;
@@ -545,5 +639,6 @@ class rhs_russian_ak_barrel_slot: SlotInfo {
         ACC_FLASHLIGHT_TRIPLET_LMD(02);
         ACC_FLASHLIGHT_TRIPLET_LMD(03);
         ACC_FLASHLIGHT_TRIPLET_LMD(04);
+        ACC_FLASHLIGHT_TRIPLET_LMD(05);
 	};
 };

--- a/addons/strongerFlashlights/config.cpp
+++ b/addons/strongerFlashlights/config.cpp
@@ -21,7 +21,7 @@ class CfgPatches {
         requiredAddons[] = {"cup_weapons_east_attachments", "cup_weapons_west_attachments", "ace_laserpointer"};
         skipWhenMissingDependencies = 1;
         author = "Potato";
-        authors[] = {"Carl", "Chesheire"};
+        authors[] = {"Carl", "Chesheire", "Lambda.Tiger"};
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
         VERSION_CONFIG;
     };

--- a/addons/strongerFlashlights/config.cpp
+++ b/addons/strongerFlashlights/config.cpp
@@ -10,7 +10,11 @@ class CfgPatches {
 //CUP flashlight
             QGVAR(CUP_LED_flashlight_Flood),
             QGVAR(CUP_LED_flashlight_Beam),
-            QGVAR(CUP_LED_flashlight)
+            QGVAR(CUP_LED_flashlight),
+            GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(02),
+            GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(03),
+            GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(04),
+            GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(05)
         };
         units[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/strongerFlashlights/script_component.hpp
+++ b/addons/strongerFlashlights/script_component.hpp
@@ -10,3 +10,7 @@
 #endif
 
 #include "\z\potato\addons\core\script_macros.hpp"
+
+#define GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(ENUM) QUOTE(DOUBLES(GVAR(acc_cup_Flashlight),ENUM)),\
+QUOTE(TRIPLES(GVAR(acc_cup_Flashlight),ENUM,Spot)),\
+QUOTE(TRIPLES(GVAR(acc_cup_Flashlight),ENUM,Wide))


### PR DESCRIPTION
This PR adds 4 flashlights of varying brightness and color.

- A red, yellow, and white flashlight that aren't blindingly bright but provide a multimode flashlight brighter than vanilla.
- A bright white flashlight that sits somewhere between Chesh's super bright and the other three.

Video in relevant discord channel