### PR TITLE
Armor Mod - Adjust for ace 3.20 changes

### DIFF
--- a/addons/armor_modifier_ace/XEH_PREP.hpp
+++ b/addons/armor_modifier_ace/XEH_PREP.hpp
@@ -1,3 +1,5 @@
+PREP(getHitpointArmor);
+PREP(getItemArmor);
 PREP(handleDamage);
 PREP(resolveHitPoints);
 PREP(setClassArmor);

--- a/addons/armor_modifier_ace/XEH_preInit.sqf
+++ b/addons/armor_modifier_ace/XEH_preInit.sqf
@@ -9,4 +9,7 @@ GVAR(defaultArmorHash) = DEFAULT_HASH_SETTINGS;
 // CBA Settings
 #include "initSettings.inc.sqf"
 
+// for getItemArmor funcs from ace
+GVAR(armorCache) = createHashMap;
+
 ADDON = true;

--- a/addons/armor_modifier_ace/functions/fnc_getHitpointArmor.sqf
+++ b/addons/armor_modifier_ace/functions/fnc_getHitpointArmor.sqf
@@ -1,0 +1,55 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Pterolatypus, LinkIsGrim
+ * (This file is a copy from ACE3 3.19)
+ * Checks a unit's equipment to calculate the total armor on a hitpoint.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ * 1: Hitpoint <STRING>
+ *
+ * Return Value:
+ * Total armor and scaled armor for the given hitpoint <ARRAY of NUMBERs>
+ *
+ * Example:
+ * [player, "HitChest"] call potato_armor_modifier_ace_fnc_getHitpointArmor
+ *
+ * Public: No
+ */
+
+params ["_unit", "_hitpoint"];
+
+private _uniform = uniform _unit;
+// If unit is naked, use its underwear class instead
+if (_uniform isEqualTo "") then {
+    _uniform = getText (configOf _unit >> "nakedUniform");
+};
+
+private _gear = [
+    _uniform,
+    vest _unit,
+    headgear _unit
+];
+
+private _rags = _gear joinString "$";
+private _var = format [QGVAR(armorCache$%1), _hitpoint];
+_unit getVariable [_var, ["", 0, 0]] params ["_prevRags", "_armor", "_armorScaled"];
+
+if (_rags != _prevRags) then {
+    _armor = 0;
+    _armorScaled = 0;
+
+    {
+        ([_x, _hitpoint] call FUNC(getItemArmor)) params ["_itemArmor", "_itemArmorScaled"];
+        _armor = _armor + _itemArmor;
+        _armorScaled = _armorScaled + _itemArmorScaled;
+    } forEach _gear;
+
+    // Armor should be at least 1 to prevent dividing by 0
+    _armor = _armor max 1;
+    _armorScaled = _armorScaled max 1;
+
+    _unit setVariable [_var, [_rags, _armor, _armorScaled]];
+};
+
+[_armor, _armorScaled] // return

--- a/addons/armor_modifier_ace/functions/fnc_getItemArmor.sqf
+++ b/addons/armor_modifier_ace/functions/fnc_getItemArmor.sqf
@@ -1,0 +1,70 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Pterolatypus, LinkIsGrim
+ * Returns the regular and scaled armor values the given item provides to a particular hitpoint, either from a cache or by reading the item config.
+ *
+ * Arguments:
+ * 0: Item Class <STRING>
+ * 1: Hitpoint <STRING>
+ *
+ * Return Value:
+ * Regular and scaled item armor for the given hitpoint <ARRAY of NUMBERs>
+ *
+ * Example:
+ * ["V_PlateCarrier_rgr", "HitChest"] call potato_armor_modifier_ace_fnc_getItemArmor
+ *
+ * Public: No
+ */
+
+params ["_item", "_hitpoint"];
+
+private _key = format ["%1$%2", _item, _hitpoint];
+private _return = GVAR(armorCache) get _key;
+
+if (isNil "_return") then {
+    private _armor = 0;
+    private _armorScaled = 0;
+    private _passThrough = 1;
+    TRACE_2("Cache miss",_item,_hitpoint);
+    if ("" in [_item, _hitpoint]) exitWith {
+        _return = [_armor, _armorScaled];
+        GVAR(armorCache) set [_key, _return];
+    };
+
+    private _itemInfo = configFile >> "CfgWeapons" >> _item >> "ItemInfo";
+    private _itemType = getNumber (_itemInfo >> "type");
+    private _passThroughEffect = [1, 0.6] select (_itemType == TYPE_VEST);
+
+    if (_itemType == TYPE_UNIFORM) then {
+        private _unitCfg = configFile >> "CfgVehicles" >> getText (_itemInfo >> "uniformClass");
+        if (_hitpoint == "#structural") then {
+            // TODO: I'm not sure if this should be multiplied by the base armor value or not
+            _armor = getNumber (_unitCfg >> "armorStructural");
+        } else {
+            private _entry = _unitCfg >> "HitPoints" >> _hitpoint;
+            _armor = getNumber (_unitCfg >> "armor") * (1 max getNumber (_entry >> "armor"));
+            _passThrough = 0.1 max getNumber (_entry >> "passThrough") min 1; // prevent dividing by 0
+        };
+    } else {
+        private _condition = format ["getText (_x >> 'hitpointName') == '%1'", _hitpoint];
+        private _entry = configProperties [_itemInfo >> "HitpointsProtectionInfo", _condition] param [0, configNull];
+        if (!isNull _entry) then {
+            _armor = getNumber (_entry >> "armor");
+            _passThrough = 0.1 max getNumber (_entry >> "passThrough") min 1;
+        };
+    };
+
+    // Scale armor using passthrough to fix explosive-resistant armor (#9063)
+    // Skip scaling for uniforms and items that don't cover the hitpoint to prevent infinite armor
+    if (_armor > 0) then {
+        if (_itemType == TYPE_UNIFORM) then {
+            _armorScaled = _armor;
+        } else {
+            _armorScaled = (log (_armor / (_passThrough ^ _passThroughEffect))) * 10;
+        };
+    };
+    _return = [_armor, _armorScaled];
+    GVAR(armorCache) set [_key, _return];
+};
+
+_return // return

