### PR TITLE
 DUI GoBy - Use Alpha Channel on CBA Setting

### DIFF
--- a/addons/dui_goby/initSettings.inc.sqf
+++ b/addons/dui_goby/initSettings.inc.sqf
@@ -30,6 +30,6 @@ private _category = ["POTATO - User", "Go By (DUI Nametags)"];
     [1, 0.3, 0, 1],
     false,
     {
-        GVAR(colorHex) = [(_this select 0) * 255,(_this select 1) * 255,(_this select 2) * 255] call diwako_dui_main_fnc_toHex;
+        GVAR(colorHex) = _this call BIS_fnc_colorRGBAtoHTML;
     }
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
This PR utilizes the alpha channel setting for the DUI goby sub-addon.
