### PR TITLE
Makers - Fix Markers Again

### DIFF
--- a/addons/adminMenu/functions/fnc_uihook_attachMarkerGroup.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_attachMarkerGroup.sqf
@@ -39,7 +39,7 @@ if (_markerArray isEqualTo []) exitWith {
     TRACE_1("Bad marker selected",_hashKey);
 };
 if (group (_markerArray#0) != group _selectedUnit) then {
-    private _newHashKey = str side _selectedUnit + groupId group _selectedUnit;
+    private _newHashKey = GROUP_MARKER_ID_GROUPSTRING_UNIT(_selectedUnit);
     private _newMarkerArray = [_newHashKey, getPosATL _selectedUnit,
      _selectedUnit, side _selectedUnit, _markerArray#1, _markerArray#3,
      _markerArray#2, _markerArray#4];

--- a/addons/adminMenu/functions/fnc_uihook_attachMarkerUnit.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_attachMarkerUnit.sqf
@@ -39,10 +39,10 @@ if (_markerArray isEqualTo []) exitWith {
     TRACE_1("Bad marker selected",_hashKey);
 };
 
-private _newHashKey = str side _selectedUnit + str _selectedUnit;
+private _newHashKey = GROUP_MARKER_ID_UNITSTRING_UNIT(_selectedUnit);
 private _itr = 0;
 while {(_newHashKey == _hashKey || (_newHashKey in EGVAR(markers,markerHash))) && _itr < 25 } do {
-    _newHashKey = str side _selectedUnit + str _selectedUnit + str _itr;
+    _newHashKey = GROUP_MARKER_ID_UNITSTRING_UNIT(_selectedUnit) + str _itr;
     _itr = _itr + 1;
 };
 private _newMarkerArray = [_newHashKey, getPosATL _selectedUnit, _selectedUnit, side _selectedUnit, _markerArray#1, _markerArray#3, _markerArray#2, _markerArray#4];

--- a/addons/markers/defaultMarkerDefines.hpp
+++ b/addons/markers/defaultMarkerDefines.hpp
@@ -7,6 +7,10 @@
 #define BLACK_ARRAY [0,0,0,1]
 #define PINK_ARRAY [1,0.753,0.796,1]
 
+#define GROUP_MARKER_ID_GROUPSTRING_GROUP(group) str side group + groupId group
+#define GROUP_MARKER_ID_GROUPSTRING_UNIT(unit) str side group unit + groupId group unit
+#define GROUP_MARKER_ID_UNITSTRING_UNIT(unit) str side unit + str unit
+
 #define COLOR_TO_MARKER_HASH [\
     [\
         QUOTE(RED_ARRAY),\

--- a/addons/markers/functions/fnc_addMarkerInfoToHash.sqf
+++ b/addons/markers/functions/fnc_addMarkerInfoToHash.sqf
@@ -20,16 +20,16 @@ TRACE_1("Params",_this);
 params ["_drawObject"];
 
 private _localObject = local _drawObject;
-private _hashKey = str side _drawObject + (if (_drawObject isEqualType grpNull) then {
+private _hashKey = if (_drawObject isEqualType grpNull) then {
     _localObject = local leader _drawObject;
-    groupId _drawObject
+    GROUP_MARKER_ID_GROUPSTRING_GROUP(_drawObject)
 } else {
     if (_drawObject getVariable [QGVAR(groupMarker), false]) then {
-        groupId group _drawObject
+        GROUP_MARKER_ID_GROUPSTRING_UNIT(_drawObject)
     } else {
-        str _drawObject
+        GROUP_MARKER_ID_UNITSTRING_UNIT(_drawObject)
     }
-});
+};
 
 if (isNull _drawObject || !_localObject || _hashKey == ""
     || {!(_drawObject getVariable [QGVAR(addMarker), false])}

--- a/addons/markers/functions/fnc_becomeGroupLeader_condition.sqf
+++ b/addons/markers/functions/fnc_becomeGroupLeader_condition.sqf
@@ -16,6 +16,6 @@
 
 call ACEFUNC(interaction,canBecomeLeader) ||
     (GVAR(groupAndUnitEnabled) && {
-   private _markerArray = GVAR(markerHash) getOrDefault [groupId group _player, [_player]];
+   private _markerArray = GVAR(markerHash) getOrDefault [str side group _player + groupId group _player, [_player]];
    _markerArray#0 isEqualType objNull && {_markerArray#0 != _player}
 })

--- a/addons/markers/functions/fnc_becomeGroupLeader_condition.sqf
+++ b/addons/markers/functions/fnc_becomeGroupLeader_condition.sqf
@@ -16,6 +16,6 @@
 
 call ACEFUNC(interaction,canBecomeLeader) ||
     (GVAR(groupAndUnitEnabled) && {
-   private _markerArray = GVAR(markerHash) getOrDefault [str side group _player + groupId group _player, [_player]];
+   private _markerArray = GVAR(markerHash) getOrDefault [GROUP_MARKER_ID_GROUPSTRING_UNIT(_player), [_player]];
    _markerArray#0 isEqualType objNull && {_markerArray#0 != _player}
 })

--- a/addons/markers/functions/fnc_becomeGroupLeader_statement.sqf
+++ b/addons/markers/functions/fnc_becomeGroupLeader_statement.sqf
@@ -20,7 +20,7 @@ if (call ACEFUNC(interaction,canBecomeLeader)) then {
 
 if (!GVAR(groupAndUnitEnabled)) exitWith {};
 private _grp = group player;
-private _hashKey = str side _grp +  groupId _grp;
+private _hashKey = GROUP_MARKER_ID_GROUPSTRING_GROUP(_grp);
 private _markerArray = GVAR(markerHash) getOrDefault [_hashKey, []];
 if (_markerArray isNotEqualTo [] &&
     _hashKey != "" &&

--- a/addons/markers/functions/fnc_hasMarkerAttached.sqf
+++ b/addons/markers/functions/fnc_hasMarkerAttached.sqf
@@ -16,8 +16,8 @@ params [
     ["_object", objNull, [objNull]]
 ];
 
-private _array = GVAR(markerHash) getOrDefault [groupId group _object, []];
+private _array = GVAR(markerHash) getOrDefault [GROUP_MARKER_ID_GROUPSTRING_UNIT(_object), []];
 if (_array isEqualTo []) then {
-    _array = GVAR(markerHash) getOrDefault [str _object, [objNull]];
+    _array = GVAR(markerHash) getOrDefault [GROUP_MARKER_ID_UNITSTRING_UNIT(_object), [objNull]];
 };
 _array#0 == _object

--- a/addons/markers/functions/fnc_joinGroup_statement.sqf
+++ b/addons/markers/functions/fnc_joinGroup_statement.sqf
@@ -14,7 +14,7 @@
  */
 //IGNORE_PRIVATE_WARNING["_target", "_player"];
 private _group = group player;
-private _hashKey = str side _group + groupId _group;
+private _hashKey = GROUP_MARKER_ID_GROUPSTRING_GROUP(_group);
 [_player] joinSilent group _target;
 
 if (!GVAR(groupAndUnitEnabled)) exitWith {};

--- a/addons/markers/functions/fnc_leaveGroup_statement.sqf
+++ b/addons/markers/functions/fnc_leaveGroup_statement.sqf
@@ -15,10 +15,9 @@
 //IGNORE_PRIVATE_WARNING["_target", "_player"];
 
 private _group = group _player;
-private _groupSide = side _group;
-private _hashKey = str _groupSide + groupId _group;
+private _hashKey = GROUP_MARKER_ID_GROUPSTRING_GROUP(_group);
 private _oldGroup = units _group;
-private _newGroup = createGroup _groupSide;
+private _newGroup = createGroup side _group;
 [_player] joinSilent _newGroup;
 {_player reveal _x} forEach _oldGroup;
 if !(GVAR(groupAndUnitEnabled)) exitWith {};


### PR DESCRIPTION
This PR fixes an issue where leaders could not claim the marker due to a difference in marker name. In addition, this PR adds a default macro to use across all files creating or recreating marker hash keys to avoid future issues.