### PR TITLE
assignGear - Fix Supply Boxes Config Skipping

### DIFF
--- a/addons/assignGear/functions/fnc_assignGearSupplyBox.sqf
+++ b/addons/assignGear/functions/fnc_assignGearSupplyBox.sqf
@@ -41,7 +41,8 @@ if (!isClass _path) exitWith {
     diag_log formatText ["[POTATO-assignGear] - No loadout found for %1 (typeOf %2)", _theBox, typeOf _theBox];
 };
 
-private _subBoxes = "true" configClasses _path;
+// For some reason configClasses doesn't seem to work as needed on missionConfig
+private _subBoxes = configProperties [_path, "isClass _x"];
 if (_subBoxes isNotEqualTo [] && GVAR(setSupplyBoxLoadouts) == 2) then {
     private _boxName = getText (_path >> "boxCustomName");
     if (_boxName isNotEqualTo "") then {

--- a/addons/assignGear/functions/fnc_assignGearVehicle.sqf
+++ b/addons/assignGear/functions/fnc_assignGearVehicle.sqf
@@ -96,7 +96,7 @@ switch (GVAR(setVehicleLoadouts)) do {
         clearMagazineCargoGlobal _theVehicle;
         clearItemCargoGlobal _theVehicle;
         clearBackpackCargoGlobal _theVehicle;
-        private _boxes = "true" configClasses _path;
+        private _boxes = configProperties [_path, "isClass _x"];;
         if (_boxes isEqualTo []) exitWith {
             [_theVehicle, _path] call FUNC(setContainerContentsFromConfig);
         };


### PR DESCRIPTION
Sometimes `fnc_assignGearSupplyBox` skips child config classes. It would seem `configProperties` doesn't always work in `missionConfigFile`.