### PR TITLE
miscFixes - PhotonVFX - Settings Revert to Vanilla to Minimie Particle Deletion

### DIFF
--- a/addons/miscFixes/patchPhoton/CfgVideoOptions.hpp
+++ b/addons/miscFixes/patchPhoton/CfgVideoOptions.hpp
@@ -1,0 +1,14 @@
+
+class CfgVideoOptions {
+    class Particles {
+        class Low {
+            smokeZoomCoef = 1.42857;
+        };
+        class Normal {
+            smokeZoomCoef = 1.42857;
+        };
+        class High {
+            smokeZoomCoef = 1.42857;
+        };
+    };
+};

--- a/addons/miscFixes/patchPhoton/CfgVideoOptions.hpp
+++ b/addons/miscFixes/patchPhoton/CfgVideoOptions.hpp
@@ -1,4 +1,3 @@
-
 class CfgVideoOptions {
     class Particles {
         class Low {

--- a/addons/miscFixes/patchPhoton/config.cpp
+++ b/addons/miscFixes/patchPhoton/config.cpp
@@ -1,0 +1,21 @@
+#include "\z\potato\addons\miscFixes\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT miscFixes_patchPhotonVFX
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "ANZ_MissileEfxMod",
+            "WNZ_SparksFX"
+        };
+        skipWhenMissingDependencies = 1;
+        author = "Bourbon Warfare";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVideoOptions.hpp"


### PR DESCRIPTION
This PR does what the name says and returns the Low, Normal, and High particle settings back to vanilla values.