### PR TITLE
cswCompat - Hide GM CSW Compat

### DIFF
--- a/addons/cswCompat/patchGM/CfgMagazines.hpp
+++ b/addons/cswCompat/patchGM/CfgMagazines.hpp
@@ -3,8 +3,8 @@ class CfgMagazines {
     class gm_1Rnd_milan_heat_dm82;
     class gm_1Rnd_milan_heat_dm82_csw: gm_1Rnd_milan_heat_dm82 {
         displayName = "[CSW] HEAT DM82 (MILAN 1)";
-        scope = 2;
-        scopeArsenal = 2;
+        scope = 1;
+        scopeArsenal = 1;
         type = 256;
         count = 1;
         model = "\gm\gm_weapons\gm_launchers\gm_milan\gm_1rnd_milan_heat_dm92.p3d";
@@ -15,8 +15,8 @@ class CfgMagazines {
     class gm_1Rnd_milan_heat_dm92;
     class gm_1Rnd_milan_heat_dm92_csw: gm_1Rnd_milan_heat_dm92 {
         displayName = "[CSW] HEAT DM92 (MILAN 2)";
-        scope = 2;
-        scopeArsenal = 2;
+        scope = 1;
+        scopeArsenal = 1;
         type = 256;
         count = 1;
         model = "\gm\gm_weapons\gm_launchers\gm_milan\gm_1rnd_milan_heat_dm92.p3d";
@@ -28,8 +28,8 @@ class CfgMagazines {
     class gm_1Rnd_fagot_heat_9m111;
     class gm_1Rnd_fagot_heat_9m111_csw: gm_1Rnd_fagot_heat_9m111 {
         displayName = "[CSW] HEAT 9M111 (Fagot)";
-        scope = 2;
-        scopeArsenal = 2;
+        scope = 1;
+        scopeArsenal = 1;
         type = 256;
         picture = ACE_CSW_PATH(UI\StaticAT_Icon.paa);
         ACE_isBelt = 0;

--- a/addons/cswCompat/patchGM/CfgVehicles.hpp
+++ b/addons/cswCompat/patchGM/CfgVehicles.hpp
@@ -43,6 +43,8 @@ class CfgVehicles {
         };
     };
     class gm_ge_army_milan_launcher_tripod_csw: gm_ge_army_milan_launcher_tripod {
+        scope = 1;
+        scopeArsenal = 1;
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 class ACE_csw_pickUp {
@@ -141,6 +143,8 @@ class CfgVehicles {
         };
     };
     class gm_gc_army_fagot_launcher_tripod_csw: gm_gc_army_fagot_launcher_tripod {
+        scope = 1;
+        scopeArsenal = 1;
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 class ACE_csw_pickUp {
@@ -246,6 +250,8 @@ class CfgVehicles {
         };
     };
     class GVAR(gm_MG3Tripod): ace_csw_m3Tripod {
+        scope = 1;
+        scopeArsenal = 1;
         class ACE_Actions: ACE_Actions {
             class ACE_MainActions: ACE_MainActions {
                 selection = "machinegunturret_01_mounthide";

--- a/addons/cswCompat/patchGM/CfgWeapons.hpp
+++ b/addons/cswCompat/patchGM/CfgWeapons.hpp
@@ -22,8 +22,8 @@ class CfgWeapons {
         };
         displayName = "[CSW] MILAN (GM)";
         author = "Lambda.Tiger";
-        scope = 2;
-        scopeArsenal = 2;
+        scope = 1;
+        scopeArsenal = 1;
         model = ACE_APL_PATH(ACE_CSW_Bag.p3d);
         modes[] = {};
         picture = "\gm\gm_weapons\gm_launchers\gm_milan\data\ui\picture_gm_milan_launcher_weaponBag_ca";
@@ -45,8 +45,8 @@ class CfgWeapons {
         };
         displayName = "[CSW] Fagot (GM)";
         author = "Lambda.Tiger";
-        scope = 2;
-        scopeArsenal = 2;
+        scope = 1;
+        scopeArsenal = 1;
         model = ACE_APL_PATH(ACE_CSW_Bag.p3d);
         modes[] = {};
         picture = "\gm\gm_weapons\gm_launchers\gm_fagot\data\ui\picture_gm_fagot_launcher_weaponBag_ca";
@@ -71,6 +71,8 @@ class CfgWeapons {
         class WeaponSlotsInfo: WeaponSlotsInfo {};
     };
     class GVAR(gm_MG3TripodCarry): ace_csw_m3CarryTripod {
+        scope = 1;
+        scopeArsenal = 1;
         class ACE_CSW {
             type = "mount";
             deployTime = 4;


### PR DESCRIPTION
This PR hides the Potato GM CSW weapons to prepare for the move of the compat from potato to ACE