### PR TITLE
missileGuidanceCompat - Temporary fix for Missing Redeye Ammo

### DIFF
--- a/addons/customGear/CfgAmmo.hpp
+++ b/addons/customGear/CfgAmmo.hpp
@@ -73,17 +73,16 @@ class CfgAmmo {
     };
 
     class AMMO(40x46mm_HEDP_M433_penetrator): ammo_Penetrator_Base {
-        hit = 90; // a guess
-        caliber = 4.2; // 63mm steel
+        hit = 80; // a guess
+        caliber = 4.467; // 67mm steel (should be 4.2 for 63mm, but it was under performing)
         timeToLive = 0.1;
         // fix double explosion
         soundsetexplosion[] = {};
     };
     class AMMO(40x53mm_HEDP_M430A1_penetrator): ammo_Penetrator_Base {
-        hit = 80; // a guess
+        hit = 90;
         caliber = 5.067; // 76mm steel
         timeToLive = 0.1;
-        // fix double explosion
         soundsetexplosion[] = {};
     };
 };

--- a/addons/customGear/CfgAmmo.hpp
+++ b/addons/customGear/CfgAmmo.hpp
@@ -73,7 +73,7 @@ class CfgAmmo {
     };
 
     class AMMO(40x46mm_HEDP_M433_penetrator): ammo_Penetrator_Base {
-        hit = 70; // a guess
+        hit = 90; // a guess
         caliber = 4.2; // 63mm steel
         timeToLive = 0.1;
         // fix double explosion

--- a/addons/missileGuidanceCompat/patchCWR/config.cpp
+++ b/addons/missileGuidanceCompat/patchCWR/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"potato_missileGuidanceCompat", "cwr3_weapon_config"};
+        requiredAddons[] = {"potato_missileGuidanceCompat", "gm_weapons_launchers_fim43", "cwr3_weapon_config"};
         skipWhenMissingDependencies = 1;
         author = "Bourbon Warfare";
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
@@ -19,6 +19,6 @@ class CfgPatches {
 class CfgMagazines {
     class CA_LauncherMagazine;
     class cwr3_redeye_m: CA_LauncherMagazine {
-        ammo = QEGVAR(missileGuidanceCompat,redeye);
+        ammo = "gm_rocket_70mm_HE_m585";
     };
 };


### PR DESCRIPTION
This PR:
- Fixes a missing ammo class for the CWR3 Redeye
- Ups the Potato HEDP penetration `hit` value from 70 to 90