### PR TITLE
M136A1 CS-RS + M72A9 (LASM)

### DIFF
--- a/addons/customGear/README.md
+++ b/addons/customGear/README.md
@@ -11,3 +11,7 @@ A mod that serves as a place to put custom gear retextures, new gear items, and 
 - Adds 40x53mm HV M430A1 HEDP and M384 HE grenades for Mk19 and similar grenade launchers
 
 - Adds 40x46mm LV M433 HEDP grenades for M203 and EGLM UGLs
+
+- Adds modern reduced backblast version of the M136 called the M136 CS-RS
+
+- Adds new HEDP/ASM version of the M72A6 LAW called the M72A9 (LASM)

--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -1,0 +1,22 @@
+class CfgAmmo {
+    // Base Classes
+    class ammo_Penetrator_Base;
+    class RocketCore;
+    class RocketBase: RocketCore{};
+    
+    // CUP Inheritances
+    class CUP_R_M72A6_AT: RocketBase {};
+    
+    // M72A9 HEDP Rocket
+    class potato_R_M72A9_HEDP: CUP_R_M72A6_AT {
+        hit = 150;
+        indirectHit = 30;
+        indirectHitRange = 5;
+        warheadName = "HE";
+        submunitionAmmo = "CUP_P_M72A6_AT";
+        cost = 100;
+        explosionEffects = "ATMissileExplosion";
+        airLock = 0; // maybe 1? determines if AI use against air vehicles
+        allowAgainstInfantry = 1;
+    };
+};

--- a/addons/customGear/launchers/CfgMagazines.hpp
+++ b/addons/customGear/launchers/CfgMagazines.hpp
@@ -1,0 +1,17 @@
+class CfgMagazines {
+    // Base Classes
+    class CA_LauncherMagazine;
+    
+    // CUP Inheritances
+    class CUP_M72A6_M: CA_LauncherMagazine {};
+    
+    // M72A9 HEDP magazine
+    class potato_M72A9_M: CUP_M72A6_M {
+        scope = 2;
+        author = "Potato";
+        ammo = "potato_R_M72A9_HEDP";
+        descriptionshort = "Range: 0 - 200 m<br/>Type: HEDP<br/>Used in: M72A9";
+        displayname = "M72A9 (HEDP) Rocket";
+        displaynameshort = "$STR_A3_HEAT_0"; // swap to HEDP?
+    };
+};

--- a/addons/customGear/launchers/CfgWeapons.hpp
+++ b/addons/customGear/launchers/CfgWeapons.hpp
@@ -1,0 +1,102 @@
+class CfgWeapons {
+    // Base Classes
+    class Launcher;
+    class Launcher_Base_F: Launcher {
+        class WeaponSlotsInfo;
+    };
+    
+    // CUP Inheritances
+    class CUP_launch_M136_Loaded: Launcher_Base_F {
+        class WeaponSlotsInfo;
+        class EventHandlers;
+    };
+    class CUP_launch_M136: CUP_launch_M136_Loaded {};
+    class CUP_launch_M136_Used: CUP_launch_M136_Loaded {};
+    class CUP_launch_M72A6_Loaded: Launcher_Base_F {
+        class WeaponSlotsInfo;
+        class EventHandlers;
+    };
+    class CUP_launch_M72A6: CUP_launch_M72A6_Loaded {};
+    class CUP_launch_M72A6_Used: CUP_launch_M72A6_Loaded {};
+    
+    // M136 AT4 Confined Space-Reduced Sensitivity
+    class potato_launch_M136A1_CS_Loaded: CUP_launch_M136_Loaded {
+        author = "Potato";
+        scope = 1;
+        scopeArsenal = 1;
+        displayName = "M136A1 CS-RS";
+        baseWeapon = "potato_launch_M136A1_CS_Loaded";
+        jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
+        AGM_UsedTube = "AGM_launch_M136_Used_F";
+        ace_overpressure_angle = 10;
+        ace_overpressure_damage = 0.5;
+        ace_overpressure_range = 2;
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 177.4;
+        };
+        class EventHandlers {
+            fired = "_this call CBA_fnc_firedDisposable";
+        };
+    };
+    class potato_launch_M136A1_CS: potato_launch_M136A1_CS_Loaded {
+        author = "Potato";
+        baseWeapon = "potato_launch_M136A1_CS";
+        scope = 2;
+        scopeArsenal = 2;
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 177.4;
+        };
+    };
+    class potato_launch_M136A1_CS_Used: potato_launch_M136A1_CS_Loaded {
+        author = "Potato";
+        displayName = "M136A1 CS-RS (Used)";
+        scope = 1;
+        baseWeapon = "potato_launch_M136A1_CS_Used";
+        model = "\CUP\Weapons\CUP_Weapons_M136\CUP_AT4_used.p3d";
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 117.4;
+        };
+    };
+    
+    // M72A9 (Light Anti-Structure Munition)
+    class potato_launch_M72A9_Loaded: CUP_launch_M72A6_Loaded {
+        author = "Potato";
+        scope = 1;
+        scopeArsenal = 1;
+        displayName = "M72A9 (LASM)";
+        baseWeapon = "potato_launch_M72A9_Loaded";
+        jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
+        magazines[] = {"potato_M72A9_M"};
+        descriptionShort = "Anti-structure missile launcher <br/>Unguided";
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            allowedSlots[] = {901};
+			mass = 94.6;
+        };
+        class EventHandlers {
+            fired = "_this call CBA_fnc_firedDisposable";
+        };
+    };
+    class potato_launch_M72A9: potato_launch_M72A9_Loaded {
+        author = "Potato";
+        baseWeapon = "potato_launch_M72A9";
+        scope = 2;
+        scopeArsenal = 2;
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 94.6;
+        };
+    };
+    class potato_launch_M72A9_Used: potato_launch_M72A9_Loaded {
+        author = "Potato";
+        displayName = "M72A9 (LASM) (Used)";
+        scope = 1;
+        baseWeapon = "potato_launch_M72A9_Used";
+        model = "\CUP\Weapons\CUP_Weapons_M72A6\CUP_m72a6_used.p3d";
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 72.4;
+        };
+    };
+};

