### PR TITLE
Multi-Addon - Fix and Small Updates

### DIFF
--- a/addons/aceEdits/CfgAmmo.hpp
+++ b/addons/aceEdits/CfgAmmo.hpp
@@ -24,4 +24,9 @@ class CfgAmmo {
             lineGainD = 10;
         };
     };
+    // clean up missile and smoke mod to make Vikhr's visible
+    class M_Scalpel_AT;
+    class ace_missile_vikhr_9k121: M_Scalpel_AT {
+        effectsMissile = "Missile2_vanilla";
+    };
 };

--- a/addons/adminMenu/functions/fnc_uihook_unitGroupSideBrief.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_unitGroupSideBrief.sqf
@@ -18,9 +18,10 @@
 private _debugMsg = format ["Group and Unit Brief Test"];
 ["potato_adminMsg", [_debugMsg, profileName]] call CBA_fnc_globalEvent;
 
-//Needs a player to add to breifing:
+// Needs a player to add to breifing:
 if ((isNull player) || {!alive player}) exitWith {};
 
+/// Group and Unit
 private _briefs = ["<font size=20 ace=""PuristaBold"">Group and Unit Briefs</font>"];
 {
     private _brief = _x getVariable ["potato_briefing_briefing", ""];
@@ -41,22 +42,23 @@ if (count _briefs > 1) then {
     player createDiaryRecord ["POTATO", ["Group and Unit Briefs", _briefs joinString "<br/><br/>"], taskNull, "NONE", false];
 };
 
+/// Side briefing
 {
     private _sideText = [format ["<font size=28 face=""PuristaBold"">%1 Brief</font><br/>",_x]];
     private _sideBriefMission = getMissionConfigValue [format [QEGVAR(briefing,brief%1Mission), _x], ""];
     private _sideBriefSituation = getMissionConfigValue [format [QEGVAR(briefing,brief%1Situation), _x], ""];
     private _sideBriefAdministration = getMissionConfigValue [format [QEGVAR(briefing,brief%1Administration), _x], ""];
-    if (_sideBriefAdministration != "") then {
-        _sideText pushBack "<font size=20 face=""PuristaBold"">Admin</font>";
-        _sideText pushBack (_sideBriefAdministration + "<br/>");
+    if (_sideBriefSituation != "") then {
+        _sideText pushBack "<font size=20 face=""PuristaBold"">Situation</font>";
+        _sideText pushBack (_sideBriefSituation + "<br/>");
     };
     if (_sideBriefMission != "") then {
         _sideText pushBack "<font size=20 face=""PuristaBold"">Mission</font>";
         _sideText pushBack (_sideBriefMission + "<br/>");
     };
-    if (_sideBriefSituation != "") then {
-        _sideText pushBack "<font size=20 face=""PuristaBold"">Situation</font>";
-        _sideText pushBack (_sideBriefSituation + "<br/>");
+    if (_sideBriefAdministration != "") then {
+        _sideText pushBack "<font size=20 face=""PuristaBold"">Admin</font>";
+        _sideText pushBack (_sideBriefAdministration + "<br/>");
     };
     if (count _sideText > 1) then {
         player createDiaryRecord [

--- a/addons/customGear/CfgAmmo.hpp
+++ b/addons/customGear/CfgAmmo.hpp
@@ -73,7 +73,7 @@ class CfgAmmo {
     };
 
     class AMMO(40x46mm_HEDP_M433_penetrator): ammo_Penetrator_Base {
-        hit = 80; // a guess
+        hit = 90; // a guess
         caliber = 4.467; // 67mm steel (should be 4.2 for 63mm, but it was under performing)
         timeToLive = 0.1;
         // fix double explosion

--- a/addons/miscFixes/patchCUP/CfgAmmo.hpp
+++ b/addons/miscFixes/patchCUP/CfgAmmo.hpp
@@ -3,4 +3,7 @@ class CfgAmmo {
     class cup_m_9k11_at3_sagger_at: MissileBase {
         effectsMissile = "Missile4_vanilla";
     };
+    class CUP_M_9K121_Vikhr_AT16_Scallion_AT: MissileBase {
+        effectsMissile = "Missile2_vanilla";
+    };
 };

--- a/addons/strongerFlashlights/CfgWeapons.hpp
+++ b/addons/strongerFlashlights/CfgWeapons.hpp
@@ -478,7 +478,7 @@ class CfgWeapons {
         };
     };
     class GVAR(acc_cup_Flashlight_04_Wide): GVAR(acc_cup_Flashlight_02_Wide) {
-        displayName="Flashlight (Flood, White)";
+        displayName="Flashlight (Flood, Red)";
         MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_04);
         MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_04_Spot);
         MRT_switchItemHintText = "Flashlight (Flood, Red)";
@@ -504,10 +504,10 @@ class CfgWeapons {
         };
     };
     class GVAR(acc_cup_Flashlight_05_Spot): GVAR(acc_cup_Flashlight_02_Spot) {
-        displayName="Flashlight (White, Red)";
+        displayName="Flashlight (Multimode, Medium White)";
         MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_05_Wide);
         MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_05);
-        MRT_switchItemHintText = "Flashlight (White, Red)";
+        MRT_switchItemHintText = "Flashlight (Medium White)";
         baseWeapon = QGVAR(acc_cup_Flashlight_05);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
@@ -527,10 +527,10 @@ class CfgWeapons {
         };
     };
     class GVAR(acc_cup_Flashlight_05): GVAR(acc_cup_Flashlight_02) {
-        displayName="Flashlight (Multimode, White)";
+        displayName="Flashlight (Multimode, Medium White)";
         MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_05_Spot);
         MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_05_Wide);
-        MRT_switchItemHintText = "Flashlight (White)";
+        MRT_switchItemHintText = "Flashlight (Medium White)";
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
                 ACE_Flashlight_Size = 1;
@@ -548,10 +548,10 @@ class CfgWeapons {
         };
     };
     class GVAR(acc_cup_Flashlight_05_Wide): GVAR(acc_cup_Flashlight_02_Wide) {
-        displayName="Flashlight (Flood, White)";
+        displayName="Flashlight (Flood, Medium White)";
         MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_05);
         MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_05_Spot);
