### PR TITLE
M249 Recoil Re-Adjustment

### DIFF
--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -244,28 +244,22 @@ class CfgRecoils {
         permanent = 0.1;
         temporary = 0.005;
     };
-    class GVAR(recoil_SAW): recoil_default { // original modified saw recoil
-        muzzleOuter[] = {0.8,1.4,0.35,0.25};
+    class GVAR(recoil_SAW): recoil_default { // testing +15% muzzleOuter x,y
+        muzzleOuter[] = {0.59,1.04,0.29,0.21};
         kickBack[] = {0.015,0.02};
-        permanent = 0.08;
-        temporary = 0.005;
+        permanent = 0.03;
+        temporary = 0.015;
     };
-    class GVAR(recoil_SAW_2): recoil_default { // testing weird shit v2
+    class GVAR(recoil_SAW_2): recoil_default { // the one
         muzzleOuter[] = {0.52,0.91,0.29,0.21};
         kickBack[] = {0.015,0.02};
         permanent = 0.03;
         temporary = 0.015;
     };
-    class GVAR(recoil_SAW_3): recoil_default { // 35% reduced vertical and horizontal recoil
-        muzzleOuter[] = {0.52,0.91,0.35,0.21};
+    class GVAR(recoil_SAW_3): recoil_default { // increasing permanent value
+        muzzleOuter[] = {0.52,0.91,0.29,0.21};
         kickBack[] = {0.015,0.02};
-        permanent = 0.08;
-        temporary = 0.005;
-    };
-    class GVAR(recoil_SAW_4): recoil_default { // testing weird shit
-        muzzleOuter[] = {0.52,0.91,0.35,0.25};
-        kickBack[] = {0.015,0.02};
-        permanent = 0.03;
+        permanent = 0.038;
         temporary = 0.015;
     };
     class GVAR(recoil_uk59): recoil_default {
@@ -361,9 +355,6 @@ class CfgWeapons {
     };
     class CUP_lmg_m249_pip3: CUP_lmg_minimi_railed {
         recoil = QGVAR(recoil_SAW_3);
-    };
-    class CUP_lmg_m249_pip4: CUP_lmg_minimi_railed {
-        recoil = QGVAR(recoil_SAW_4);
     };
     class CUP_smg_MP7: Rifle_Short_Base_F { // Applies the APEX dlc MP5 recoil to the CUP MP7
         recoil = "recoil_smg_05";

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -250,11 +250,11 @@ class CfgRecoils {
         permanent = 0.08;
         temporary = 0.005;
     };
-    class GVAR(recoil_SAW_2): recoil_default { // 15% reduced vertical and horizontal recoil
-        muzzleOuter[] = {0.68,1.19,0.35,0.21};
-        kickBack[] = {0.015,0.02};
-        permanent = 0.08;
-        temporary = 0.005;
+    class GVAR(recoil_SAW_2): recoil_default { // testing weird shit v2
+        muzzleOuter[] = {0.52,0.91,0.35,0.25};
+        kickBack[] = {0.018,0.023};
+        permanent = 0.03;
+        temporary = 0.015;
     };
     class GVAR(recoil_SAW_3): recoil_default { // 35% reduced vertical and horizontal recoil
         muzzleOuter[] = {0.52,0.91,0.35,0.21};

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -244,7 +244,7 @@ class CfgRecoils {
         permanent = 0.1;
         temporary = 0.005;
     };
-    class GVAR(recoil_SAW): recoil_default { // testing +15% muzzleOuter x,y
+    class GVAR(recoil_SAW): recoil_default { // testing +15% muzzleOuter x,y (my favorite, more bouncy but less mouse control needed)
         muzzleOuter[] = {0.59,1.04,0.29,0.21};
         kickBack[] = {0.015,0.02};
         permanent = 0.03;
@@ -262,7 +262,7 @@ class CfgRecoils {
         permanent = 0.038;
         temporary = 0.015;
     };
-    class GVAR(recoil_SAW_4): recoil_default { // 35% reduced vertical and horizontal recoil
+    class GVAR(recoil_SAW_4): recoil_default { // 35% reduced vertical and horizontal recoil (my second favorite, harder to keep on target but still "controllable" in the vertical)
         muzzleOuter[] = {0.52,0.91,0.35,0.21};
         kickBack[] = {0.015,0.02};
         permanent = 0.08;

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -251,16 +251,16 @@ class CfgRecoils {
         temporary = 0.005;
     };
     class GVAR(recoil_SAW_2): recoil_default { // testing weird shit v2
-        muzzleOuter[] = {0.52,0.91,0.35,0.25};
+        muzzleOuter[] = {0.442,0.7735,0.2975,0.2125};
         kickBack[] = {0.015,0.02};
-        permanent = 0.03;
-        temporary = 0.015;
+        permanent = 0.04;
+        temporary = 0.02;
     };
-    class GVAR(recoil_SAW_2prone): recoil_default { // testing weird shit v2
+    class GVAR(recoil_SAW_2prone): recoil_default {
         muzzleOuter[] = {0.26,0.455,0.175,0.125};
         kickBack[] = {0.0075,0.01};
         permanent = 0.015;
-        temporary = 0.0075;
+        temporary = 0.005;
     };
     class GVAR(recoil_SAW_3): recoil_default { // 35% reduced vertical and horizontal recoil
         muzzleOuter[] = {0.52,0.91,0.35,0.21};
@@ -270,9 +270,9 @@ class CfgRecoils {
     };
     class GVAR(recoil_SAW_4): recoil_default { // testing weird shit
         muzzleOuter[] = {0.52,0.91,0.35,0.25};
-        kickBack[] = {0.018,0.023};
+        kickBack[] = {0.015,0.02};
         permanent = 0.03;
-        temporary = 0.013;
+        temporary = 0.015;
     };
     class GVAR(recoil_uk59): recoil_default {
         muzzleOuter[] = {0.71,1.22,0.35,0.55};

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -251,22 +251,10 @@ class CfgRecoils {
         temporary = 0.005;
     };
     class GVAR(recoil_SAW_2): recoil_default { // testing weird shit v2
-        muzzleOuter[] = {0.52,0.91,0.35,0.25};
+        muzzleOuter[] = {0.52,0.91,0.29,0.21};
         kickBack[] = {0.015,0.02};
         permanent = 0.03;
         temporary = 0.015;
-    };
-    class GVAR(recoil_SAW_2prone): recoil_default {
-        muzzleOuter[] = {0.1,0.3,0.2,0.2};
-        kickBack[] = {0.01,0.03};
-        permanent = 0.04;
-        temporary = 0.005;
-    };
-    class GVAR(recoil_SAW_2prone_old): recoil_default {
-        muzzleOuter[] = {0.26,0.455,0.175,0.125};
-        kickBack[] = {0.0075,0.01};
-        permanent = 0.015;
-        temporary = 0.005;
     };
     class GVAR(recoil_SAW_3): recoil_default { // 35% reduced vertical and horizontal recoil
         muzzleOuter[] = {0.52,0.91,0.35,0.21};
@@ -370,7 +358,6 @@ class CfgWeapons {
     class CUP_lmg_minimi_railed: CUP_lmg_minimipara {};
     class CUP_lmg_m249_pip2: CUP_lmg_minimi_railed {
         recoil = QGVAR(recoil_SAW_2);
-        recoilProne = QGVAR(recoil_SAW_2prone);
     };
     class CUP_lmg_m249_pip3: CUP_lmg_minimi_railed {
         recoil = QGVAR(recoil_SAW_3);

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -252,7 +252,7 @@ class CfgRecoils {
     };
     class GVAR(recoil_SAW_2): recoil_default { // testing weird shit v2
         muzzleOuter[] = {0.52,0.91,0.35,0.25};
-        kickBack[] = {0.018,0.023};
+        kickBack[] = {0.015,0.02};
         permanent = 0.03;
         temporary = 0.015;
     };

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -251,12 +251,18 @@ class CfgRecoils {
         temporary = 0.005;
     };
     class GVAR(recoil_SAW_2): recoil_default { // testing weird shit v2
-        muzzleOuter[] = {0.442,0.7735,0.2975,0.2125};
+        muzzleOuter[] = {0.52,0.91,0.35,0.25};
         kickBack[] = {0.015,0.02};
-        permanent = 0.04;
-        temporary = 0.02;
+        permanent = 0.03;
+        temporary = 0.015;
     };
     class GVAR(recoil_SAW_2prone): recoil_default {
+        muzzleOuter[] = {0.1,0.3,0.2,0.2};
+        kickBack[] = {0.01,0.03};
+        permanent = 0.04;
+        temporary = 0.005;
+    };
+    class GVAR(recoil_SAW_2prone_old): recoil_default {
         muzzleOuter[] = {0.26,0.455,0.175,0.125};
         kickBack[] = {0.0075,0.01};
         permanent = 0.015;

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -244,11 +244,29 @@ class CfgRecoils {
         permanent = 0.1;
         temporary = 0.005;
     };
-    class GVAR(recoil_SAW): recoil_default {
+    class GVAR(recoil_SAW): recoil_default { // original modified saw recoil
         muzzleOuter[] = {0.8,1.4,0.35,0.25};
         kickBack[] = {0.015,0.02};
         permanent = 0.08;
         temporary = 0.005;
+    };
+    class GVAR(recoil_SAW_2): recoil_default { // 15% reduced vertical and horizontal recoil
+        muzzleOuter[] = {0.68,1.19,0.35,0.21};
+        kickBack[] = {0.015,0.02};
+        permanent = 0.08;
+        temporary = 0.005;
+    };
+    class GVAR(recoil_SAW_3): recoil_default { // 35% reduced vertical and horizontal recoil
+        muzzleOuter[] = {0.52,0.91,0.35,0.21};
+        kickBack[] = {0.015,0.02};
+        permanent = 0.08;
+        temporary = 0.005;
+    };
+    class GVAR(recoil_SAW_4): recoil_default { // testing weird shit
+        muzzleOuter[] = {0.52,0.91,0.35,0.25};
+        kickBack[] = {0.018,0.023};
+        permanent = 0.03;
+        temporary = 0.013;
     };
     class GVAR(recoil_uk59): recoil_default {
         muzzleOuter[] = {0.71,1.22,0.35,0.55};
@@ -336,6 +354,16 @@ class CfgWeapons {
     class CUP_saw_base;
     class CUP_lmg_minimipara: CUP_saw_base { // Applies good cool M249 custom recoil values defined in cfgrecoil
         recoil = QGVAR(recoil_SAW);
+    };
+    class CUP_lmg_minimi_railed: CUP_lmg_minimipara {};
+    class CUP_lmg_m249_pip2: CUP_lmg_minimi_railed {
+        recoil = QGVAR(recoil_SAW_2);
+    };
+    class CUP_lmg_m249_pip3: CUP_lmg_minimi_railed {
+        recoil = QGVAR(recoil_SAW_3);
+    };
+    class CUP_lmg_m249_pip4: CUP_lmg_minimi_railed {
+        recoil = QGVAR(recoil_SAW_4);
     };
     class CUP_smg_MP7: Rifle_Short_Base_F { // Applies the APEX dlc MP5 recoil to the CUP MP7
         recoil = "recoil_smg_05";

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -244,29 +244,11 @@ class CfgRecoils {
         permanent = 0.1;
         temporary = 0.005;
     };
-    class GVAR(recoil_SAW): recoil_default { // testing +15% muzzleOuter x,y (my favorite, more bouncy but less mouse control needed)
+    class GVAR(recoil_SAW): recoil_default {
         muzzleOuter[] = {0.59,1.04,0.29,0.21};
         kickBack[] = {0.015,0.02};
         permanent = 0.03;
         temporary = 0.015;
-    };
-    class GVAR(recoil_SAW_2): recoil_default { // the one
-        muzzleOuter[] = {0.52,0.91,0.29,0.21};
-        kickBack[] = {0.015,0.02};
-        permanent = 0.03;
-        temporary = 0.015;
-    };
-    class GVAR(recoil_SAW_3): recoil_default { // increasing permanent value
-        muzzleOuter[] = {0.52,0.91,0.29,0.21};
-        kickBack[] = {0.015,0.02};
-        permanent = 0.038;
-        temporary = 0.015;
-    };
-    class GVAR(recoil_SAW_4): recoil_default { // 35% reduced vertical and horizontal recoil (my second favorite, harder to keep on target but still "controllable" in the vertical)
-        muzzleOuter[] = {0.52,0.91,0.35,0.21};
-        kickBack[] = {0.015,0.02};
-        permanent = 0.08;
-        temporary = 0.005;
     };
     class GVAR(recoil_uk59): recoil_default {
         muzzleOuter[] = {0.71,1.22,0.35,0.55};
@@ -354,16 +336,6 @@ class CfgWeapons {
     class CUP_saw_base;
     class CUP_lmg_minimipara: CUP_saw_base { // Applies good cool M249 custom recoil values defined in cfgrecoil
         recoil = QGVAR(recoil_SAW);
-    };
-    class CUP_lmg_minimi_railed: CUP_lmg_minimipara {};
-    class CUP_lmg_m249_pip2: CUP_lmg_minimi_railed {
-        recoil = QGVAR(recoil_SAW_2);
-    };
-    class CUP_lmg_m249_pip3: CUP_lmg_minimi_railed {
-        recoil = QGVAR(recoil_SAW_3);
-    };
-    class CUP_lmg_m249_pip4: CUP_lmg_minimi_railed {
-        recoil = QGVAR(recoil_SAW_4);
     };
     class CUP_smg_MP7: Rifle_Short_Base_F { // Applies the APEX dlc MP5 recoil to the CUP MP7
         recoil = "recoil_smg_05";

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -262,6 +262,12 @@ class CfgRecoils {
         permanent = 0.038;
         temporary = 0.015;
     };
+    class GVAR(recoil_SAW_4): recoil_default { // 35% reduced vertical and horizontal recoil
+        muzzleOuter[] = {0.52,0.91,0.35,0.21};
+        kickBack[] = {0.015,0.02};
+        permanent = 0.08;
+        temporary = 0.005;
+    };
     class GVAR(recoil_uk59): recoil_default {
         muzzleOuter[] = {0.71,1.22,0.35,0.55};
         kickBack[] = {0.026,0.064};
@@ -355,6 +361,9 @@ class CfgWeapons {
     };
     class CUP_lmg_m249_pip3: CUP_lmg_minimi_railed {
         recoil = QGVAR(recoil_SAW_3);
+    };
+    class CUP_lmg_m249_pip4: CUP_lmg_minimi_railed {
+        recoil = QGVAR(recoil_SAW_4);
     };
     class CUP_smg_MP7: Rifle_Short_Base_F { // Applies the APEX dlc MP5 recoil to the CUP MP7
         recoil = "recoil_smg_05";

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -256,6 +256,12 @@ class CfgRecoils {
         permanent = 0.03;
         temporary = 0.015;
     };
+    class GVAR(recoil_SAW_2prone): recoil_default { // testing weird shit v2
+        muzzleOuter[] = {0.26,0.455,0.175,0.125};
+        kickBack[] = {0.0075,0.01};
+        permanent = 0.015;
+        temporary = 0.0075;
+    };
     class GVAR(recoil_SAW_3): recoil_default { // 35% reduced vertical and horizontal recoil
         muzzleOuter[] = {0.52,0.91,0.35,0.21};
         kickBack[] = {0.015,0.02};
@@ -358,6 +364,7 @@ class CfgWeapons {
     class CUP_lmg_minimi_railed: CUP_lmg_minimipara {};
     class CUP_lmg_m249_pip2: CUP_lmg_minimi_railed {
         recoil = QGVAR(recoil_SAW_2);
+        recoilProne = QGVAR(recoil_SAW_2prone);
     };
     class CUP_lmg_m249_pip3: CUP_lmg_minimi_railed {
         recoil = QGVAR(recoil_SAW_3);


### PR DESCRIPTION
Adjusts the previous CUP M249 recoil adjustment to be tuned down following [feedback in the discord.](https://discord.com/channels/204621032428929025/1393171695401173083)

This changes the recoil from a significant permanent up-and-to-the-right recoil to a much softer temporary "bouncy" recoil. The intent is to reduce the need to control the recoil with the mouse, but still prevent the M249 from being a laser beam @ 100m.