### PR TITLE
DUI Compass Settings Update

### DIFF
--- a/addons/settings/BW_Settings.inc.sqf
+++ b/addons/settings/BW_Settings.inc.sqf
@@ -108,7 +108,6 @@ if (["diwako_dui_main"] call ACEFUNC(common,isModLoaded)) then { _settings appen
 ["diwako_dui_indicators_range", 20], // User-Setting
 
 // DUI - Squad Radar - Radar
-["diwako_dui_compassRange", 50, true], // User-Setting (this one sets the starting range)
 ["diwako_dui_compassRangeLimit", 50, true], // this one sets the MAX limit
 ["diwako_dui_radar_compassrangecrew", 75, true], // User-Setting
 ["diwako_dui_enable_compass_dir", 1, true], // User-Setting "Show Bearing = only in vehicles"

--- a/addons/settings/BW_Settings.inc.sqf
+++ b/addons/settings/BW_Settings.inc.sqf
@@ -108,13 +108,14 @@ if (["diwako_dui_main"] call ACEFUNC(common,isModLoaded)) then { _settings appen
 ["diwako_dui_indicators_range", 20], // User-Setting
 
 // DUI - Squad Radar - Radar
+["diwako_dui_compassRange", 50], // User-Setting (this one sets the starting range)
 ["diwako_dui_compassRangeLimit", 50, true], // this one sets the MAX limit
 ["diwako_dui_radar_compassrangecrew", 75, true], // User-Setting
 ["diwako_dui_enable_compass_dir", 1, true], // User-Setting "Show Bearing = only in vehicles"
 ["diwako_dui_radar_sqlfirst", true],
 ["diwako_dui_radar_vehiclecompassenabled", true], // turning back on due to giant marker issue fixed due to below setting
 ["diwako_dui_radar_icon_scale_crew", 1.5, true], // the scaling was set to 6.0, which is why when we enabled the vehicle compass, the icon was massive
-["diwako_dui_distanceWarning", 5, true], // User-Setting
+["diwako_dui_distanceWarning", 5], // User-Setting
 
 // DUI - Squad Radar - Nametags
 ["diwako_dui_nametags_enableocclusion", false, true], // User-Setting

--- a/addons/settings/BW_Settings.inc.sqf
+++ b/addons/settings/BW_Settings.inc.sqf
@@ -45,7 +45,7 @@ _settings = [
 [QACEGVAR(cookoff,ammoCookoffDuration), 0.15],
 [QACEGVAR(dragging,weightCoefficient), 0.25], // allows carry/drag 4x the normal weight
 [QACEGVAR(finger,enabled), true],
-[QACEGVAR(finger,maxrange), 7, true],
+[QACEGVAR(finger,maxrange), 7, true], // still seems to only work when set via the mission settings
 [QACEGVAR(fortify,timeCostCoefficient), 0],
 [QACEGVAR(fortify,timeMin), 0],
 [QACEGVAR(gforces,enabledFor), 0],
@@ -108,11 +108,14 @@ if (["diwako_dui_main"] call ACEFUNC(common,isModLoaded)) then { _settings appen
 ["diwako_dui_indicators_range", 20], // User-Setting
 
 // DUI - Squad Radar - Radar
-["diwako_dui_compassRange", 35, true], // User-Setting
+["diwako_dui_compassRange", 50, true], // User-Setting (this one sets the starting range)
+["diwako_dui_compassRangeLimit", 50, true], // this one sets the MAX limit
 ["diwako_dui_radar_compassrangecrew", 75, true], // User-Setting
 ["diwako_dui_enable_compass_dir", 1, true], // User-Setting "Show Bearing = only in vehicles"
 ["diwako_dui_radar_sqlfirst", true],
-["diwako_dui_radar_vehiclecompassenabled", false], // (getting giant markers if this is on w/ low range, so I think leave off??)
+["diwako_dui_radar_vehiclecompassenabled", true], // turning back on due to giant marker issue fixed due to below setting
+["diwako_dui_radar_icon_scale_crew", 1.5, true], // the scaling was set to 6.0, which is why when we enabled the vehicle compass, the icon was massive
+["diwako_dui_distanceWarning", 5, true], // User-Setting
 
 // DUI - Squad Radar - Nametags
 ["diwako_dui_nametags_enableocclusion", false, true], // User-Setting


### PR DESCRIPTION
- Sets the default visual range of the DUI compass to the current max range (50m)

- Enables the Vehicle Compass again

- Sets the Vehicle Crew compass scale, fixing the previous issue of giant icons in the DUI hud when in a vehicle - this one might need more testing with various UI scales to verify?

- Increases the distance warning from 3m to 5m

The only thing that I really will advocate for is the compass range stuff, everything else was just something I discovered by coincidence when testing and am fine with splitting them up if we don't like the other stuff being on.