### PR TITLE
RHS T-72 Ammo Buffs

### DIFF
--- a/addons/miscFixes/patchRHSAFRF/CfgAmmo.hpp
+++ b/addons/miscFixes/patchRHSAFRF/CfgAmmo.hpp
@@ -36,30 +36,25 @@ class CfgAmmo {
     
     // Base Classes
     class Sh_125mm_APFSDS;
-    class rhs_ammo_bm_base: Sh_125mm_APFSDS {};
-    class rhs_ammo_3bm_base: rhs_ammo_bm_base {};
+    class rhs_ammo_ap_penetrator: Sh_125mm_APFSDS {};
     
     // 3BM42 - used by T-72B (original)
-    class rhs_ammo_3bm42: rhs_ammo_3bm_base {
-        caliber = 19.2157; // was 0.1
-        hit = 520; // was nil
+    class rhs_ammo_3bm42_penetrator: rhs_ammo_ap_penetrator {
+        hit = 520; // was 250
     };
     
     // 3BM42M "Mango" - used by T-72B (1985)
-    class rhs_ammo_3bm42m: rhs_ammo_3bm_base {
-        caliber = 24.7619; // was 0.1
-        hit = 542.2; // was nil
+    class rhs_ammo_3bm42m_penetrator: rhs_ammo_ap_penetrator {
+        hit = 542.2; // was 270
     };
     
-    // 3BM46 - used by T-72B3
-    class rhs_ammo_3bm46: rhs_ammo_3bm_base {
-        caliber = 26.7059; // was 0.1
-        hit = 626.8; // was nil
+    // 3BM46 - used by T-72B3  
+    class rhs_ammo_3bm46_penetrator: rhs_ammo_ap_penetrator {
+        hit = 626.8; // was 300
     };
     
-    // 3BM69 - used by T90
-    class rhs_ammo_3bm69: rhs_ammo_3bm_base {
-        caliber = 33.6842; // was 0.1
-        hit = 858.16; // was nil
+    // 3BM69 - used by T90+
+    class rhs_ammo_3bm69_penetrator: rhs_ammo_ap_penetrator {
+        hit = 858.16; // was 300
     };
 };

--- a/addons/miscFixes/patchRHSAFRF/CfgAmmo.hpp
+++ b/addons/miscFixes/patchRHSAFRF/CfgAmmo.hpp
@@ -33,4 +33,33 @@ class CfgAmmo {
             enabled = 0;
         };
     };
+    
+    // Base Classes
+    class Sh_125mm_APFSDS;
+    class rhs_ammo_bm_base: Sh_125mm_APFSDS {};
+    class rhs_ammo_3bm_base: rhs_ammo_bm_base {};
+    
+    // 3BM42 - used by T-72B (original)
+    class rhs_ammo_3bm42: rhs_ammo_3bm_base {
+        caliber = 19.2157; // was 0.1
+        hit = 520; // was nil
+    };
+    
+    // 3BM42M "Mango" - used by T-72B (1985)
+    class rhs_ammo_3bm42m: rhs_ammo_3bm_base {
+        caliber = 24.7619; // was 0.1
+        hit = 542.2; // was nil
+    };
+    
+    // 3BM46 - used by T-72B3
+    class rhs_ammo_3bm46: rhs_ammo_3bm_base {
+        caliber = 26.7059; // was 0.1
+        hit = 626.8; // was nil
+    };
+    
+    // 3BM69 - used by T90
+    class rhs_ammo_3bm69: rhs_ammo_3bm_base {
+        caliber = 33.6842; // was 0.1
+        hit = 858.16; // was nil
+    };
 };


### PR DESCRIPTION
- Increases caliber and adds hit values to RHS T-72/T-90 rounds comparable to CUP values for same/similar rounds

- In testing, this allowed for RHS tanks to actually penetrate and kill CUP/CWR3 M60A3s and in some cases (3BM46 and 69) penetrate CUP/CWR3 M1A1s

- Rounds might be a little overtuned due to the submunitions also having hit values, but imo this at least makes RHS tanks usable against certain CUP assets