### PR TITLE
CUP MLRS Submunitions Fix

### DIFF
--- a/addons/miscFixes/patchCUP/CfgAmmo.hpp
+++ b/addons/miscFixes/patchCUP/CfgAmmo.hpp
@@ -6,4 +6,28 @@ class CfgAmmo {
     class CUP_M_9K121_Vikhr_AT16_Scallion_AT: MissileBase {
         effectsMissile = "Missile2_vanilla";
     };
+    
+    // CUP MLRS Fix
+    class R_230mm_HE;
+	class CUP_R_GRAD_HE : R_230mm_HE {
+		submunitionAmmo = "";
+		simulation = "shotShell";
+		indirectHitRange = 5;
+	};
+	class CUP_R_Techical_HE : CUP_R_GRAD_HE {
+		indirectHitRange = 5;
+	};
+	class CUP_R_S8_techical_HE : CUP_R_GRAD_HE{
+		hit = 150;
+		indirectHit = 40;
+		indirectHitRange = 12;
+		suppressionRadiusHit = 30;
+		
+		model = "\CUP\Weapons\CUP_Weapons_Ammunition\Generic_70mm_Rocket\CUP_70mmRocket.p3d";
+		proxyShape = "\CUP\Weapons\CUP_Weapons_Ammunition\Generic_70mm_Rocket\CUP_70mmRocket.p3d";
+		CraterEffects = "HERocketCrater";
+		effectsMissile = "missile1";
+		explosioneffects = "HERocketExplosion";
+		explosionSoundEffect = "DefaultExplosion";
+	};
 };

--- a/addons/miscFixes/patchCUP/CfgAmmo.hpp
+++ b/addons/miscFixes/patchCUP/CfgAmmo.hpp
@@ -8,6 +8,7 @@ class CfgAmmo {
     };
     
     // CUP MLRS Fix
+    // Credit to martin509 via the CUP discord for the fix
     class R_230mm_HE;
 	class CUP_R_GRAD_HE : R_230mm_HE {
 		submunitionAmmo = "";

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -392,6 +392,27 @@ class CfgWeapons {
             };
         };
     };
+    
+    // CUP MLRS Fix - accuracy buff for technical rocket pods
+    class RocketPods;
+    class rockets_230mm_GAT : RocketPods {
+        class Close;
+    };
+    class CUP_Vmlauncher_GRAD_veh  : rockets_230mm_GAT{
+        class Close;
+    };
+    class CUP_Vmlauncher_technical: CUP_Vmlauncher_GRAD_veh {
+        class Close : Close {
+            artilleryDispersion = 8;
+        };
+    };
+    class CUP_Vmlauncher_ub32_technical: CUP_Vmlauncher_GRAD_veh {
+        class Close : Close {
+            artilleryDispersion = 12;
+            aiRateOfFire = 0.35;
+            aiRateOfFireDistance = 1054;
+        };
+    };
 };
 
 class SlotInfo;

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -394,6 +394,7 @@ class CfgWeapons {
     };
     
     // CUP MLRS Fix - accuracy buff for technical rocket pods
+    // Credit to martin509 via the CUP discord for the fix
     class RocketPods;
     class rockets_230mm_GAT : RocketPods {
         class Close;


### PR DESCRIPTION
"Nerfs" the CUP GRAD, Hilux MLRS, Hilux UB-32 launcher damage by removing the inherited 230mm submunition from the warhead. This makes the damage much more reasonable instead of being portable nukes.

Additionally, buffs the Hilux MLRS and UB-32 accuracy so that way it's reasonably usable for grid-square targets post-damage nerf.