### PR TITLE
missileGuidanceCompat - Add MG Version of Milan for use with Specific Vehicles

### DIFF
--- a/addons/missileGuidanceCompat/patchGM/ACE_CSW_Groups.hpp
+++ b/addons/missileGuidanceCompat/patchGM/ACE_CSW_Groups.hpp
@@ -1,0 +1,11 @@
+class ACE_CSW_Groups {
+    //// MILAN
+    class gm_1Rnd_milan_heat_dm82_csw {
+        delete gm_1Rnd_milan_heat_dm82;
+        gm_1Rnd_milan_heat_dm82_ace_mg = 1;
+    };
+    class gm_1Rnd_milan_heat_dm92_csw {
+        delete gm_1Rnd_milan_heat_dm92;
+        gm_1Rnd_milan_heat_dm92_ace_mg = 1;
+    };
+};

--- a/addons/missileGuidanceCompat/patchGM/CfgAmmo.hpp
+++ b/addons/missileGuidanceCompat/patchGM/CfgAmmo.hpp
@@ -1,0 +1,22 @@
+#include "..\CfgMissileTypesNato.hpp"
+
+class CfgAmmo {
+    // Milan - problem with SCALOS aiming
+    class gm_missile_milan_heat_dm82;
+    class gm_missile_milan_heat_dm82_ace_mg: gm_missile_milan_heat_dm82 {
+        maneuvrability = 0;
+        class ace_missileguidance: ACEGVAR(missileguidance,type_Milan) {
+            enabled = 1;
+            initialPitch = 0.4;
+        };
+    };
+
+    class gm_missile_milan_heat_dm92;
+    class gm_missile_milan_heat_dm92_ace_mg: gm_missile_milan_heat_dm92 {
+        maneuvrability = 0;
+        class ace_missileguidance: ACEGVAR(missileguidance,type_Milan) {
+            enabled = 1;
+            initialPitch = 0.4;
+        };
+    };
+};

--- a/addons/missileGuidanceCompat/patchGM/CfgMagazines.hpp
+++ b/addons/missileGuidanceCompat/patchGM/CfgMagazines.hpp
@@ -1,0 +1,10 @@
+class CfgMagazines {
+    class gm_1Rnd_milan_heat_dm82;
+    class gm_1Rnd_milan_heat_dm82_ace_mg: gm_1Rnd_milan_heat_dm82 {
+        ammo = "gm_missile_milan_heat_dm82_ace_mg";
+    };
+    class gm_1Rnd_milan_heat_dm92;
+    class gm_1Rnd_milan_heat_dm92_ace_mg: gm_1Rnd_milan_heat_dm92 {
+        ammo = "gm_missile_milan_heat_dm92_ace_mg";
+    };
+};

--- a/addons/missileGuidanceCompat/patchGM/CfgVehicles.hpp
+++ b/addons/missileGuidanceCompat/patchGM/CfgVehicles.hpp
@@ -1,0 +1,43 @@
+class CfgVehicles {
+    // TPz 1A0 Recon
+    class gm_fuchs_base;
+    class gm_fuchsa0_base: gm_fuchs_base {
+        class Turrets;
+    };
+    class gm_fuchsa0_reconnaissance_base: gm_fuchsa0_base {
+        class MachineGunTurret_base;
+        class Turrets: Turrets {
+            class MilanTurret_01: MachineGunTurret_base {
+                magazines[] = {"gm_1Rnd_milan_heat_dm92_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg"};
+            };
+        };
+    };
+
+    // M113A1G Milan
+    class gm_m113a1_base;
+    class gm_m113a1g_base: gm_m113a1_base {
+        class Turrets;
+    };
+    class gm_m113a1g_apc_milan_base: gm_m113a1g_base {
+        class MachineGunTurret_base;
+        class Turrets: Turrets {
+            class MilanTurret_01: MachineGunTurret_base {
+                magazines[] = {"gm_1Rnd_milan_heat_dm92_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg"};
+            };
+        };
+    };
+
+    // Iltis with MILAN
+    class gm_wheeled_car_base;
+    class gm_iltis_base: gm_wheeled_car_base {
+        class Turrets;
+    };
+    class gm_iltis_milan_base: gm_iltis_base {
+        class MachineGunTurret_base;
+        class Turrets: Turrets {
+            class MilanTurret_01: MachineGunTurret_base {
+                magazines[] = {"gm_1Rnd_milan_heat_dm92_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg"};
+            };
+        };
+    };
+};

--- a/addons/missileGuidanceCompat/patchGM/CfgWeapons.hpp
+++ b/addons/missileGuidanceCompat/patchGM/CfgWeapons.hpp
@@ -1,0 +1,6 @@
+class CfgWeapons {
+    class gm_milan_launcher_base;
+    class gm_milan_launcher: gm_milan_launcher_base {
+        magazines[] += {"gm_1Rnd_milan_heat_dm82_ace_mg","gm_1Rnd_milan_heat_dm92_ace_mg"};
+    };
+};

--- a/addons/missileGuidanceCompat/patchGM/config.cpp
+++ b/addons/missileGuidanceCompat/patchGM/config.cpp
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class COMPONENT {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "ace_missileguidance",
+            "gm_weapons_launchers_milan"
+        };
+        skipWhenMissingDependencies = 1;
+        author = "Potato";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        url = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+        addonRootClass = QUOTE(ADDON);
+    };
+};
+
+#include "ACE_CSW_Groups.hpp"
+#include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
+#include "CfgVehicles.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/missileGuidanceCompat/patchGM/script_component.hpp
+++ b/addons/missileGuidanceCompat/patchGM/script_component.hpp
@@ -1,0 +1,3 @@
+#include "..\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT missileGuidanceCompat_patchGM


### PR DESCRIPTION
This PR adds Missile Guidance to the Milan missile used in GM. All vehicles except for Marder variants are changed to a new magazine that uses Missile Guidance, as Missile Guidance can not currently handle turrets on turrets like the Marder's Milan turret. To work around that, this PR:

- Creates alternate magazines and ammo
- Makes changes to the GM CSW Compat if the subaddon is loaded.
- Replaces magazines for the MILAN variants of the,
  - Fuchs
  - M113A1G
  - Iltis