### PR TITLE
DUI GoBy - Use Alpha Channel on CBA Setting

### DIFF
--- a/addons/dui_goby/initSettings.inc.sqf
+++ b/addons/dui_goby/initSettings.inc.sqf
@@ -30,6 +30,6 @@ private _category = ["POTATO - User", "Go By (DUI Nametags)"];
     [1, 0.3, 0, 1],
     false,
     {
-        GVAR(colorHex) = [(_this select 0) * 255,(_this select 1) * 255,(_this select 2) * 255] call diwako_dui_main_fnc_toHex;
+        GVAR(colorHex) = _this call BIS_fnc_colorRGBAtoHTML;
     }
 ] call CBA_fnc_addSetting;

--- a/addons/miscFixes/config.cpp
+++ b/addons/miscFixes/config.cpp
@@ -23,6 +23,12 @@ class RscChatListDefault {
     colorBackground[] = {0,0,0,0.3};
     colorMessageProtocol[] = {0.65,0.65,0.65,0.9};
 };
+class CfgDamageAround {
+    class DamageAroundHouse {
+        indirectHit = 0.7;
+        radiusRatio = 1;
+    };
+};
 
 #include "CfgAmmo.hpp"
 #include "CfgCloudlets.hpp"

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -134,7 +134,7 @@ class CfgVehicles {
         armor = 600; // original 300
     };
     class Land_Kasarna: House {
-        armor = 450; // original 200
+        armor = 500; // original 200
     };
     class Land_Dum_mesto_in: Land_Dum_mesto_in_bare {
         armor = 600; // original 300

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -31,7 +31,9 @@ class MainTurret: MainTurret {\
 #include "CfgAmmo.hpp"
 class CfgVehicles {
     #include "CfgVehiclesA10A.hpp"
-    // Base classes
+    /// Base classes
+    class House;
+    class House_EP1;
     class Car;
     class Car_F: Car {
         class HitPoints {
@@ -40,7 +42,16 @@ class CfgVehicles {
         };
         class Turrets;
     };
-    // Fix broken artillery computer on FV432 Mortar (shows artillery computer for 7.62mg)
+
+    /// Building armor x4 default
+    class Land_A_BuildingWIP: House {
+        armor = 2000;
+    };
+    class Land_A_BuildingWIP_EP1: House_EP1 {
+        armor = 2000;
+    };
+
+    /// Fix broken artillery computer on FV432 Mortar (shows artillery computer for 7.62mg)
     class CUP_B_FV432_Bulldog_GB_D;
     class CUP_B_FV432_Base: CUP_B_FV432_Bulldog_GB_D {
         class Turrets;

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -34,6 +34,7 @@ class CfgVehicles {
     /// Base classes
     class House;
     class House_EP1;
+    class House_F;
     class Car;
     class Car_F: Car {
         class HitPoints {
@@ -43,12 +44,139 @@ class CfgVehicles {
         class Turrets;
     };
 
-    /// Building armor x4 default
+    /// Building armor increases
+    class Land_Budova4_in;
+    class Land_Garaz_s_tankem;
+    class Land_Cihlovej_Dum_in;
+    class Land_Dum_olezlina_closed;
+    class Land_Dum_mesto_in_bare;
+    class Land_Ind_Shed_01_EP1;
+    class Land_Dum_olez_istan1_closed;
     class Land_A_BuildingWIP: House {
-        armor = 2000;
+        armor = 2000; // original 500
     };
     class Land_A_BuildingWIP_EP1: House_EP1 {
-        armor = 2000;
+        armor = 2000; // original 500
+    };
+    class Land_A_Pub_01: House {
+        armor = 1200; // original 600
+    };
+    class Land_Mil_Barracks_L: House {
+        armor = 800; // original 400
+    };
+    class Land_Mil_Barracks_i: House {
+        armor = 600; // original 400
+    };
+    class Land_Mil_Barracks: House {
+        armor = 600; // original 400
+    };
+    class Land_HouseB_Tenement: House {
+        armor = 288; // original 180
+    };
+    class Land_a_stationhouse: House {
+        armor = 800; // original 320
+    };
+    class Land_WIP_F: House_F {
+        armor = 2000; // original 500
+    };
+    class Land_Letistni_hala: House {
+        armor = 400; // original 200
+    };
+    class Land_Garaz_bez_tanku: Land_Garaz_s_tankem {
+        armor = 600; // original 300
+    };
+    class Land_Budova4: Land_Budova4_in {
+        armor = 700; // original 150
+    };
+    class Land_Budova3: House {
+        armor = 600; // original 300
+    };
+    class Land_Budova2: House {
+        armor = 700; // original 150
+    };
+    class Land_Budova1: House {
+        armor = 700; // original 500
+    };
+    class Land_Garaz: House {
+        armor = 225; // original 75
+    };
+    class Land_Dum_olez_istan1: Land_Dum_olez_istan1_closed {
+        armor = 300; // original 150
+    };
+    class Land_Stanice: House {
+        armor = 800; // original 500
+    };
+    class Land_Cihlovej_Dum_mini: Land_Cihlovej_Dum_in {
+        armor = 1000; // original 500
+    };
+    class Land_Dum_olezlina: Land_Dum_olezlina_closed {
+        armor = 600; // original 150
+    };
+    class Land_Dum_m2: House {
+        armor = 750; // original 500
+    };
+    class Land_Dum_mesto3: House {
+        armor = 400; // original 150
+    };
+    class Land_Budova5: House {
+        armor = 750; // original 500
+    };
+    class Land_Repair_center: House {
+        armor = 750; // original 500
+    };
+    class Land_Dumruina_mini: House {
+        armor = 800; // original 500
+    };
+    class Land_Sara_zluty_statek_in: House {
+        armor = 300; // original 150
+    };
+    class Land_Sara_domek_zluty: House {
+        armor = 600; // original 300
+    };
+    class Land_Kasarna: House {
+        armor = 450; // original 200
+    };
+    class Land_Dum_mesto_in: Land_Dum_mesto_in_bare {
+        armor = 600; // original 300
+    };
+    class Land_Barrack2: House {
+        armor = 300; // original 100
+    };
+    class Land_Ind_Shed_02_EP1: Land_Ind_Shed_01_EP1 {
+        armor = 250; // original 110
+    };
+    class Land_Mil_Repair_center_EP1: House_EP1 {
+        armor = 750; // original 250
+    };
+    class Land_Mil_Barracks_EP1: House_EP1 {
+        armor = 500; // original 250
+    };
+    class Land_Mil_Barracks_i_EP1: House_EP1 {
+        armor = 800; // original 400
+    };
+    class Land_Mil_Barracks_L_EP1: House_EP1 {
+        armor = 800; // original 400
+    };
+    class Land_Mil_Guardhouse_EP1: House_EP1 {
+        armor = 600; // original 250
+    };
+    class Land_House_L_9_EP1: House_EP1 {
+        armor = 750; // original 250
+    };
+    class Land_ZalChata: House {
+        armor = 800; // original 500
+    };
+    class Land_Mil_Guardhouse: House {
+        armor = 800; // original 400
+    };
+    class Land_Bouda3: House {
+        armor = 600; // original 200
+    };
+    class Land_Dum_olez_istan2_maly: House {
+        armor = 600; // original 150
+    };
+    class Land_Dum_istan2: House {
+        armor = 800; // original 700
     };
 
     /// Fix broken artillery computer on FV432 Mortar (shows artillery computer for 7.62mg)

--- a/addons/miscFixes/patchGM/CfgWeapons.hpp
+++ b/addons/miscFixes/patchGM/CfgWeapons.hpp
@@ -11,19 +11,14 @@ class CfgWeapons {
             "\gm\gm_weapons\gm_machinepistols\gm_mp2\data\gld\gm_mp2a1_ext_01_gld_co.paa"
         };
     };
-    class CannonCore;
-    class gm_cannon_base: CannonCore {
-        class GunParticles;
-    };
-    class gm_autoCannon_base: gm_cannon_base {
-        class GunParticles: GunParticles {
-            class Effect_01;
-        };
-    };
+
+    class gm_autoCannon_base;
     class gm_145mm_kpvt_base: gm_autoCannon_base {
-        class GunParticles: GunParticles {
-            class Effect_01: Effect_01 {
+        class GunParticles {
+            class Effect_01 {
+                directionName = "MainTurret_Gun_pos";
                 effectName = QGVARMAIN(MachineGunCloud);
+                positionName = "MainTurret_Gun_dir";
             };
         };
     };


### PR DESCRIPTION
This PR utilizes the alpha channel setting for the DUI goby sub-addon.