### PR TITLE
arsenalExport - Fix Export Errors & Disable Outside of Editor and ACE Arsenal

### DIFF
--- a/addons/arsenalExport/XEH_preInit.sqf
+++ b/addons/arsenalExport/XEH_preInit.sqf
@@ -7,36 +7,40 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
-// Add at pre-Init so it works in 3den
-["ace_arsenal_displayOpened", {
-    INFO("ACE arsenalOpened EH");
-    #ifdef DISABLE_COMPILE_CACHE
-    call ACE_PREP_RECOMPILE;
-    #endif
-    params ["_display"];
-    [_display, true] call FUNC(arsenalOpened);
-}] call CBA_fnc_addEventHandler;
-
-
-[
-    missionNamespace,
-    "arsenalOpened",
-    {
-        INFO("BIS arsenalOpened EH");
+if (is3DENPreview || is3DEN || {
+    QACEFUNC(arsenal,onPause) in getMissionConfigValue ["onPauseScript", []]
+    }) then {
+    // Add at pre-Init so it works in 3den
+    ["ace_arsenal_displayOpened", {
+        INFO("ACE arsenalOpened EH");
         #ifdef DISABLE_COMPILE_CACHE
         call ACE_PREP_RECOMPILE;
         #endif
         params ["_display"];
-        [_display, false] call FUNC(arsenalOpened);
-    }
-] call bis_fnc_addscriptedeventhandler;
+        [_display, true] call FUNC(arsenalOpened);
+    }] call CBA_fnc_addEventHandler;
 
 
-["ace_arsenal_statsToggle", {
-    params ["_display", "_showStats"];
-    private _ctrlGroup = _display displayCtrl IDC_CTRLGROUP;
-    _ctrlGroup ctrlShow _showStats;
-}] call CBA_fnc_addEventHandler;
+    [
+        missionNamespace,
+        "arsenalOpened",
+        {
+            INFO("BIS arsenalOpened EH");
+            #ifdef DISABLE_COMPILE_CACHE
+            call ACE_PREP_RECOMPILE;
+            #endif
+            params ["_display"];
+            [_display, false] call FUNC(arsenalOpened);
+        }
+    ] call bis_fnc_addscriptedeventhandler;
+
+
+    ["ace_arsenal_statsToggle", {
+        params ["_display", "_showStats"];
+        private _ctrlGroup = _display displayCtrl IDC_CTRLGROUP;
+        _ctrlGroup ctrlShow _showStats;
+    }] call CBA_fnc_addEventHandler;
+};
 
 
 ADDON = true;

