### PR TITLE
zeusUtils - Add Draw Markers Button

### DIFF
--- a/addons/zeusUtils/CfgUI.hpp
+++ b/addons/zeusUtils/CfgUI.hpp
@@ -5,13 +5,22 @@ class RscDisplayCurator {
             idc = ZEUSUTILS_IDC_DISPLAYFPSBUTTON;
             // based on Potato's ACRE spectate button
             x = "safezoneX";
-            y = "safezoneY + safeZoneH - 28 * pixelH";
+            y = "safezoneY + safeZoneH - 42 * pixelH";
             w = "80 * pixelW";
             h = "12 * pixelH";
             sizeEx = "12 * pixelH";
             text = "FPS Display";
-            onLoad = QUOTE([ARR_2(_this#0,1)] call FUNC(changeFPSDisplayState));
+            tooltip = "Display player FPS under each the unit of each client.";
+            onLoad = QUOTE([ARR_2(_this#0,true)] call FUNC(changeFPSDisplayState));
             onButtonClick = QUOTE([_this#0] call FUNC(changeFPSDisplayState));
+        };
+        class GVAR(displayMarkersButton): GVAR(displayFPSButton) {
+            idc = ZEUSUTILS_IDC_DISPLAYMARKERBUTTON;
+            y = "safezoneY + safeZoneH - 28 * pixelH";
+            text = "Marker Display";
+            tooltip = "Display markers above units with them.";
+            onLoad = QUOTE([ARR_2(_this#0,true)] call FUNC(changeMarkerDisplayState));
+            onButtonClick = QUOTE([_this#0] call FUNC(changeMarkerDisplayState));
         };
     };
 };

--- a/addons/zeusUtils/XEH_PREP.hpp
+++ b/addons/zeusUtils/XEH_PREP.hpp
@@ -1,7 +1,11 @@
 TRACE_1("",QUOTE(ADDON));
 
+PREP(addDraw3DEH);
 PREP(changeFPSDisplayState);
-PREP(drawFPSHandle);
+PREP(changeMarkerDisplayState);
+PREP(drawFPS);
+PREP(drawMarkers);
 PREP(handleZeusFPSRequest);
 PREP(initLocalFPSEH);
+PREP(removeDraw3DEH);
 PREP(updateServerFPSList);

--- a/addons/zeusUtils/XEH_postInit.sqf
+++ b/addons/zeusUtils/XEH_postInit.sqf
@@ -2,7 +2,7 @@
 
 if (isServer && isMultiplayer) then {
     [QGVAR(ZeusFPSMonitorUpdate), LINKFUNC(handleZeusFPSRequest)] call CBA_fnc_addEventHandler;
-    GVAR(serverUpdateFPSEH) = [{
+    [{
         {
             _x publicVariableClient QGVAR(playerFPSCache);
         } forEach GVAR(clientsTrackingFPS);

--- a/addons/zeusUtils/XEH_preInit.sqf
+++ b/addons/zeusUtils/XEH_preInit.sqf
@@ -6,7 +6,8 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
-GVAR(fpsDisplayEH) = -1;
+GVAR(draw3DFunctions) = createHashMap;
+GVAR(draw3DEH) = -1;
 GVAR(fpsAvgCalcEH) = -1;
 GVAR(fpsAvgCalc) = [0, [0, 0, 0, 0, 0]];
 GVAR(playerFPSCache) = createHashMap;

--- a/addons/zeusUtils/XEH_preInit.sqf
+++ b/addons/zeusUtils/XEH_preInit.sqf
@@ -11,7 +11,6 @@ GVAR(fpsAvgCalcEH) = -1;
 GVAR(fpsAvgCalc) = [0, [0, 0, 0, 0, 0]];
 GVAR(playerFPSCache) = createHashMap;
 GVAR(clientsTrackingFPS) = [];
-GVAR(serverUpdateFPSEH) = -1;
 
 #include "initSettings.inc.sqf"
 

--- a/addons/zeusUtils/functions/fnc_addDraw3DEH.sqf
+++ b/addons/zeusUtils/functions/fnc_addDraw3DEH.sqf
@@ -1,0 +1,51 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * Description:
+ * This function adds a zeusUtil function to the draw hashmap or update state.
+ * Each draw function is provided with the current camera as the
+ * "_localCuratorModule" variable. If there currently isn't a draw3D EH, then
+ * one is created. The draw 3D EH is removed when the zeus interface is closed.
+ *
+ *
+ * Arguments:
+ * 0: The eventhandler tpye (SCALAR, default ZEUSUTILS_DEH_INVALID)
+ *
+ * Return Value:
+ * None
+ *
+ * Examples:
+ * [ZEUTUTILS_DEH_FPS, 3] call potato_zeusUtils_fnc_addDraw3DEH;
+ *
+ * Public: No
+ */
+//IGNORE_PRIVATE_WARNING["_thisEvent", "_thisEventHandler"];
+params [["_ehType", ZEUSUTILS_DEH_INVALID, [ZEUSUTILS_DEH_INVALID]]];
+
+if (_ehType == ZEUSUTILS_DEH_INVALID) exitWith {
+    TRACE_1("invalid draw EH",_ehType);
+};
+
+if (GVAR(draw3DEH) < 0) then {
+    GVAR(draw3DEH) = addMissionEventHandler ["Draw3D", {
+        if (isNull findDisplay 312) then {
+            diag_log formatText ["Removing display EH: %1", diag_frameNo];
+            removeMissionEventHandler [_thisEvent, _thisEventHandler];
+            GVAR(draw3DEH) = -1;
+        };
+        private _localCuratorModule = curatorCamera;
+        {
+            call _y
+        } forEach GVAR(draw3DFunctions);
+    }];
+};
+
+switch (_ehType) do {
+    case ZEUSUTILS_DEH_FPS: {
+        GVAR(draw3DFunctions) set [QGVAR(fpsEH), {call FUNC(drawFPS)}];
+    };
+    case ZEUSUTILS_DEH_MARKERS: {
+        GVAR(draw3DFunctions) set [QGVAR(markerEH), {call FUNC(drawMarkers)}];
+    };
+    default {};
+};

--- a/addons/zeusUtils/functions/fnc_changeFPSDisplayState.sqf
+++ b/addons/zeusUtils/functions/fnc_changeFPSDisplayState.sqf
@@ -1,14 +1,13 @@
 #include "..\script_component.hpp"
 /*
  * Author: Lambda.Tiger
- *
- *
+ * Description:
+ * This function will either toggle showing FPS or if the control is just being
+ * loaded, it will reinit the display EH as needed.
  *
  * Arguments:
  * 0: The control that an event happens to
- * 1: What mode to change to, either (NUMBER, default 0)
- *   - 0 - Toggle display between on and off
- *   - 1 - Load last value and re-add EH as necessary
+ * 1: Whether the function is called by a load event (BOOL, default false)
  *
  * Return Value:
  * None
@@ -20,33 +19,35 @@
  */
 params [
     "_control",
-    ["_toggleMode", 0, [0]]
+    ["_onLoad", false]
 ];
 TRACE_2("",_control,_toggleMode);
 
 if !(GVAR(missionFPSEnable)) exitWith {
     _control ctrlSetFade 1;
+    _control ctrlSetTextColor [1, 1, 1, 1];
     _control ctrlCommit 0;
 };
-_control ctrlSetFade ([0, 0.2] select (GVAR(fpsDisplayEH) > 0));
+private _inDrawQueue = QGVAR(fpsEH) in GVAR(draw3DFunctions);
+_control ctrlSetFade ([0, 0.2] select _inDrawQueue);
 
-if (_toggleMode == 1 && GVAR(fpsDisplayEH) == -2) then {
-    _toggleMode = 0;
-};
-
-if (_toggleMode == 0) then {
-    TRACE_1("Toggling diag frame fps, current EH:",GVAR(fpsDisplayEH));
-    if (GVAR(fpsDisplayEH) > 0) then {
+if (_onLoad) then {
+    if (_inDrawQueue) then {
+        [ZEUSUTILS_DEH_FPS] call FUNC(addDraw3DEH);
+        _control ctrlSetTextColor [0, 1, 0, 1];
+    };
+} else {
+    TRACE_1("Toggling diag frame fps: ",CBA_missionTime);
+    if (_inDrawQueue) then {
         [QGVAR(ZeusFPSMonitorUpdate), [clientOwner, false]] call CBA_fnc_serverEvent;
-        removeMissionEventHandler ["Draw3D", GVAR(fpsDisplayEH)];
-        GVAR(fpsDisplayEH) = -1;
+        [ZEUSUTILS_DEH_FPS] call FUNC(removeDraw3DEH);
         _control ctrlSetFade 0;
+        _control ctrlSetTextColor [1, 1, 1, 1];
         INFORM_USER(Disabled FPS display);
     } else {
         [QGVAR(ZeusFPSMonitorUpdate), [clientOwner, true]] call CBA_fnc_serverEvent;
-        GVAR(fpsDisplayEH) = addMissionEventHandler ["Draw3D",
-            {call FUNC(drawFPSHandle)}
-        ];
+        [ZEUSUTILS_DEH_FPS] call FUNC(addDraw3DEH);
+        _control ctrlSetTextColor [0, 1, 0, 1];
         INFORM_USER(Enabled FPS display);
     };
 };

--- a/addons/zeusUtils/functions/fnc_changeMarkerDisplayState.sqf
+++ b/addons/zeusUtils/functions/fnc_changeMarkerDisplayState.sqf
@@ -41,7 +41,6 @@ if (_onLoad) then {
         _control ctrlSetTextColor [1, 1, 1, 1];
         INFORM_USER(Disabled markers display);
     } else {
-        EGVAR(markers,viewBluForMarkers) = [east, west, civilian, resistance];
         [ZEUSUTILS_DEH_MARKERS] call FUNC(addDraw3DEH);
         _control ctrlSetTextColor [0, 1, 0, 1];
         INFORM_USER(Enabled markers display);

--- a/addons/zeusUtils/functions/fnc_changeMarkerDisplayState.sqf
+++ b/addons/zeusUtils/functions/fnc_changeMarkerDisplayState.sqf
@@ -1,0 +1,48 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * Description:
+ * This function will either toggle showing markes or if the control load in
+ * calls the function, it will reinit the draw3d.
+ *
+ * Arguments:
+ * 0: The control that an event happens to
+ * 1: Whether the function is called by a load event (BOOL, default false)
+ *
+ * Return Value:
+ * None
+ *
+ * Examples:
+ * [_control, 0] call potato_zeusUtils_fnc_changeMarkerDisplayState;
+ *
+ * Public: No
+ */
+params [
+    "_control",
+    ["_onLoad", false]
+];
+TRACE_2("",_control,_toggleMode);
+
+private _inDrawQueue = QGVAR(markerEH) in GVAR(draw3DFunctions);
+_control ctrlSetFade ([0, 0.2] select _inDrawQueue);
+
+if (_onLoad) then {
+    if (_inDrawQueue) then {
+        [ZEUSUTILS_DEH_MARKERS] call FUNC(addDraw3DEH);
+        _control ctrlSetTextColor [0, 1, 0, 1];
+    };
+} else {
+    TRACE_1("Toggling diag frame fps: ",CBA_missionTime);
+    if (_inDrawQueue) then {
+        [ZEUSUTILS_DEH_MARKERS] call FUNC(removeDraw3DEH);
+        _control ctrlSetFade 0;
+        _control ctrlSetTextColor [1, 1, 1, 1];
+        INFORM_USER(Disabled markers display);
+    } else {
+        EGVAR(markers,viewBluForMarkers) = [east, west, civilian, resistance];
+        [ZEUSUTILS_DEH_MARKERS] call FUNC(addDraw3DEH);
+        _control ctrlSetTextColor [0, 1, 0, 1];
+        INFORM_USER(Enabled markers display);
+    };
+};
+_control ctrlCommit 0;

--- a/addons/zeusUtils/functions/fnc_changeMarkerDisplayState.sqf
+++ b/addons/zeusUtils/functions/fnc_changeMarkerDisplayState.sqf
@@ -2,8 +2,10 @@
 /*
  * Author: Lambda.Tiger
  * Description:
- * This function will either toggle showing markes or if the control load in
- * calls the function, it will reinit the draw3d.
+ * This function will either toggle showing markers, or if the control load in
+ * calls the function it will reinit the draw3d. Enabling this function will
+ * result in the player entering zeus seeing ALL markers on the map including
+ * markers used by other sides not configured to show to the player.
  *
  * Arguments:
  * 0: The control that an event happens to

--- a/addons/zeusUtils/functions/fnc_drawFPS.sqf
+++ b/addons/zeusUtils/functions/fnc_drawFPS.sqf
@@ -17,15 +17,12 @@
  *
  * Public: No
  */
-//IGNORE_PRIVATE_WARNING["_thisEvent", "_thisEventHandler"];
+//IGNORE_PRIVATE_WARNING["_thisEvent", "_thisEventHandler","_localCuratorModule"];
 TRACE_1("diag FPS Handle:",diag_frameNo);
-if (isNull findDisplay 312 ||
-    !GVAR(missionFPSEnable)) exitWith {
-    removeMissionEventHandler [_thisEvent, _thisEventHandler];
-    GVAR(fpsDisplayEH) = -2;
+if !(GVAR(missionFPSEnable)) exitWith {
+    [ZEUSUTILS_DEH_FPS] call FUNC(removeDraw3DEH);
 };
 
-private _localCuratorModule = curatorCamera;
 // It takes twice as long to access all these global variables as it does
 // to make a private copy and use that
 private _colorSelectArray = [[1, 1, 1, GVAR(fpsWarningColor)#3], GVAR(fpsWarningColor)];

--- a/addons/zeusUtils/functions/fnc_drawMarkers.sqf
+++ b/addons/zeusUtils/functions/fnc_drawMarkers.sqf
@@ -1,0 +1,69 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * This function is called each frame from a Draw3D EH.
+ * It adds an FPS count to each unit that reports it and will only show when
+ * the Zeus interface is open. This function MUST be called through the Draw3D
+ * event handler.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Examples:
+ * call potato_zeusUtils_fnc_drawFPSHandle;
+ *
+ * Public: No
+ */
+//IGNORE_PRIVATE_WARNING["_localCuratorModule"];
+TRACE_1("diag marker Handle:",diag_frameNo);
+
+// It takes twice as long to access all these global variables as it does
+// to make a private copy and use that
+private _maxDisplayDistance = GVAR(markerDisplayDistance);
+private _markerScale = GVAR(markerDisplayScale) / 12; // Marker of size 24 => 2
+private _showMarkerText = GVAR(showMarkerText);
+{
+    _y params ["_drawObject", "_text", "_icon", "_color", "_size", "_posATL"];
+    if (isNull _drawObject) then {continue};
+
+    private _baseDrawPos = (getPosASLVisual _drawObject) vectorAdd [0, 0, 7.5];
+    private _distance = _baseDrawPos distance _localCuratorModule;
+    if (_maxDisplayDistance < _distance) then {continue};
+
+    private _sizeModifier = _markerScale * _size * exp (-_distance / 300);
+    private _colorAlpha = +_color;
+    _colorAlpha set [3, 0.55];
+    if (_showMarkerText) then {
+        drawIcon3D [
+            _icon,
+            _colorAlpha,
+            _baseDrawPos,
+            _sizeModifier,
+            _sizeModifier,
+            0,
+            _text,
+            2,
+            0.05 * _sizeModifier,
+            "RobotoCondensedBold",
+            "right",
+            false,
+            0.002 * _sizeModifier,
+            -0.0265 * _sizeModifier
+        ];
+    } else {
+        drawIcon3D [
+            _icon,
+            _colorAlpha,
+            _baseDrawPos,
+            _sizeModifier,
+            _sizeModifier,
+            0,
+            "",
+            2,
+            0.04 * _sizeModifier
+        ];
+    };
+} forEach EGVAR(markers,markerHash);

--- a/addons/zeusUtils/functions/fnc_drawMarkers.sqf
+++ b/addons/zeusUtils/functions/fnc_drawMarkers.sqf
@@ -2,8 +2,8 @@
 /*
  * Author: Lambda.Tiger
  * This function is called each frame from a Draw3D EH.
- * It adds an FPS count to each unit that reports it and will only show when
- * the Zeus interface is open. This function MUST be called through the Draw3D
+ * It draws all markers in the relevant marker arrays.
+ * This function MUST be called through the Draw3D
  * event handler.
  *
  * Arguments:

--- a/addons/zeusUtils/functions/fnc_removeDraw3DEH.sqf
+++ b/addons/zeusUtils/functions/fnc_removeDraw3DEH.sqf
@@ -2,7 +2,7 @@
 /*
  * Author: Lambda.Tiger
  * Description:
- * This function removes a specific draw event from the zeus utils draw
+ * This function removes a specific draw function from the zeus utils draw
  * queue. If there are no actively drawn events, the event handler is removed.
  *
  *

--- a/addons/zeusUtils/functions/fnc_removeDraw3DEH.sqf
+++ b/addons/zeusUtils/functions/fnc_removeDraw3DEH.sqf
@@ -1,0 +1,40 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * Description:
+ * This function removes a specific draw event from the zeus utils draw
+ * queue. If there are no actively drawn events, the event handler is removed.
+ *
+ *
+ * Arguments:
+ * 0: The eventhandler tpye (SCALAR, default ZEUSUTILS_DEH_INVALID)
+ *
+ * Return Value:
+ * None
+ *
+ * Examples:
+ * [ZEUTUTILS_DEH_FPS, 3] call potato_zeusUtils_fnc_addDraw3DEH;
+ *
+ * Public: No
+ */
+//IGNORE_PRIVATE_WARNING["_thisEvent", "_thisEventHandler"];
+params [["_ehType", ZEUSUTILS_DEH_INVALID, [ZEUSUTILS_DEH_INVALID]]];
+
+if (_ehType == ZEUSUTILS_DEH_INVALID) exitWith {
+    TRACE_1("invalid draw EH",_ehType);
+};
+
+switch (_ehType) do {
+    case ZEUSUTILS_DEH_FPS: {
+        GVAR(draw3DFunctions) deleteAt QGVAR(fpsEH);
+    };
+    case ZEUSUTILS_DEH_MARKERS: {
+        GVAR(draw3DFunctions) deleteAt QGVAR(markerEH);
+    };
+    default {};
+};
+
+if (GVAR(draw3DFunctions) isEqualTo createHashMap) then {
+    removeMissionEventHandler ["Draw3D", GVAR(draw3DEH)];
+    GVAR(draw3DEH) = -1;
+};

--- a/addons/zeusUtils/initSettings.inc.sqf
+++ b/addons/zeusUtils/initSettings.inc.sqf
@@ -74,3 +74,33 @@
     {},
     false
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(markerDisplayDistance), "SLIDER",
+    ["Maximum Marker display distance", "The maximum distance a marker will be displayed"],
+    ["POTATO - Zeus", "Zeus Markers Display"],
+    [100, 2000, 800, 0, false],
+    2,
+    {},
+    false
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(markerDisplayScale), "SLIDER",
+    ["Marker Display Scale", "The scaling for the unit markers above a unit's head"],
+    ["POTATO - Zeus", "Zeus Markers Display"],
+    [0.1, 2, 1, 2, false],
+    2,
+    {},
+    false
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(showMarkerText), "CHECKBOX",
+    ["Show Marker Text", "Show the text for the displayed markers."],
+    ["POTATO - Zeus", "Zeus Markers Display"],
+    true,
+    2,
+    {},
+    false
+] call CBA_fnc_addSetting;

--- a/addons/zeusUtils/script_component.hpp
+++ b/addons/zeusUtils/script_component.hpp
@@ -2,7 +2,7 @@
 #include "\z\potato\addons\core\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_ADMINCOMS

--- a/addons/zeusUtils/script_component.hpp
+++ b/addons/zeusUtils/script_component.hpp
@@ -2,7 +2,7 @@
 #include "\z\potato\addons\core\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_ADMINCOMS
@@ -12,5 +12,10 @@
 #include "\z\potato\addons\core\script_macros.hpp"
 
 #define ZEUSUTILS_IDC_DISPLAYFPSBUTTON 241119
+#define ZEUSUTILS_IDC_DISPLAYMARKERBUTTON 241120
+
+#define ZEUSUTILS_DEH_INVALID -1
+#define ZEUSUTILS_DEH_FPS      0
+#define ZEUSUTILS_DEH_MARKERS  1
 
 #define INFORM_USER(var1) systemChat QUOTE([POTATO][zeusUtils] var1)


### PR DESCRIPTION
This PR adds the ability to draw markers above the marker's holder. 

- It does not show markers for dead units or for markers detached for units
- The marker size is scale with distance and to marker map size
- Custom local settings for:
  - Max marker draw distance
  - Marker size
  - Displaying marker text
- Created common Draw3D EH
- Updated button UI to be more readable 