--- a/addons/customGear/launchers/CfgWeapons.hpp
+++ b/addons/customGear/launchers/CfgWeapons.hpp
@@ -28,9 +28,9 @@ class CfgWeapons {
         baseWeapon = "potato_launch_M136A1_CS_Loaded";
         jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
         AGM_UsedTube = "AGM_launch_M136_Used_F";
-        ace_overpressure_angle = 10;
-        ace_overpressure_damage = 0.5;
-        ace_overpressure_range = 2;
+        ace_overpressure_angle = 15;
+        ace_overpressure_damage = 0.6;
+        ace_overpressure_range = 3;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             mass = 177.4;
         };

--- a/addons/customGear/launchers/CfgWeapons.hpp
+++ b/addons/customGear/launchers/CfgWeapons.hpp
@@ -29,8 +29,8 @@ class CfgWeapons {
         jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
         AGM_UsedTube = "AGM_launch_M136_Used_F";
         ace_overpressure_angle = 15;
-        ace_overpressure_damage = 0.6;
-        ace_overpressure_range = 3;
+        ace_overpressure_damage = 0.5;
+        ace_overpressure_range = 5;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             mass = 177.4;
         };

--- a/addons/customGear/launchers/CfgWeapons.hpp
+++ b/addons/customGear/launchers/CfgWeapons.hpp
@@ -28,9 +28,9 @@ class CfgWeapons {
         baseWeapon = "potato_launch_M136A1_CS_Loaded";
         jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
         AGM_UsedTube = "AGM_launch_M136_Used_F";
-        ace_overpressure_angle = 15;
+        ace_overpressure_angle = 10;
         ace_overpressure_damage = 0.5;
-        ace_overpressure_range = 5;
+        ace_overpressure_range = 4;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             mass = 177.4;
         };

--- a/addons/customGear/launchers/config.cpp
+++ b/addons/customGear/launchers/config.cpp
@@ -1,0 +1,34 @@
+#include "\z\potato\addons\customGear\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT customGear_launchers
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {
+            "potato_launch_M136A1_CS_Loaded",
+            "potato_launch_M136A1_CS",
+            "potato_launch_M136A1_CS_Used",
+            "potato_launch_M72A9_Loaded",
+            "potato_launch_M72A9",
+            "potato_launch_M72A9_Used"
+        };
+        magazines[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = { "potato_core", "CUP_Weapons_LoadOrder", "jsrs_soundmod_complete_edition", "jsrs_soundmod_complete_edition_soundFiles" };
+        skipWhenMissingDependencies = 1;
+        author = "Potato";
+        authors[] = {"AChesheireCat"};
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+class CBA_DisposableLaunchers {
+    potato_launch_M136A1_CS_Loaded[] = {"potato_launch_M136A1_CS","potato_launch_M136A1_CS_Used"};
+    potato_launch_M72A9_Loaded[] = {"potato_launch_M72A9","potato_launch_M72A9_Used"};
+};
+
+#include "CfgWeapons.hpp"
+#include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -434,7 +434,7 @@ class CfgWeapons {
     class CUP_launch_M136_Loaded: Launcher_Base_F {
         ace_overpressure_angle = 45;
         ace_overpressure_damage = 0.5;
-        ace_overpressure_range = 50; // increasing range due to reduction in "lethal" damage - original 10m was described as "lethal"
+        ace_overpressure_range = 50; // increasing range due to reduction in "lethal" damage - original 10m was described as "lethal", irl total backblast range listed as 100m
     };
 };
 

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -426,6 +426,16 @@ class CfgWeapons {
             "CUP_200Rnd_TE1_Red_Tracer_127x99_M"
         };
     };
+    
+    class Launcher;
+    class Launcher_Base_F: Launcher {
+        class WeaponSlotsInfo;
+    };
+    class CUP_launch_M136_Loaded: Launcher_Base_F {
+        ace_overpressure_angle = 45;
+        ace_overpressure_damage = 0.5;
+        ace_overpressure_range = 50; // increasing range due to reduction in "lethal" damage - original 10m was described as "lethal"
+    };
 };
 
 class SlotInfo;


### PR DESCRIPTION
- Tweaked CUP M136 backblast range up to 50m from 10m in order to better represent original M136 backblast range (total 100m, lethal 10-20m)

- Adds a CUP AT4 copy that has reduced backblast range and angle to represent an AT4CS that can be used inside of buildings

- Adds a CUP M72A6 copy that replicates the M72A9 LASM HEDP/ASM launcher