### PR TITLE
CUP Boxer HMG rollback

### DIFF
--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -100,7 +100,7 @@ class CfgVehicles {
     class CUP_nM1025_SOV_Base: CUP_nHMMWV_Base {
         attenuationEffectType = "OpenCarAttenuation";
     };
-    // Tweaks to the GTK Boxer's handling (accel/braking) + HMG swap to M3M + countermeasures move to gunner
+    // Tweaks to the GTK Boxer's handling (accel/braking) + countermeasures move to gunner
     class Wheeled_APC_F: Car_F {
         class NewTurret;
         class Turrets {
@@ -123,8 +123,8 @@ class CfgVehicles {
     class CUP_Boxer_Base_HMG: CUP_Boxer_Base {
         class Turrets {
             class MainTurret: NewTurret {
-                weapons[] = {"CUP_Vhmg_M3P_veh","SmokeLauncher"}; // was CUP_Vhmg_M2_veh
-                magazines[] = {"CUP_200Rnd_TE1_Red_Tracer_127x99_M", "CUP_200Rnd_TE1_Red_Tracer_127x99_M", "CUP_200Rnd_TE1_Red_Tracer_127x99_M", "CUP_200Rnd_TE1_Red_Tracer_127x99_M", "CUP_200Rnd_TE1_Red_Tracer_127x99_M", "CUP_200Rnd_TE1_Red_Tracer_127x99_M", "SmokeLauncherMag"}; // was CUP_200Rnd_TE1_Red_Tracer_127x99_M
+                weapons[] = {"CUP_Vhmg_M2_veh","SmokeLauncher"};
+                magazines[] = {"CUP_100Rnd_TE4_Red_Tracer_127x99_M","CUP_100Rnd_TE4_Red_Tracer_127x99_M","CUP_100Rnd_TE4_Red_Tracer_127x99_M","CUP_100Rnd_TE4_Red_Tracer_127x99_M","CUP_100Rnd_TE4_Red_Tracer_127x99_M","CUP_100Rnd_TE4_Red_Tracer_127x99_M","CUP_100Rnd_TE4_Red_Tracer_127x99_M","CUP_100Rnd_TE4_Red_Tracer_127x99_M","SmokeLauncherMag"}; // was CUP_200Rnd_TE1_Red_Tracer_127x99_M
             };
             class CommanderTurret: NewTurret {
                 weapons[] = {}; // was "SmokeLauncher"
@@ -139,20 +139,6 @@ class CfgVehicles {
             class wheel_1_1 {
                 maxBrakeTorque = 20000; // was 12500
                 maxHandBrakeTorque = 30000; // was 25000
-            };
-        };
-        class AnimationSources: AnimationSources {
-            class main_gun_muzzle_rot {
-                weapon = "CUP_Vhmg_M3P_veh";
-            };
-            class main_gun_reload {
-                weapon="CUP_Vhmg_M3P_veh";
-            };
-            class main_gun_reload_mag {
-                weapon="CUP_Vhmg_M3P_veh";
-            };
-            class main_gun_revolving {
-                weapon="CUP_Vhmg_M3P_veh";
             };
         };
     };
@@ -359,24 +345,6 @@ class CfgWeapons {
     class CUP_Vhmg_AGS30_veh;
     class CUP_Vgmg_MK19_veh: CUP_Vhmg_AGS30_veh {
         magazineWell[] += {"potato_HV_40x53mm"};
-    };
-
-    // Boxer HMG weapon
-    class CUP_Vhmg_M2_veh;
-    class CUP_Vhmg_M3P_veh: CUP_Vhmg_M2_veh {
-         magazines[] = {
-            "CUP_250Rnd_TE1_Red_Tracer_127x99_M", // CUP_Vhmg_M3P_veh default
-            "CUP_100Rnd_127x99_M", // rest from CUP_Vhmg_M2_veh
-            "CUP_100Rnd_TE4_Red_Tracer_127x99_M",
-            "CUP_100Rnd_TE4_Green_Tracer_127x99_M",
-            "CUP_100Rnd_TE4_Yellow_Tracer_127x99_M",
-            "CUP_100Rnd_TE4_White_Tracer_127x99_M",
-            "CUP_100Rnd_TE1_Red_Tracer_127x99_M",
-            "CUP_100Rnd_TE1_Green_Tracer_127x99_M",
-            "CUP_100Rnd_TE1_Yellow_Tracer_127x99_M",
-            "CUP_100Rnd_TE1_White_Tracer_127x99_M",
-            "CUP_200Rnd_TE1_Red_Tracer_127x99_M"
-        };
     };
 
     // M47 Dragon Optic Zoom

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -118,7 +118,6 @@ class CfgVehicles {
                 radius = 0.1;
             };
         };
-        class AnimationSources;
     };
     class CUP_Boxer_Base_HMG: CUP_Boxer_Base {
         class Turrets {


### PR DESCRIPTION
Previous change was incorrect/unrealistic - the Bundeswehr does not equip their Boxer APCs (with the FLW-200 RCWS) with the M3M but rather the M2HB QCB variant which does NOT use the faster firerate of the M3M. The original source cited for the change was incorrect/did not appropriately source their claims.

Additionally, ammunition was swapped from 200rnd boxes to 100rnd TE4 boxes to match with the last source (2:03). This also matches the decal on the in-game vehicle :)

Sources:

https://www.bundeswehr.de/de/ausruestung-technik-bundeswehr/ausruestung-bewaffnung/schweres-maschinengewehr-m2-qcb

https://knds.com/en/products/systems/flw-200-range/flw-200

https://youtu.be/eLLbo2c_pZo

https://youtu.be/OGoL6E9VCzo