--- a/addons/arsenalExport/functions/fnc_buttonClick.sqf
+++ b/addons/arsenalExport/functions/fnc_buttonClick.sqf
@@ -98,7 +98,6 @@ case ("hmg"): {
                 private _cfgPath = _cswGroups >> _x;
                 if (isClass _cfgPath && {
                     private _convertMags = (configProperties [_cfgPath, "getNumber _x == 1"]) apply {configName _x};
-                    systemChat format ["convert mags: %1 | intersect: %2", _convertMags, _convertMags arrayIntersect _compatibleMagazines];
                     (_convertMags arrayIntersect _compatibleMagazines) isNotEqualTo []
                 }) then {
                     _cswMagCfgs pushBack _x;
@@ -141,7 +140,6 @@ case ("hat"): {
                 private _cfgPath = _cswGroups >> _x;
                 if (isClass _cfgPath && {
                     private _convertMags = (configProperties [_cfgPath, "getNumber _x == 1"]) apply {configName _x};
-                    systemChat format ["convert mags: %1 | intersect: %2", _convertMags, _convertMags arrayIntersect _compatibleMagazines];
                     (_convertMags arrayIntersect _compatibleMagazines) isNotEqualTo []
                 }) then {
                     _cswMagCfgs pushBack _x;

--- a/addons/arsenalExport/functions/fnc_export.sqf
+++ b/addons/arsenalExport/functions/fnc_export.sqf
@@ -94,11 +94,6 @@ switch (true) do {
         _lines pushBack format ['#define GLRIFLE_MAG_HE "1Rnd_HE_Grenade_shell:5"'];
         _lines pushBack format ['#define GLRIFLE_MAG_FLARE "UGL_FlareYellow_F:4"'];
     };
-    case (({"rhs_GRD40_White" == _x} count _glMags) > 0):{
-        _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "rhs_GRD40_White:2","rhs_GRD40_Red:2"'];
-        _lines pushBack format ['#define GLRIFLE_MAG_HE "rhs_VOG25:5"'];
-        _lines pushBack format ['#define GLRIFLE_MAG_FLARE "rhs_VG40OP_red:4"'];
-    };
     default {
         _lines pushBack format ["// WARNING - Unknown GL Muzzle [%1->%2]", GVAR(loadout_glrifle), _glMuzzle];
         _lines pushBack format ['#define GLRIFLE_MAG_SMOKE ""'];

--- a/addons/arsenalExport/functions/fnc_exportBoxes.sqf
+++ b/addons/arsenalExport/functions/fnc_exportBoxes.sqf
@@ -123,20 +123,20 @@ switch (_boxType) do {
         private _glMuzzle = (getArray (configFile >> "CfgWeapons" >> GVAR(loadout_glrifle) >> "muzzles")) param [1, "no2ndMuzzle"];
         private _glMags = [configFile >> "CfgWeapons" >> GVAR(loadout_glrifle) >> _glMuzzle] call CBA_fnc_compatibleMagazines;
         switch (true) do {
-            case (({"1Rnd_Smoke_Grenade_shell" == _x} count _glMags) > 0): {
-                _transMags append [
-                    "1Rnd_Smoke_Grenade_shell:4",
-                    "1Rnd_SmokeRed_Grenade_shell",
-                    "1Rnd_SmokeGreen_Grenade_shell",
-                    "potato_1Rnd_40mm_m433_HEDP:6"
-                ];
-            };
             case (({"rhs_GRD40_White" == _x} count _glMags) > 0): {
                 _transMags append [
                     "rhs_GRD40_White:4",
                     "rhs_GRD40_Green",
                     "rhs_GRD40_Red",
                     "rhs_VOG25:6"
+                ];
+            };
+            case (({"1Rnd_Smoke_Grenade_shell" == _x} count _glMags) > 0): {
+                _transMags append [
+                    "1Rnd_Smoke_Grenade_shell:4",
+                    "1Rnd_SmokeRed_Grenade_shell",
+                    "1Rnd_SmokeGreen_Grenade_shell",
+                    "potato_1Rnd_40mm_m433_HEDP:6"
                 ];
             };
             default {};
@@ -172,36 +172,42 @@ switch (_boxType) do {
     };
     case "AT": {
         /// LAT Boxes - 6 tubes or 10 rockets
-        if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_at))) isNotEqualTo []) then {
-            _transWeaps = [GVAR(loadout_at) + QUOTE(:LAT_CRATE_ROUNDS)];
-        } else {
-            private _count = count GVAR(loadout_atMags);
-            private _nRounds = floor (LAT_CRATE_MAX_ROUNDS / _count);
-            {
-                _transMags pushBack format ["%1:%2", _x, _nRounds];
-            } forEach GVAR(loadout_atMags);
+        if (GVAR(loadout_at) isNotEqualTo [] && GVAR(loadout_at) != "NotSet") then {
+            if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_at))) isNotEqualTo []) then {
+                _transWeaps = [GVAR(loadout_at) + QUOTE(:LAT_CRATE_ROUNDS)];
+            } else {
+                private _count = 1 max count GVAR(loadout_atMags);
+                private _nRounds = floor (LAT_CRATE_MAX_ROUNDS / _count);
+                {
+                    _transMags pushBack format ["%1:%2", _x, _nRounds];
+                } forEach GVAR(loadout_atMags);
+            };
+            ["Box_NATO_WpsLaunch_F", "Launcher Crate"] call _fnc_dumpBoxType;
         };
-        ["Box_NATO_WpsLaunch_F", "Launcher Crate"] call _fnc_dumpBoxType;
-        if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_mat))) isNotEqualTo []) then {
-            _transWeaps = [GVAR(loadout_mat) + QUOTE(:MAT_ROUNDS)];
-        } else {
-            private _count = count GVAR(loadout_matMags);
-            private _nRounds = floor (MAT_ROUNDS / _count);
-            {
-                _transMags pushBack format ["%1:%2", _x, _nRounds];
-            } forEach GVAR(loadout_matMags);
+        if (GVAR(loadout_mat) isNotEqualTo [] && GVAR(loadout_mat) != "NotSet") then {
+            if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_mat))) isNotEqualTo []) then {
+                _transWeaps = [GVAR(loadout_mat) + QUOTE(:MAT_ROUNDS)];
+            } else {
+                private _count = 1 max count GVAR(loadout_matMags);
+                private _nRounds = floor (MAT_ROUNDS / _count);
+                {
+                    _transMags pushBack format ["%1:%2", _x, _nRounds];
+                } forEach GVAR(loadout_matMags);
+            };
+            ["Box_NATO_WpsSpecial_F", "MAT Crate"] call _fnc_dumpBoxType;
         };
