### PR TITLE
arsenalExport - Add Export Options for Resupply Boxes & Misc Fixes

### DIFF
--- a/addons/arsenalExport/XEH_PREP.hpp
+++ b/addons/arsenalExport/XEH_PREP.hpp
@@ -3,3 +3,4 @@ TRACE_1("",QUOTE(ADDON));
 PREP(arsenalOpened);
 PREP(buttonClick);
 PREP(export);
+PREP(exportBoxes);

--- a/addons/arsenalExport/functions/fnc_arsenalOpened.sqf
+++ b/addons/arsenalExport/functions/fnc_arsenalOpened.sqf
@@ -1,5 +1,5 @@
 #include "script_component.hpp"
-
+#define QQUOTE(var1) QUOTE(QUOTE(var1))
 #define PIXELSCALE  0.25
 #define GRID_W (pixelW * pixelGridNoUIScale * PIXELSCALE)
 
@@ -27,7 +27,7 @@ private _fnc_updateInfo = {
     private _aceCtrlMenu = _display displayCtrl 10;
     private _ctrlGroup = _display displayCtrl IDC_CTRLGROUP;
     if (isNull _aceCtrlMenu) exitWith {};
-    _ctrlGroup ctrlShow (ctrlShown _aceCtrlMenu); 
+    _ctrlGroup ctrlShow (ctrlShown _aceCtrlMenu);
 };
 _display displayAddEventHandler ["MouseMoving", _fnc_updateInfo];
 _display displayAddEventHandler ["MouseHolding", _fnc_updateInfo];
