### PR TITLE
Custom Gear - Adds Potato 40x53mm CSW Magazines

### DIFF
--- a/addons/customGear/ACE_CSW_Groups.hpp
+++ b/addons/customGear/ACE_CSW_Groups.hpp
@@ -1,0 +1,9 @@
+class ace_csw_groups {
+    //// MK-19
+    class MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP_csw) {
+        MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP) = 1;
+    };
+    class MAGAZINE(48Rnd_40mm_MK19_M384_HE_csw) { // Same name as the carryable magazine
+        MAGAZINE(48Rnd_40mm_MK19_M384_HE) = 1;    // Vehicle magazine that will be loaded when loading this magazine
+    };
+};

--- a/addons/customGear/CfgMagazines.hpp
+++ b/addons/customGear/CfgMagazines.hpp
@@ -4,16 +4,16 @@ class CfgMagazines {
     class MAGAZINE(1Rnd_40mm_M433_HEDP): 1Rnd_HE_Grenade_shell {
         ammo = QAMMO(40x46mm_HEDP_M433);
         count = 1;
-        displayNameshort = "M433 HEDP";
+        displayNameShort = "M433 HEDP";
         displayName = "40x46mm M433 (HEDP) Grenade";
     };
 
-    // HV 40x53mm grenade launcher
+    /// HV 40x53mm grenade launcher
     class 200Rnd_40mm_G_belt;
     class MAGAZINE(96Rnd_40mm_MK19_M430A1_HEDP): 200Rnd_40mm_G_belt {
         ammo = QAMMO(40x53mm_HEDP_M430A1);
         count = 96;
-        displayNameshort = "M430A1 HEDP";
+        displayNameShort = "M430A1 HEDP";
         displayName = "40x53mm M430A1 HEDP";
         initSpeed = 241;
     };
@@ -23,11 +23,34 @@ class CfgMagazines {
     class MAGAZINE(96Rnd_40mm_MK19_M384_HE): 200Rnd_40mm_G_belt {
         ammo = QAMMO(40x53mm_HE_M384);
         count = 96;
-        displayNameshort = "M384 HE";
+        displayNameShort = "M384 HE";
         displayName = "40x53mm M384 HE";
         initSpeed = 241;
     };
     class MAGAZINE(48Rnd_40mm_MK19_M384_HE): MAGAZINE(96Rnd_40mm_MK19_M384_HE) {
         count = 48;
+    };
+    // HV 40x53mm grenade CSW
+    class MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP_csw): MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP) {
+        displayName = "[CSW] 48Rnd 40x53mm M430A1 HEDP (Mk19)";
+        displayNameShort = "[CSW] 48Rnd M430A1 HEDP (Mk19)";
+        scope = 2;
+        scopeArsenal = 2;
+        type = 256;
+        model = "\A3\Structures_F_EPB\Items\Military\Ammobox_rounds_F.p3d";
+        picture = "\z\ace\addons\csw\UI\ammoBox_50bmg_ca.paa";
+        ACE_isBelt = 1;
+        mass = 40;
+    };
+    class MAGAZINE(48Rnd_40mm_MK19_M384_HE_csw): MAGAZINE(48Rnd_40mm_MK19_M384_HE) {
+        displayName = "[CSW] 48Rnd 40x53mm M384 HE (Mk19)";
+        displayNameShort = "[CSW] 48Rnd M384 HE (Mk19)";
+        scope = 2;
+        scopeArsenal = 2;
+        type = 256;
+        model = "\A3\Structures_F_EPB\Items\Military\Ammobox_rounds_F.p3d";
+        picture = "\z\ace\addons\csw\UI\ammoBox_50bmg_ca.paa";
+        ACE_isBelt = 1;
+        mass = 40;
     };
 };

--- a/addons/customGear/config.cpp
+++ b/addons/customGear/config.cpp
@@ -17,6 +17,7 @@ class CfgPatches {
     };
 };
 
+#include "ACE_CSW_Groups.hpp"
 #include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgMagazineWells.hpp"


### PR DESCRIPTION
This PR adds CSW mags for both potato HE and HEDP grenades for the Mk19