-        ["Box_NATO_WpsSpecial_F", "MAT Crate"] call _fnc_dumpBoxType;
-        if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_hat))) isNotEqualTo []) then {
-            _transWeaps = [GVAR(loadout_hat) + QUOTE(:HAT_ROUNDS)];
-        } else {
-            private _count = count GVAR(loadout_hatMags);
-            private _nRounds = floor (HAT_ROUNDS / _count);
-            {
-                _transMags pushBack format ["%1:%2", _x, _nRounds];
-            } forEach GVAR(loadout_hatMags);
+        if (GVAR(loadout_hat) isNotEqualTo [] && GVAR(loadout_hat) != "NotSet") then {
+            if ((getArray (configFile >> "CBA_DisposableLaunchers" >> GVAR(loadout_hat))) isNotEqualTo []) then {
+                _transWeaps = [GVAR(loadout_hat) + QUOTE(:HAT_ROUNDS)];
+            } else {
+                private _count = 1 max count GVAR(loadout_hatMags);
+                private _nRounds = floor (HAT_ROUNDS / _count);
+                {
+                    _transMags pushBack format ["%1:%2", _x, _nRounds];
+                } forEach GVAR(loadout_hatMags);
+            };
+            ["Box_EAF_WpsSpecial_F", "HAT Crate"] call _fnc_dumpBoxType;
         };
-        ["Box_EAF_WpsSpecial_F", "HAT Crate"] call _fnc_dumpBoxType;
     };
     case "MG": {
         /// MMG Crate
@@ -210,7 +216,7 @@ switch (_boxType) do {
         _transMags = flatten (([GVAR(loadout_hmg), GVAR(loadout_hmgMags), HMG_ROUNDS] call _fnc_getMags) splitString ", ");
         if ("ERROR_no_valid_mags" in _transMags) then {
             _transMags = [
-                "Could not find relevant mag, may be NSV or M2:",
+                "Could not find relevant mag, may be NSV/Kord or M2:",
                 "ace_csw_50Rnd_127x108_mag:5",
                 "ace_csw_100Rnd_127x99_mag:5"
             ];


### PR DESCRIPTION
This PR will:

- Add error checking for exporting AT crates
- Prefer GP-30 launched grenades for resupply box export
- Disable arsenal export dialog when not in the editor, an editor launched mission, or the ACE Arsenal launched from main menu