### PR TITLE
markers - Player Only Intra-Group Markers Setting

### DIFF
--- a/addons/markers/functions/fnc_drawMarkers.sqf
+++ b/addons/markers/functions/fnc_drawMarkers.sqf
@@ -98,21 +98,21 @@ if (GVAR(intraFireteamEnabled) && {(ctrlMapScale _mapControl) < 0.5}) then {
             private _unitPosition = position _x;
             private _unitName = if (alive _x) then { name _x } else { "" };
 
-            _mapControl drawIcon [UNIT_MARKER_ICON,
-                                  _color,
-                                  _unitPosition,
-                                  UNIT_MARKER_SIZE * _sizeFactor,
-                                  UNIT_MARKER_SIZE * _sizeFactor,
-                                  direction _x,
-                                  _unitName,
-                                  1,
-                                  (([0,0.02] select (((ctrlMapScale _mapControl) * _mapSize) < 0.005)) * _sizeFactor),
-                                  'TahomaB',
-                                  "left"];
+            _mapControl drawIcon [
+                UNIT_MARKER_ICON,
+                _color,
+                _unitPosition,
+                UNIT_MARKER_SIZE * _sizeFactor,
+                UNIT_MARKER_SIZE * _sizeFactor,
+                direction _x,
+                _unitName,
+                1,
+                (([0,0.02] select (((ctrlMapScale _mapControl) * _mapSize) < 0.005)) * _sizeFactor),
+                'TahomaB',
+                "left"
+            ];
         };
-
-        nil
-    } count (units (group player));
+    } forEach ([units (group player), [player]] select GVAR(intraFireteam_playerOnly));
 };
 
 END_COUNTER(drawMarkers);

--- a/addons/markers/initSettings.inc.sqf
+++ b/addons/markers/initSettings.inc.sqf
@@ -10,7 +10,17 @@
 
 [
     QGVAR(intraFireteamEnabled), "CHECKBOX",
-    ["intraFireteam"], 
+    ["intraFireteam"],
+    ["POTATO - Mission Maker", "Markers"],
+    false, // default value
+    true, // isGlobal
+    {},
+    true // Needs mission restart
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(intraFireteam_playerOnly), "CHECKBOX",
+    ["intraFireteam - player only"],
     ["POTATO - Mission Maker", "Markers"],
     false, // default value
     true, // isGlobal


### PR DESCRIPTION
This PR adds a setting to allow the intra-group markers to be set to player only, skipping all other units except for the current player.