-        MRT_switchItemHintText = "Flashlight (Flood, White)";
+        MRT_switchItemHintText = "Flashlight (Flood, Medium White)";
         baseWeapon = QGVAR(acc_cup_Flashlight_05);
         class ItemInfo: ItemInfo {
             class FlashLight: FlashLight {
@@ -564,6 +564,47 @@ class CfgWeapons {
                 class Attenuation: Attenuation {
                     hardLimitStart = 30;
                     hardLimitEnd = 80;
+                    start = 5;
+                };
+            };
+        };
+    };
+    class GVAR(acc_cup_Flashlight_06_Spot): GVAR(acc_cup_Flashlight_05_Spot) {
+        displayName="Flashlight (Spot, White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_06_Wide);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_06);
+        MRT_switchItemHintText = "Flashlight (Spot, White)";
+        baseWeapon = QGVAR(acc_cup_Flashlight_06);
+        class ItemInfo: ItemInfo {};
+    };
+    class GVAR(acc_cup_Flashlight_06): GVAR(acc_cup_Flashlight_05) {
+        displayName="Flashlight (Multimode, White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_06_Spot);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_06_Wide);
+        MRT_switchItemHintText = "Flashlight (White)";
+        class ItemInfo: ItemInfo {};
+    };
+    class GVAR(acc_cup_Flashlight_06_Wide): GVAR(acc_cup_Flashlight_05_Wide) {
+        displayName="Flashlight (Flood, White)";
+        MRT_SwitchItemNextClass = QGVAR(acc_cup_Flashlight_06);
+        MRT_SwitchItemPrevClass = QGVAR(acc_cup_Flashlight_06_Spot);
+        MRT_switchItemHintText = "Flashlight (Flood, White)";
+        baseWeapon = QGVAR(acc_cup_Flashlight_06);
+        class ItemInfo: ItemInfo {
+            class FlashLight: FlashLight {
+                ACE_Flashlight_Size = 1;
+                useFlare = 1;
+                flareMaxDistance = 40;
+                flareSize = 1;
+                intensity = 4;
+                volumeShape = "";
+                class Attenuation: Attenuation {
+                    hardLimitStart = 30;
+                    hardLimitEnd = 80;
+                    start = 1;
+                    constant = 0.5;
+                    linear = 0;
+                    quadratic = 0.02;
                 };
             };
         };
@@ -588,6 +629,7 @@ class asdg_FrontSideRail: asdg_SlotInfo {
         ACC_FLASHLIGHT_TRIPLET_LMD(03);
         ACC_FLASHLIGHT_TRIPLET_LMD(04);
         ACC_FLASHLIGHT_TRIPLET_LMD(05);
+        ACC_FLASHLIGHT_TRIPLET_LMD(06);
     };
 };
 class PointerSlot;
@@ -616,5 +658,6 @@ class rhs_russian_ak_barrel_slot: SlotInfo {
         ACC_FLASHLIGHT_TRIPLET_LMD(03);
         ACC_FLASHLIGHT_TRIPLET_LMD(04);
         ACC_FLASHLIGHT_TRIPLET_LMD(05);
+        ACC_FLASHLIGHT_TRIPLET_LMD(06);
 	};
 };