@@ -73,11 +73,34 @@ private _fnc_createButton = {
 ["Set Spotter", "spotter", [QGVAR(loadout_spotter), QGVAR(loadout_spotterMags), QGVAR(loadout_spotterAttachments)]] call _fnc_createButton;
 ["Set SMG", "smg", [QGVAR(loadout_smg), QGVAR(loadout_smgMags)]] call _fnc_createButton;
 ["Set Pistol", "pistol", [QGVAR(loadout_pistol), QGVAR(loadout_pistolMags), QGVAR(loadout_pistolAttachments)]] call _fnc_createButton;
+["Set Grenades", "grenades", [QGVAR(loadout_handGrenade), QGVAR(loadout_smokeGrenade)]] call _fnc_createButton;
 
 private _rscButton = _display ctrlCreate ["RscButton", -1, _ctrlGroup];
-_rscButton ctrlSetText "Export";
+_rscButton ctrlSetText "Export Loadout";
 _rscButton ctrlSetEventHandler ["ButtonClick", 'call FUNC(export)'];
 _rscButton ctrlSetPosition [0 + (1 * _height), 0 + _height * (_y + 0.25), 8 * _height, _height];
+_rscButton ctrlSetTooltip "Export the standard loadout arrays.";
+_rscButton ctrlCommit 0.25;
+_y = _y  + 1;
+_rscButton = _display ctrlCreate ["RscButton", -1, _ctrlGroup];
+_rscButton ctrlSetText "Export Fireteam Crates";
+_rscButton ctrlSetEventHandler ["ButtonClick", QUOTE([QQUOTE(FT)] call FUNC(exportBoxes))];
+_rscButton ctrlSetPosition [0 + (1 * _height), 0 + _height * (_y + 0.25), 8 * _height, _height];
+_rscButton ctrlSetTooltip "Export a standard fireteam resupply crate based on loadout.";
+_rscButton ctrlCommit 0.25;
+_y = _y  + 1;
+_rscButton = _display ctrlCreate ["RscButton", -1, _ctrlGroup];
+_rscButton ctrlSetText "Export LAT, MAT, & HAT Crates";
+_rscButton ctrlSetEventHandler ["ButtonClick", QUOTE([QQUOTE(AT)] call FUNC(exportBoxes))];
+_rscButton ctrlSetPosition [0 + (1 * _height), 0 + _height * (_y + 0.25), 8 * _height, _height];
+_rscButton ctrlSetTooltip "Export a standard LAT, MAT, and HAT crates based on loadout.";
+_rscButton ctrlCommit 0.25;
+_y = _y  + 1;
+_rscButton = _display ctrlCreate ["RscButton", -1, _ctrlGroup];
+_rscButton ctrlSetText "Export MMG & HMG Crates";
+_rscButton ctrlSetEventHandler ["ButtonClick", QUOTE([QQUOTE(MG)] call FUNC(exportBoxes))];
+_rscButton ctrlSetPosition [0 + (1 * _height), 0 + _height * (_y + 0.25), 8 * _height, _height];
+_rscButton ctrlSetTooltip "Export a standard MMG, abd HMG crate based on loadout.";
 _rscButton ctrlCommit 0.25;
 
 _ctrlGroup ctrlSetPosition [_xPos, _yPos, 12*_height, _height * (_y + 1.5)];

--- a/addons/arsenalExport/functions/fnc_buttonClick.sqf
+++ b/addons/arsenalExport/functions/fnc_buttonClick.sqf
@@ -127,6 +127,30 @@ case ("pistol"): {
         GVAR(loadout_pistolAttachments) = handgunItems _unit;
         systemChat format ["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_pistol), GVAR(loadout_pistolMags), GVAR(loadout_pistolAttachments)];
     };
+case ("grenades"): {
+        private _throwables = (throwables _unit) apply {_x#0};
+        _throwables = _throwables arrayIntersect _throwables;
+        private _cfgMags = configFile >> "CfgMagazines";
+        private _cfgAmmo = configFile >> "CfgAmmo";
+        GVAR(loadout_smokeGrenade) = _throwables select {
+            private _ammo = getText (_cfgMags >> _x >> "ammo");
+            private _aiAmmoCfg = _cfgAmmo >> _ammo >> "aiAmmoUsageFlags";
+            if (isText _aiAmmoCfg) then { // check if "4" flag is set for smoke
+                private _aiAmmoValues = (((getText _aiAmmoCfg) splitString " +") apply {parseNumber _x});
+                4 in _aiAmmoValues || {
+                    private _tempBool = false;
+                    {
+                        _tempBool = _tempBool || [_x, 4] call BIS_fnc_bitflagsCheck
+                    } forEach _aiAmmoValues;
+                    _tempBool
+                }
+            } else {
+                [getNumber _aiAmmoCfg, 4] call BIS_fnc_bitflagsCheck
+            };
+        };
+        GVAR(loadout_handGrenade) = _throwables - GVAR(loadout_smokeGrenade);
+        systemChat format ["[Set %1]: %2, %3", _fncString, GVAR(loadout_handGrenade), GVAR(loadout_smokeGrenade)];
+    };
     default {ERROR_1("bad fnc [%1]",_fncString);};
 };
 

--- a/addons/arsenalExport/functions/fnc_buttonClick.sqf
+++ b/addons/arsenalExport/functions/fnc_buttonClick.sqf
@@ -76,6 +76,34 @@ case ("mat"): {
 case ("hmg"): {
         GVAR(loadout_hmg) = secondaryWeapon _unit;
         GVAR(loadout_hmgMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_hmg)] call CBA_fnc_compatibleMagazines);
+        if (GVAR(loadout_hmgMags) isEqualTo [] && {isClass (configFile >> "CfgWeapons" >> GVAR(loadout_hat) >> "ace_csw")}) then {
+            // Find CSW vehicle
+            private _cswCfg = configFile >> "CfgWeapons" >> GVAR(loadout_hmg) >> "ace_csw";
+            private _vehicle = if (isClass (_cswCfg >> "assembleTo")) then {
+                private _assembleTo = configName ((configProperties [_cswCfg >> "assembleTo"])#0);
+                getText (_cswCfg >> "assembleTo" >> _assembleTo);
+            } else {
+                getText (_cswCfg >> "deploy");
+            };
+            // Find weapon and compatible magazines
+            private _vehicleTurretCfg = configFile >> "CfgVehicles" >> _vehicle >> "Turrets";
+            private _firstTurret = (configProperties [_vehicleTurretCfg, "isClass _x"])#0;
+            private _weapon = (getArray (_firstTurret >> "weapons"))#0;
+            private _compatibleMagazines = compatibleMagazines _weapon;
+            // Find player CSW mags
+            private _unitMags = magazines _unit;
+            private _cswGroups = configFile >> "ace_csw_groups";
+            private _cswMagCfgs = [];
+            {
+                if (isClass (_cswGroups >> _x)) then {
+                    _cswMagCfgs pushBack (_cswGroups >> _x);
+                };
+            } forEach (_unitMags arrayIntersect _unitMags);
+            _cswMags = flatten (_cswMagCfgs apply {
+                (configProperties [_x, "getNumber _x == 1"]) apply {configName _x}
+            });
+            GVAR(loadout_hmgMags) = _compatibleMagazines arrayIntersect _cswMags;
+        };
         systemChat format ["[Set %1]: %2 %3", _fncString, GVAR(loadout_hmg), GVAR(loadout_hmgMags)];
     };
 case ("hmg_tri_1"): {
@@ -89,6 +117,34 @@ case ("hmg_tri_2"): {
 case ("hat"): {
         GVAR(loadout_hat) = secondaryWeapon _unit;
         GVAR(loadout_hatMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_hat)] call CBA_fnc_compatibleMagazines);
+        if (GVAR(loadout_hatMags) isEqualTo [] && {isClass (configFile >> "CfgWeapons" >> GVAR(loadout_hat) >> "ace_csw")}) then {
+            // Find CSW vehicle
+            private _cswCfg = configFile >> "CfgWeapons" >> GVAR(loadout_hat) >> "ace_csw";
+            private _vehicle = if (isClass (_cswCfg >> "assembleTo")) then {
+                private _assembleTo = configName ((configProperties [_cswCfg >> "assembleTo"])#0);
+                getText (_cswCfg >> "assembleTo" >> _assembleTo);
+            } else {
+                getText (_cswCfg >> "deploy");
+            };
+            // Find weapon and compatible magazines
+            private _vehicleTurretCfg = configFile >> "CfgVehicles" >> _vehicle >> "Turrets";
+            private _firstTurret = (configProperties [_vehicleTurretCfg, "isClass _x"])#0;
+            private _weapon = (getArray (_firstTurret >> "weapons"))#0;
+            private _compatibleMagazines = compatibleMagazines _weapon;
+            // Find player CSW mags
+            private _unitMags = magazines _unit;
+            private _cswGroups = configFile >> "ace_csw_groups";
+            private _cswMagCfgs = [];
+            {
+                if (isClass (_cswGroups >> _x)) then {
+                    _cswMagCfgs pushBack (_cswGroups >> _x);
+                };
+            } forEach (_unitMags arrayIntersect _unitMags);
+            _cswMags = flatten (_cswMagCfgs apply {
+                (configProperties [_x, "getNumber _x == 1"]) apply {configName _x}
+            });
+            GVAR(loadout_hatMags) = _compatibleMagazines arrayIntersect _cswMags;
+        };
         systemChat format ["[Set %1]: %2 %3", _fncString, GVAR(loadout_hat), GVAR(loadout_hatMags)];
     };
 case ("hat_tri_1"): {

--- a/addons/arsenalExport/functions/fnc_buttonClick.sqf
+++ b/addons/arsenalExport/functions/fnc_buttonClick.sqf
@@ -76,7 +76,7 @@ case ("mat"): {
 case ("hmg"): {
         GVAR(loadout_hmg) = secondaryWeapon _unit;
         GVAR(loadout_hmgMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_hmg)] call CBA_fnc_compatibleMagazines);
-        if (GVAR(loadout_hmgMags) isEqualTo [] && {isClass (configFile >> "CfgWeapons" >> GVAR(loadout_hat) >> "ace_csw")}) then {
+        if (GVAR(loadout_hmgMags) isEqualTo [] && {isClass (configFile >> "CfgWeapons" >> GVAR(loadout_hmg) >> "ace_csw")}) then {
             // Find CSW vehicle
             private _cswCfg = configFile >> "CfgWeapons" >> GVAR(loadout_hmg) >> "ace_csw";
             private _vehicle = if (isClass (_cswCfg >> "assembleTo")) then {

--- a/addons/arsenalExport/functions/fnc_buttonClick.sqf
+++ b/addons/arsenalExport/functions/fnc_buttonClick.sqf
@@ -90,19 +90,21 @@ case ("hmg"): {
             private _firstTurret = (configProperties [_vehicleTurretCfg, "isClass _x"])#0;
             private _weapon = (getArray (_firstTurret >> "weapons"))#0;
             private _compatibleMagazines = compatibleMagazines _weapon;
-            // Find player CSW mags
+            // Find compatible player CSW mags
             private _unitMags = magazines _unit;
             private _cswGroups = configFile >> "ace_csw_groups";
             private _cswMagCfgs = [];
             {
-                if (isClass (_cswGroups >> _x)) then {
-                    _cswMagCfgs pushBack (_cswGroups >> _x);
+                private _cfgPath = _cswGroups >> _x;
+                if (isClass _cfgPath && {
+                    private _convertMags = (configProperties [_cfgPath, "getNumber _x == 1"]) apply {configName _x};
+                    systemChat format ["convert mags: %1 | intersect: %2", _convertMags, _convertMags arrayIntersect _compatibleMagazines];
+                    (_convertMags arrayIntersect _compatibleMagazines) isNotEqualTo []
+                }) then {
+                    _cswMagCfgs pushBack _x;
                 };
             } forEach (_unitMags arrayIntersect _unitMags);
-            _cswMags = flatten (_cswMagCfgs apply {
-                (configProperties [_x, "getNumber _x == 1"]) apply {configName _x}
-            });
-            GVAR(loadout_hmgMags) = _compatibleMagazines arrayIntersect _cswMags;
+            GVAR(loadout_hmgMags) = _cswMagCfgs;
         };
         systemChat format ["[Set %1]: %2 %3", _fncString, GVAR(loadout_hmg), GVAR(loadout_hmgMags)];
     };
@@ -131,19 +133,21 @@ case ("hat"): {
             private _firstTurret = (configProperties [_vehicleTurretCfg, "isClass _x"])#0;
             private _weapon = (getArray (_firstTurret >> "weapons"))#0;
             private _compatibleMagazines = compatibleMagazines _weapon;
-            // Find player CSW mags
+            // Find compatible player CSW mags
             private _unitMags = magazines _unit;
             private _cswGroups = configFile >> "ace_csw_groups";
             private _cswMagCfgs = [];
             {
-                if (isClass (_cswGroups >> _x)) then {
-                    _cswMagCfgs pushBack (_cswGroups >> _x);
+                private _cfgPath = _cswGroups >> _x;
+                if (isClass _cfgPath && {
+                    private _convertMags = (configProperties [_cfgPath, "getNumber _x == 1"]) apply {configName _x};
+                    systemChat format ["convert mags: %1 | intersect: %2", _convertMags, _convertMags arrayIntersect _compatibleMagazines];
+                    (_convertMags arrayIntersect _compatibleMagazines) isNotEqualTo []
+                }) then {
+                    _cswMagCfgs pushBack _x;
                 };
             } forEach (_unitMags arrayIntersect _unitMags);
-            _cswMags = flatten (_cswMagCfgs apply {
-                (configProperties [_x, "getNumber _x == 1"]) apply {configName _x}
-            });
-            GVAR(loadout_hatMags) = _compatibleMagazines arrayIntersect _cswMags;
+            GVAR(loadout_hatMags) = _cswMagCfgs;
         };
         systemChat format ["[Set %1]: %2 %3", _fncString, GVAR(loadout_hat), GVAR(loadout_hatMags)];
     };

--- a/addons/arsenalExport/functions/fnc_export.sqf
+++ b/addons/arsenalExport/functions/fnc_export.sqf
@@ -29,7 +29,7 @@ private _fnc_formatList = {
 };
 private _fnc_default = {
     params ["_gvar",["_default",""]];
-    if(isNil _gvar) exitWith {_default};
+    if(_gvar == "") exitWith {_default};
     _gvar
 };
 private _fnc_getMags = {
@@ -59,6 +59,7 @@ _lines pushBack format ["// Camo set"];
 _lines pushBack format ['#define CAMO_UNIFORM "%1"', GVAR(loadout_uniform)];
 _lines pushBack format ['#define CAMO_VEST "%1"', GVAR(loadout_vest)];
 _lines pushBack format ['#define CAMO_BACKPACK "%1"', GVAR(loadout_backpack)];
+systemChat format ["%1", [GVAR(loadout_carryall),GVAR(loadout_backpack)] call _fnc_default];
 _lines pushBack format ['#define CARRYALL "%1"', [GVAR(loadout_carryall),GVAR(loadout_backpack)] call _fnc_default];
 _lines pushBack format ['#define CAMO_HEADGEAR "%1"', GVAR(loadout_headgear)];
 _lines pushBack format ['#define CAMO_HEADGEAR_SPECIAL "%1"', [GVAR(loadout_headgear_alt),GVAR(loadout_headgear)] call _fnc_default];

--- a/addons/arsenalExport/functions/fnc_export.sqf
+++ b/addons/arsenalExport/functions/fnc_export.sqf
@@ -164,7 +164,25 @@ _lines pushBack format ['#define PISTOL_MAG %1', [GVAR(loadout_pistol), GVAR(loa
 _lines pushBack format ['#define PISTOL_ATTACHMENTS %1', [GVAR(loadout_pistolAttachments)] call _fnc_formatList];
 
 _lines pushBack format ["// Grenades"];
-_lines pushBack format ["#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT"];
+private _fragGrenades = if (count GVAR(loadout_handGrenade) > 1) then {
+    (GVAR(loadout_handGrenade) apply {str _x}) joinString ",";
+} else {
+    (GVAR(loadout_handGrenade) apply {str (_x + ":2")}) joinString ",";
+};
+if (_fragGrenades == "") then  {
+    _fragGrenades = "BASE_FRAG";
+};
+private _smokeGrenades = if (count GVAR(loadout_smokeGrenade) > 1) then {
+    (GVAR(loadout_smokeGrenade) apply {str _x}) joinString ",";
+} else {
+    (GVAR(loadout_smokeGrenade) apply {str (_x + ":2")}) joinString ",";
+};
+if (_smokeGrenades == "") then  {
+    _smokeGrenades = "BASE_SMOKE";
+};
+_lines pushBack format ["#define LEADER_GRENADES %1,LEADER_SMOKES,SIDE_CHEM_LIGHT", _fragGrenades];
+_lines pushBack format ["// SIDE_BASE_GRENADES in side_gear.hpp"];
+_lines pushBack format ["//#define SIDE_BASE_GRENADES %1,%2", _fragGrenades, _smokeGrenades];
 
 _lines pushBack format ["// Gear"];
 _lines pushBack format ["#define TOOLS BASE_TOOLS"];

--- a/addons/arsenalExport/functions/fnc_export.sqf
+++ b/addons/arsenalExport/functions/fnc_export.sqf
@@ -59,7 +59,6 @@ _lines pushBack format ["// Camo set"];
 _lines pushBack format ['#define CAMO_UNIFORM "%1"', GVAR(loadout_uniform)];
 _lines pushBack format ['#define CAMO_VEST "%1"', GVAR(loadout_vest)];
 _lines pushBack format ['#define CAMO_BACKPACK "%1"', GVAR(loadout_backpack)];
-systemChat format ["%1", [GVAR(loadout_carryall),GVAR(loadout_backpack)] call _fnc_default];
 _lines pushBack format ['#define CARRYALL "%1"', [GVAR(loadout_carryall),GVAR(loadout_backpack)] call _fnc_default];
 _lines pushBack format ['#define CAMO_HEADGEAR "%1"', GVAR(loadout_headgear)];
 _lines pushBack format ['#define CAMO_HEADGEAR_SPECIAL "%1"', [GVAR(loadout_headgear_alt),GVAR(loadout_headgear)] call _fnc_default];

--- a/addons/arsenalExport/functions/fnc_export.sqf
+++ b/addons/arsenalExport/functions/fnc_export.sqf
@@ -164,6 +164,12 @@ _lines pushBack format ['#define PISTOL_MAG %1', [GVAR(loadout_pistol), GVAR(loa
 _lines pushBack format ['#define PISTOL_ATTACHMENTS %1', [GVAR(loadout_pistolAttachments)] call _fnc_formatList];
 
 _lines pushBack format ["// Grenades"];
+if (GVAR(loadout_handGrenade) isEqualType "") then {
+    GVAR(loadout_handGrenade) = [];
+};
+if (GVAR(loadout_smokeGrenade) isEqualType "") then {
+    GVAR(loadout_smokeGrenade) = [];
+};
 private _fragGrenades = if (count GVAR(loadout_handGrenade) > 1) then {
     (GVAR(loadout_handGrenade) apply {str _x}) joinString ",";
 } else {

--- a/addons/arsenalExport/functions/fnc_exportBoxes.sqf
+++ b/addons/arsenalExport/functions/fnc_exportBoxes.sqf
@@ -7,7 +7,7 @@ TRACE_1("exportBoxes",_this);
 #define RIFLE_ROUNDS 300
 #define GLRIFLE_ROUNDS 150
 #define CARBINE_ROUNDS 300
-#define AR_ROUNDS 800
+#define AR_ROUNDS 600
 #define LAT_ROUNDS 2
 #define LAT_CRATE_ROUNDS 6
 #define LAT_CRATE_MAX_ROUNDS 8

--- a/addons/arsenalExport/functions/fnc_exportBoxes.sqf
+++ b/addons/arsenalExport/functions/fnc_exportBoxes.sqf
@@ -1,0 +1,237 @@
+#include "script_component.hpp"
+#define QQUOTE(var1) QUOTE(QUOTE(var1))
+
+params [["_boxType", "FT", [""]]];
+TRACE_1("exportBoxes",_this);
+
+#define RIFLE_ROUNDS 300
+#define GLRIFLE_ROUNDS 150
+#define CARBINE_ROUNDS 300
+#define AR_ROUNDS 800
+#define LAT_ROUNDS 2
+#define LAT_CRATE_ROUNDS 6
+#define LAT_CRATE_MAX_ROUNDS 8
+#define MAT_ROUNDS 6
+#define HAT_ROUNDS 4
+#define SAM_ROUNDS 2
+#define MMG_ROUNDS 1000
+#define HMG_ROUNDS 800
+
+private _lines = [];
+private _transWeaps = [];
+private _transMags = [];
+private _transItems = [];
+private _fnc_dumpBoxType = {
+    params ["_boxConfig", "_boxName"];
+    _lines pushBack format ["class %1 {", _boxConfig];
+    _lines pushBack format ["  boxCustomName = ""%1"";", _boxName];
+    // Weapons
+    if (_transWeaps isNotEqualTo []) then {
+        _lines pushBack "  TransportWeapons[] = {";
+        private _count = count _transWeaps - 1;
+        {
+            _lines pushBack format ["    ""%1""%2", _x, [",", ""] select (_count == _forEachIndex)];
+        } forEach _transWeaps;
+        _lines pushBack "  };";
+        _transWeaps = [];
+    };
+    // Magazines
+    if (_transMags isNotEqualTo []) then {
+        _lines pushBack "  TransportMagazines[] = {";
+        private _count = count _transMags - 1;
+        {
+            _lines pushBack format ["    ""%1""%2", _x, [",", ""] select (_count == _forEachIndex)];
+        } forEach _transMags;
+        _lines pushBack "  };";
+        _transMags = [];
+    };
+    // Items
+    if (_transItems isNotEqualTo []) then {
+        _lines pushBack "  TransportItems[] = {";
+        private _count = count _transItems - 1;
+        {
+            _lines pushBack format ["    ""%1""%2", _x, [",", ""] select (_count == _forEachIndex)];
+        } forEach _transItems;
+        _lines pushBack "  };";
+        _transItems = [];
+    };
+    _lines pushBack "};";
+};
+private _fnc_default = {
+    params ["_gvar",["_default",""]];
+    if(isNil _gvar) exitWith {_default};
+    _gvar
+};
+private _fnc_getMags = {
+    params ["_weapon", "_mags", ["_wantedRounds", -1]];
+    if (!(_mags isEqualType [])) exitWith {""};
+    private _magRounds = getNumber (configFile >> "CfgMagazines" >> (_mags param [0, ""]) >> "count");
+    if (_magRounds == 0) exitWith {"ERROR_no_valid_mags"};
+    private _return = "";
+    {
+        if (_wantedRounds <= 0) then {
+            _return = _return + format ["%1:1", _x];
+        } else {
+            private _magCount = 2;
+            if (_forEachIndex == 0) then {_magCount = 1 max ((ceil (_wantedRounds / _magRounds)) - 2 * ((count _mags) - 1));};
+            _return = _return + format ["%1:%2", _x, _magCount];
+        };
+        if (_forEachIndex < ((count _mags) -1)) then {_return = _return + ", ";};
+    } forEach _mags;
+    TRACE_4("getMags",_weapon,_mags,_wantedRounds,_return);
+    _return
+};
+
+
+switch (_boxType) do {
+    case "FT": {
+        if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_at))) isNotEqualTo []) then {
+            _transWeaps = [GVAR(loadout_at) + QUOTE(:LAT_ROUNDS)];
+        } else {
+            {
+                _transMags pushBack (_x + QUOTE(:LAT_ROUNDS));
+            } forEach GVAR(loadout_atMags);
+        };
+        // Add hand grenades
+        private _grenadeCount = count GVAR(loadout_handGrenade);
+        if (_grenadeCount > 1) then {
+            private _newCount = floor (6 / _grenadeCount);
+            {
+                _transMags pushBack (format ["%1:%2", _x, _newCount]);
+            } forEach GVAR(loadout_handGrenade);
+        } else {
+            if (GVAR(loadout_handGrenade) isEqualTo []) then {
+                _transMags pushBack ("HandGrenade:6");
+            } else {
+                _transMags pushBack ((GVAR(loadout_handGrenade)#0) + ":6");
+            };
+        };
+        // Add smoke grenades
+        _grenadeCount = count GVAR(loadout_smokeGrenade);
+        if (_grenadeCount > 1) then {
+            private _newCount = floor (6 / _grenadeCount);
+            {
+                _transMags pushBack (format ["%1:%2", _x, _newCount]);
+            } forEach GVAR(loadout_smokeGrenade);
+        } else {
+            if (GVAR(loadout_smokeGrenade) isEqualTo []) then {
+                _transMags pushBack ("SmokeShell:6");
+            } else {
+                _transMags pushBack ((GVAR(loadout_smokeGrenade)#0) + ":6");
+            };
+        };
+
+        private _glMuzzle = (getArray (configFile >> "CfgWeapons" >> GVAR(loadout_glrifle) >> "muzzles")) param [1, "no2ndMuzzle"];
+        private _glMags = [configFile >> "CfgWeapons" >> GVAR(loadout_glrifle) >> _glMuzzle] call CBA_fnc_compatibleMagazines;
+        switch (true) do {
+            case (({"1Rnd_Smoke_Grenade_shell" == _x} count _glMags) > 0): {
+                _transMags append [
+                    "1Rnd_Smoke_Grenade_shell:4",
+                    "1Rnd_SmokeRed_Grenade_shell",
+                    "1Rnd_SmokeGreen_Grenade_shell",
+                    "potato_1Rnd_40mm_m433_HEDP:6"
+                ];
+            };
+            case (({"rhs_GRD40_White" == _x} count _glMags) > 0): {
+                _transMags append [
+                    "rhs_GRD40_White:4",
+                    "rhs_GRD40_Green",
+                    "rhs_GRD40_Red",
+                    "rhs_VOG25:6"
+                ];
+            };
+            default {};
+        };
+        // Lets create as little clutter as possible so we put some effort into merging similar mags
+        private _magsToAdd = flatten [
+            [GVAR(loadout_ar), GVAR(loadout_arMags), AR_ROUNDS] call _fnc_getMags,
+            [GVAR(loadout_rifle), GVAR(loadout_rifleMags), RIFLE_ROUNDS] call _fnc_getMags,
+            [GVAR(loadout_glrifle), GVAR(loadout_glRifleMags), GLRIFLE_ROUNDS] call _fnc_getMags,
+            [GVAR(loadout_carbine), GVAR(loadout_carbineMags), CARBINE_ROUNDS] call _fnc_getMags
+        ];
+        _magsToAdd = flatten (_magsToAdd apply {_x splitString ", "});
+        private _magHash = createHashMap; // use a hash map to merge the same mags
+        {
+            (_x splitString ":") params ["_mag", ["_count", "1"]];
+            _count = parseNumber _count;
+            if (_mag in _magHash) then {
+                _magHash set [_mag, _count + (_magHash get _mag)];
+            } else {
+                _magHash set [_mag, _count];
+            };
+        } forEach _magsToAdd;
+        { // add mags to _transMags
+            _transMags pushBack (format ["%1:%2", _x, _y]);
+        } forEach _magHash;
+        _transItems = [
+            "ACE_elasticBandage:25",
+            "ACE_packingBandage:10",
+            "ACE_splint:6",
+            "potato_pkblister:2"
+        ];
+        ["Box_NATO_Ammo_F", "Fireteam Resupply"] call _fnc_dumpBoxType;
+    };
+    case "AT": {
+        /// LAT Boxes - 6 tubes or 10 rockets
+        if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_at))) isNotEqualTo []) then {
+            _transWeaps = [GVAR(loadout_at) + QUOTE(:LAT_CRATE_ROUNDS)];
+        } else {
+            private _count = count GVAR(loadout_atMags);
+            private _nRounds = floor (LAT_CRATE_MAX_ROUNDS / _count);
+            {
+                _transMags pushBack format ["%1:%2", _x, _nRounds];
+            } forEach GVAR(loadout_atMags);
+        };
+        ["Box_NATO_WpsLaunch_F", "Launcher Crate"] call _fnc_dumpBoxType;
+        if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_mat))) isNotEqualTo []) then {
+            _transWeaps = [GVAR(loadout_mat) + QUOTE(:MAT_ROUNDS)];
+        } else {
+            private _count = count GVAR(loadout_matMags);
+            private _nRounds = floor (MAT_ROUNDS / _count);
+            {
+                _transMags pushBack format ["%1:%2", _x, _nRounds];
+            } forEach GVAR(loadout_matMags);
+        };
+        ["Box_NATO_WpsSpecial_F", "MAT Crate"] call _fnc_dumpBoxType;
+        if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_hat))) isNotEqualTo []) then {
+            _transWeaps = [GVAR(loadout_hat) + QUOTE(:HAT_ROUNDS)];
+        } else {
+            private _count = count GVAR(loadout_hatMags);
+            private _nRounds = floor (HAT_ROUNDS / _count);
+            {
+                _transMags pushBack format ["%1:%2", _x, _nRounds];
+            } forEach GVAR(loadout_hatMags);
+        };
+        ["Box_EAF_WpsSpecial_F", "HAT Crate"] call _fnc_dumpBoxType;
+    };
+    case "MG": {
+        /// MMG Crate
+        _transMags = flatten (([GVAR(loadout_mmg), GVAR(loadout_mmgMags), MMG_ROUNDS] call _fnc_getMags) splitString ", ");
+        ["Box_NATO_Support_F", "MMG Crate"] call _fnc_dumpBoxType;
+        _transMags = flatten (([GVAR(loadout_hmg), GVAR(loadout_hmgMags), HMG_ROUNDS] call _fnc_getMags) splitString ", ");
+        if ("ERROR_no_valid_mags" in _transMags) then {
+            _transMags = [
+                "Could not find relevant mag, may be NSV or M2:",
+                "ace_csw_50Rnd_127x108_mag:5",
+                "ace_csw_100Rnd_127x99_mag:5"
+            ];
+        };
+        ["Box_NATO_Wps_F",  "HMG Crate"] call _fnc_dumpBoxType;
+    };
+};
+
+{
+    "ace" callExtension ["clipboard:append", [_x + endl]];
+} forEach _lines;
+"ace" callExtension ["clipboard:complete", []];
+switch (_boxType) do {
+    case "FT": {
+        systemChat format ["Copied fireteam crate @ %1", CBA_missionTime];
+    };
+    case "AT": {
+        systemChat format ["Copied LAT, MAT, & HAT crates @ %1", CBA_missionTime];
+    };
+    case "MG": {
+        systemChat format ["Copied MMG & HMG crates @ %1", CBA_missionTime];
+    };
+};

--- a/addons/arsenalExport/functions/fnc_exportBoxes.sqf
+++ b/addons/arsenalExport/functions/fnc_exportBoxes.sqf
@@ -13,7 +13,6 @@ TRACE_1("exportBoxes",_this);
 #define LAT_CRATE_MAX_ROUNDS 8
 #define MAT_ROUNDS 6
 #define HAT_ROUNDS 4
-#define SAM_ROUNDS 2
 #define MMG_ROUNDS 1000
 #define HMG_ROUNDS 800
 


### PR DESCRIPTION
This PR:

- Adds an export button for FT, LAT, MAT, HAT, MMG, and HMG resupply boxes based on arsenal load outs.
- Added HMG and HAT to work with CSW weapons, will take magazines if loaded into a unit's inventory
- Fixes Carryall and Alt. Helmet values being ignored on export
- Added button for side custom explosive and smoke grenades (still requires some effort for SL+)