--- a/addons/armor_modifier_ace/functions/fnc_handleDamage.sqf
+++ b/addons/armor_modifier_ace/functions/fnc_handleDamage.sqf
@@ -62,16 +62,11 @@ if (_context != 2 && {_context == 4 || _newDamage == 0}) exitWith {
     _oldDamage
 };
 
-// Get scaled armor value of hitpoint and calculate damage before armor
+// Get armor value of hitpoint and calculate damage before armor
 // We scale using passThrough to handle explosive-resistant armor properly (#9063)
 // We need realDamage to determine which limb was hit correctly
-[_unit, _hitpoint] call ACEFUNC(medical_engine,getHitpointArmor) params ["_armor", "_armorScaled"];
+[_unit, _hitpoint] call FUNC(getHitpointArmor) params ["_armor"];
 private _realDamage = _newDamage * _armor;
-if (!_structuralDamage) then {
-    private _armorCoef = _armor/_armorScaled;
-    private _damageCoef = linearConversion [0, 1, ACEGVAR(medical_engine,damagePassThroughEffect), 1, _armorCoef];
-    _newDamage = _newDamage * _damageCoef;
-};
 TRACE_6("Received hit",_hitpoint,_ammo,_newDamage,_realDamage,_directHit,_context);
 
 // Drowning doesn't fire the EH for each hitpoint so the "ace_hdbracket" code never runs

--- a/addons/settings/BW_Settings.inc.sqf
+++ b/addons/settings/BW_Settings.inc.sqf
@@ -26,7 +26,7 @@ _settings = [
 [QACEGVAR(medical_treatment,treatmentTimeTrainedTourniquet), 4], // default: 7
 [QACEGVAR(medical_treatment,allowSharedEquipment), 3], // default: 0 (allows trained medics to use their own items first)
 
-["ace_medical_engine_damagepassthrougheffect", 0],
+[QACEGVAR(medical,alternateArmorPenetration), false],
 
 // Medical Extras:
 [QACEGVAR(medical_ai,enabledFor), 0],

--- a/addons/settings/XEH_preInit.sqf
+++ b/addons/settings/XEH_preInit.sqf
@@ -47,7 +47,7 @@ if (isServer) then {
         };
 
         // report specific medical settings
-        private _log = format ["[AMA=%1] [aDmgPass=%2]", potato_armor_modifier_ace, ace_medical_engine_damagePassThroughEffect toFixed 2];
+        private _log = format ["[AMA=%1] [altPen=%2]", potato_armor_modifier_ace, ACEGVAR(medical,alternateArmorPenetration)];
         ["potato_adminMsg", [_log, "Mission"]] call CBA_fnc_globalEvent;
     }, [_settings], 4] call CBA_fnc_waitAndExecute;
 


### PR DESCRIPTION
ref https://github.com/acemod/ACE3/issues/9217

copies changes to handleDamage and fully copies old versions of getHitpointArmor funcs

test code (captured from shooting AI in chest)
results in same wounds from before
```
{
    _x call potato_armor_modifier_ace_fnc_handleDamage;
} forEach [[[q2,"head",0,q1,"B_65x39_Caseless",2,q1,"hithead",true,3]],[[q2,"",0.464393,q1,"B_65x39_Caseless",-1,q1,"",true,4]],[[q2,"",0.464393,q1,"B_65x39_Caseless",-1,q1,"",true,0]],[[q2,"face_hub",0.0133762,q1,"B_65x39_Caseless",0,q1,"hitface",true,1]],[[q2,"neck",0.0110848,q1,"B_65x39_Caseless",1,q1,"hitneck",true,1]],[[q2,"spine2",0.114368,q1,"B_65x39_Caseless",5,q1,"hitdiaphragm",true,1]],[[q2,"spine3",0.114368,q1,"B_65x39_Caseless",6,q1,"hitchest",true,1]],[[q2,"arms",0.0108112,q1,"B_65x39_Caseless",8,q1,"hitarms",true,1]],[[q2,"hands",0.0145445,q1,"B_65x39_Caseless",9,q1,"hithands",true,1]],[[q2,"body",0.000800845,q1,"B_65x39_Caseless",11,q1,"incapacitated",true,1]],[[q2,"hand_l",0.0252261,q1,"B_65x39_Caseless",12,q1,"hitleftarm",true,1]],[[q2,"hand_r",0.0245016,q1,"B_65x39_Caseless",13,q1,"hitrightarm",true,2]]]
```

