### PR TITLE
Spectate and Markers - Added spectate marker vision mode and fixed zeus marker display

### DIFF
--- a/addons/adminMenu/Interrupt_adminMenu.hpp
+++ b/addons/adminMenu/Interrupt_adminMenu.hpp
@@ -541,7 +541,7 @@ class GVAR(adminMenuDialog) {
                     y = QUOTE(0.32 * safezoneH);
                     w = QUOTE(0.26 * safezoneW);
                     h = QUOTE(0.05 * safezoneH);
-                    action = QUOTE([] call FUNC(uihook_resetMarkersButton));
+                    action = QUOTE([UI_TAB] call FUNC(uihook_resetMarkersButton));
                 };
             };
         };
@@ -627,7 +627,7 @@ class GVAR(adminMenuDialog) {
                     text = "Reload Unit Local Markers";
                     tooltip = "Reloads the selected clients\nmarkers from their local marker caches";
                     y = QUOTE(0.38 * safezoneH);
-                    action = QUOTE([] call FUNC(uihook_resetMarkersButton));
+                    action = QUOTE([MARKERS_TAB] call FUNC(uihook_resetMarkersButton));
                 };
                 class resetAllMarkers: attachMarkerToClient {
                     text = "Reload All Client Markers";

--- a/addons/adminMenu/functions/fnc_uihook_resetMarkersButton.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_resetMarkersButton.sqf
@@ -1,11 +1,22 @@
 #include "script_component.hpp"
 
 TRACE_1("params",_this);
+params [["_mode", UI_TAB, [UI_TAB]]];
 
-private _selectedUnit = missionNamespace getVariable [
-    UI_TAB_FIX_UNIT_LIST lbData (lbCurSel UI_TAB_FIX_UNIT_LIST),
-    objNull
-];
+private _selectedUnit = switch (_mode) do {
+    case MARKERS_TAB: {
+        missionNamespace getVariable [
+            UI_TAB_FIX_UNIT_LIST lbData (lbCurSel UI_TAB_FIX_UNIT_LIST),
+            objNull
+        ];
+    };
+    default {
+        missionNamespace getVariable [
+            UI_TAB_MARKERS_PLAYERS lbData (lbCurSel UI_TAB_MARKERS_PLAYERS),
+            objNull
+        ];
+    };
+};
 
 TRACE_1("Selected unit: ",_selectedUnit);
 

--- a/addons/adminMenu/script_component.hpp
+++ b/addons/adminMenu/script_component.hpp
@@ -48,6 +48,9 @@
 
 #define UI_TABS_INDEX_MARKERS 9
 
+#define UI_TAB      7
+#define MARKERS_TAB 9
+
 // Markers sub menu
 #define POTATO_MARKER_MENU_IDD 250224
 #define POTATO_MARKER_TEXT_IDC  2300

--- a/addons/spectate/functions/fnc_checkToReopen.sqf
+++ b/addons/spectate/functions/fnc_checkToReopen.sqf
@@ -20,7 +20,7 @@ TRACE_1("checkToReopen",_this);
 
 if (GVAR(running) && {isNull (missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", objNull])}) then {
     GVAR(uiVisible) = true;
-    GVAR(tagsVisible) = true;
+    GVAR(tagsVisible) = TAGS_VISIBLE_MODE_NAMES;
     GVAR(needToAddBriefings) = true;
 
     // create spectator display

--- a/addons/spectate/functions/fnc_setup.sqf
+++ b/addons/spectate/functions/fnc_setup.sqf
@@ -145,7 +145,7 @@ GVAR(needToAddBriefings) = true;
 GVAR(uiVisible) = true;
 GVAR(oldViewDistance) = viewDistance;
 GVAR(mapHighlighted) = objNull;
-GVAR(tagsVisible) = true;
+GVAR(tagsVisible) = TAGS_VISIBLE_MODE_NAMES;
 GVAR(cursorObject) = objNull;
 GVAR(holdingRightMouse) = false;
 

--- a/addons/spectate/functions/fnc_setup.sqf
+++ b/addons/spectate/functions/fnc_setup.sqf
@@ -119,7 +119,7 @@ GVAR(camTarget) = _oldUnit;
 GVAR(targetInVehicle) = !isNull objectParent GVAR(camTarget);
 GVAR(dummy) = "Logic" createVehicleLocal getPosASLVisual GVAR(camTarget);
 
-GVAR(cam) = "camcurator" camCreate eyePos GVAR(camTarget);
+GVAR(cam) = "camcurator" camCreate ASLToAGL eyePos GVAR(camTarget);
 GVAR(cam) cameraEffect ["internal", "back"];
 GVAR(cam) setPosASL eyePos GVAR(camTarget);
 GVAR(cam) setDir getDirVisual GVAR(camTarget);

--- a/addons/spectate/functions/fnc_ui_handleDraw3D.sqf
+++ b/addons/spectate/functions/fnc_ui_handleDraw3D.sqf
@@ -100,7 +100,7 @@ if !(GVAR(mapOpen) || GVAR(fullMapOpen)) then {
                     _y set [5, ASLToATL _baseDrawPosASL];
                 };
                 private _distance = _baseDrawPosASL distance _cameraPosASL;
-                if (_maxDisplayDistance < 3000) then {continue};
+                if (_distance > 3000) then {continue};
 
                 private _sizeModifier = _markerScale * _size * exp (-_distance / 300);
                 private _colorAlpha = +_color;

--- a/addons/spectate/functions/fnc_ui_handleKeyDown.sqf
+++ b/addons/spectate/functions/fnc_ui_handleKeyDown.sqf
@@ -99,7 +99,7 @@ if (inputAction "headlights" > 0) exitWith {
         _cameraLight setLightColor [0,0,0];
         _cameraLight lightAttachObject [GVAR(cam), [0,0,0]];
 
-        private _pointerLight = "#lightpoint" createVehicleLocal getPosASL GVAR(cam);
+        private _pointerLight = "#lightpoint" createVehicleLocal ASLToAGL getPosASL GVAR(cam);
         _pointerLight setLightBrightness 1;
         _pointerLight setLightAmbient [1,1,1];
         _pointerLight setLightColor [0,0,0];

--- a/addons/spectate/functions/fnc_ui_handleKeyDown.sqf
+++ b/addons/spectate/functions/fnc_ui_handleKeyDown.sqf
@@ -70,7 +70,7 @@ if (inputAction "nightVision" > 0) exitWith {
 // if the zeus key is pressed and unit is curator, open zeus interface
 if ((inputAction "CuratorInterface") > 0 && {!isNull (getAssignedCuratorLogic player)}) exitWith {
     GVAR(uiVisible) = false;
-    GVAR(tagsVisible) = false;
+    GVAR(tagsVisible) = TAGS_VISIBLE_MODE_NONE;
     GVAR(drawProjectiles) = false;
     OVERLAY closeDisplay 1;
     GVAR(cam) camCommand "manual off";
@@ -172,7 +172,7 @@ if (_key == DIK_BACKSPACE) exitWith {
 
 // handle toggling the Tags
 if (_key == DIK_BACKSLASH) exitWith {
-    GVAR(tagsVisible) = !GVAR(tagsVisible);
+    GVAR(tagsVisible) = (GVAR(tagsVisible) + 1) mod TAGS_VISIBLE_MODE_COUNT;
     true
 };
 

--- a/addons/spectate/script_component.hpp
+++ b/addons/spectate/script_component.hpp
@@ -191,7 +191,7 @@
 'Right Arrow' to switch focus to the next unit<br/>\
 'Left Arrow' to switch focus to the previous unit<br/>\
 'Backspace' to toggle the UI<br/>\
-'Back Slash' to toggle the Tags<br/>\
+'Back Slash' to cycle displaying unit Tags and Markers<br/>\
 Map toggle (default 'M') to open/close the full map<br/>\
 GPS toggle (default 'Ctrl + M') to open/close the mini map<br/>\
 Zero up (default 'Page Up') to increase client view distance<br/>\
@@ -205,5 +205,10 @@ Get over (default 'V') to toggle camera speed at ground level<br/>\
 Tasks/diary (default 'J') to open/close the briefings<br/>\
 Compass (default 'K') to open/close the compass<br/>\
 </t>
+
+#define TAGS_VISIBLE_MODE_COUNT 3
+#define TAGS_VISIBLE_MODE_NAMES 2
+#define TAGS_VISIBLE_MODE_MARKS 1
+#define TAGS_VISIBLE_MODE_NONE  0
 
 #include "\z\potato\addons\core\script_macros.hpp"

--- a/addons/zeusUtils/functions/fnc_drawMarkers.sqf
+++ b/addons/zeusUtils/functions/fnc_drawMarkers.sqf
@@ -20,6 +20,7 @@
 //IGNORE_PRIVATE_WARNING["_localCuratorModule"];
 TRACE_1("diag marker Handle:",diag_frameNo);
 
+private _modulePosASL = getPosASL _localCuratorModule;
 // It takes twice as long to access all these global variables as it does
 // to make a private copy and use that
 private _maxDisplayDistance = GVAR(markerDisplayDistance);
@@ -30,7 +31,7 @@ private _showMarkerText = GVAR(showMarkerText);
     if (isNull _drawObject) then {continue};
 
     private _baseDrawPos = (getPosASLVisual _drawObject) vectorAdd [0, 0, 15];
-    private _distance = _baseDrawPos distance _localCuratorModule;
+    private _distance = _baseDrawPos distance _modulePosASL;
     if (_maxDisplayDistance < _distance) then {continue};
 
     private _sizeModifier = _markerScale * _size * exp (-_distance / 300);

--- a/addons/zeusUtils/functions/fnc_drawMarkers.sqf
+++ b/addons/zeusUtils/functions/fnc_drawMarkers.sqf
@@ -30,8 +30,8 @@ private _showMarkerText = GVAR(showMarkerText);
     _y params ["_drawObject", "_text", "_icon", "_color", "_size", "_posATL"];
     if (isNull _drawObject) then {continue};
 
-    private _baseDrawPos = (getPosASLVisual _drawObject) vectorAdd [0, 0, 15];
-    private _distance = _baseDrawPos distance _modulePosASL;
+    private _baseDrawPosASL = (getPosASLVisual _drawObject) vectorAdd [0, 0, 15];
+    private _distance = _baseDrawPosASL distance _modulePosASL;
     if (_maxDisplayDistance < _distance) then {continue};
 
     private _sizeModifier = _markerScale * _size * exp (-_distance / 300);
@@ -41,7 +41,7 @@ private _showMarkerText = GVAR(showMarkerText);
         drawIcon3D [
             _icon,
             _colorAlpha,
-            ASLToAGL _baseDrawPos,
+            ASLToAGL _baseDrawPosASL,
             _sizeModifier,
             _sizeModifier,
             0,

--- a/addons/zeusUtils/functions/fnc_drawMarkers.sqf
+++ b/addons/zeusUtils/functions/fnc_drawMarkers.sqf
@@ -58,7 +58,7 @@ private _showMarkerText = GVAR(showMarkerText);
         drawIcon3D [
             _icon,
             _colorAlpha,
-            ASLToAGL  _baseDrawPos,
+            ASLToAGL _baseDrawPosASL,
             _sizeModifier,
             _sizeModifier,
             0,


### PR DESCRIPTION
This PR (should be three, sorry):

- Fixes admin menu markers tab reset markers on a unit button.
- Changes tags toggle to cycle through none/drawing markers/tags
- Fixed zeusUtils markers ASL/ATL mismatch