### PR TITLE
miscFixes - Fix RHS 9M113 AMG 

### DIFF
--- a/addons/miscFixes/patchRHSAFRF/CfgAmmo.hpp
+++ b/addons/miscFixes/patchRHSAFRF/CfgAmmo.hpp
@@ -1,3 +1,5 @@
+#include "\z\potato\addons\missileGuidanceCompat\CfgMissileTypesWarsaw.hpp"
+
 class CfgAmmo {
     class ShellBase;
     class ammo_Penetrator_Base: ShellBase {
@@ -9,5 +11,26 @@ class CfgAmmo {
         delete deleteParentWhenTriggered;
         delete triggerTime;
         submunitionAmmo = "";
+    };
+
+    class M_Titan_AT;
+    class rhs_ammo_atgmBase_base: M_Titan_AT {
+        class EventHandlers;
+    };
+    class rhs_ammo_9m113: rhs_ammo_atgmBase_base {
+        maneuvrability = 14;
+        class ace_missileguidance: ACEGVAR(missileguidance,DOUBLES(type,Konkurs)) {
+            enabled = 0;
+        };
+        class EventHandlers: EventHandlers {
+            class RHS_Guidance {
+                fired = "_this call RHS_fnc_saclosGuide";
+            };
+        };
+    };
+    class rhs_ammo_9m113m: rhs_ammo_9m113 {
+        class ace_missileguidance: ace_missileguidance {
+            enabled = 0;
+        };
     };
 };

--- a/addons/miscFixes/patchRHSAFRF/config.cpp
+++ b/addons/miscFixes/patchRHSAFRF/config.cpp
@@ -10,7 +10,8 @@ class CfgPatches {
         requiredAddons[] = {
             "potato_core",
             "potato_miscFixes",
-            "rhs_main_loadorder"
+            "rhs_main_loadorder",
+            "ace_compat_rhs_afrf3_missileguidance"
         };
         skipWhenMissingDependencies = 1;
         author = "Bourbon Warfare";


### PR DESCRIPTION
The RHS 9M113 on the BMP-1 and BMD series IFVs uses a turret on turret configuration not supported by Missile Guidance. This PR disables missile guidance for the 9M113 and reverts overridden parameters.