--- a/addons/strongerFlashlights/config.cpp
+++ b/addons/strongerFlashlights/config.cpp
@@ -14,7 +14,8 @@ class CfgPatches {
             GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(02),
             GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(03),
             GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(04),
-            GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(05)
+            GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(05),
+            GENERIC_CUP_ADAPTED_FLASHLIGHT_LMD(06)
         };
         units[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/vehicleCoasting/functions/fnc_addCoastingVehicle.sqf
+++ b/addons/vehicleCoasting/functions/fnc_addCoastingVehicle.sqf
@@ -34,11 +34,11 @@ if (_vehicle getHitPointDamage "hitrtrack" >  0.8 ||
         {_vehicle getHitPointDamage "hitltrack" >  0.8}) then {
     _vehicle setHitPointDamage ["hitrtrack", 0.4 min (_vehicle getHitPointDamage "hitrtrack"), false];
     _vehicle setHitPointDamage ["hitltrack", 0.4 min (_vehicle getHitPointDamage "hitltrack"), false];
-    _freeRunLen = 1 + random 2;
+    _freeRunLen = 2 + random 3;
 };
 
 if (_vehicle isKindOf "Car_F") then {
-    _freeRunLen = _freeRunLen / 4;
+    _freeRunLen = _freeRunLen / 2;
 };
 
 private _startTime = 1 + random 1;

--- a/addons/vehicleCoasting/functions/fnc_coastVehicles.sqf
+++ b/addons/vehicleCoasting/functions/fnc_coastVehicles.sqf
@@ -43,6 +43,9 @@ TRACE_1("Coast handler",CBA_missionTime);
 
 if (GVAR(activeVehicles) isEqualTo createHashMap) then {
     GVAR(loopRunning) = false;
+    #ifdef DEBUG_MODE_DRAW_EH
+    call FUNC(cleanDraw);
+    #endif
 } else {
     [{call FUNC(coastVehicles)}, 0, COAST_LOOP_INTERVAL] call CBA_fnc_waitAndExecute;
 };

--- a/addons/vehicleCoasting/functions/fnc_driverDeathHandle.sqf
+++ b/addons/vehicleCoasting/functions/fnc_driverDeathHandle.sqf
@@ -29,9 +29,12 @@ if (!local _vehicle) exitWith {
     TRACE_1("Not local",_vehicle);
 };
 #ifdef DEBUG_MODE_FULL
-diag_log text (str _vehicle + " lt: " + str (_vehicle getHitPointDamage "hitltrack") + " rt: "
-        + str (_vehicle getHitPointDamage "hitrtrack") + " e: "
-        + str (_vehicle getHitPointDamage "hitengine"));
+diag_log formatText [
+    "%1 lt: %2 rt: %3",
+    str _vehicle,
+    _vehicle getHitPointDamage "hitltrack",
+    _vehicle getHitPointDamage "hitrtrack"
+];
 #endif
 
 private _driver = driver _vehicle;
@@ -40,7 +43,7 @@ if (!(_vehicle isKindOf "LandVehicle") ||
     !alive _vehicle ||
     _unit != _driver ||
     (getObjectID _vehicle) in GVAR(activeVehicles)) exitWith {
-    TRACE_4("ExitHandle",typeOf _vehicle,speed _vehicle,_unit,_driver);
+    TRACE_5("ExitHandle",typeOf _vehicle,speed _vehicle,_unit,_driver,alive _driver);
 };
 
 TRACE_3("Continuing",_unit,_vehicle,speed _vehicle);

--- a/addons/vehicleCoasting/functions/fnc_vehicleCookOffHandle.sqf
+++ b/addons/vehicleCoasting/functions/fnc_vehicleCookOffHandle.sqf
@@ -24,9 +24,12 @@ if !(alive _vehicle && local _vehicle &&
     TRACE_3("invalid vehicle",alive _vehicle,local _vehicle,alive driver _vehicle);
 };
 #ifdef DEBUG_MODE_FULL
-diag_log text (str _vehicle + " lt: " + str (_vehicle getHitPointDamage "hitltrack") + " rt: "
-        + str (_vehicle getHitPointDamage "hitrtrack") + " e: "
-        + str (_vehicle getHitPointDamage "hitengine"));
+diag_log formatText [
+    "%1 lt: %2 rt: %3",
+    str _vehicle,
+    _vehicle getHitPointDamage "hitltrack",
+    _vehicle getHitPointDamage "hitrtrack"
+];
 #endif
 private _driver = driver _vehicle;
 // Make it happen more often


### PR DESCRIPTION
This PR:

- Added yet another multi-mode flashlight with a milder area mode
- Cleaned up multi-mode flashlight display names
- Reduces CUP and ACE Vihkr smoke to vanilla `Missle2` levels, increasing usability under ~3km
- Fixed Admin Menu Testing briefing output order (was reversed as: admin, mission, then situation)
- Extended vehicle coasting time for wheeled vehicles and updated vehicle coasting debug context
- Increased damage on potato HEDP penetrators