### PR TITLE
miscFixes - patchCUP - MLRS fix balancing and projectile fixes.

### DIFF
--- a/addons/miscFixes/patchCUP/CfgAmmo.hpp
+++ b/addons/miscFixes/patchCUP/CfgAmmo.hpp
@@ -6,29 +6,45 @@ class CfgAmmo {
     class CUP_M_9K121_Vikhr_AT16_Scallion_AT: MissileBase {
         effectsMissile = "Missile2_vanilla";
     };
-    
+
     // CUP MLRS Fix
     // Credit to martin509 via the CUP discord for the fix
+    // Fixed by Lambda.Tiger
+    class R_230mm_fly;
+    class GVARMAIN(R_GRAD_HE_fly): R_230mm_fly { // based on RHS and GM 122mm rounds
+        indirectHit = 400;
+        indirectHitRange = 25;
+        hit = 600;
+        effectFly = "";
+    };
+    class GVARMAIN(R_Techical_HE_fly): R_230mm_fly { // uses Hydra rounds
+        hit = 150;
+        indirectHit = 40;
+        indirectHitRange = 8;
+        effectFly = "";
+    };
+    class GVARMAIN(R_S5_techical_HE_fly): R_230mm_fly { // Based on GM S5
+        indirectHit = 27;
+        indirectHitRange = 10;
+        hit = 30;
+        suppressionRadiusHit = 30;
+        model = "\A3\Weapons_F\Ammo\Rocket_02_fly_F";
+        proxyShape = "\A3\Weapons_F\Ammo\Rocket_02_fly_F";
+        CraterEffects = "HERocketCrater";
+        explosioneffects = "HERocketExplosion";
+        explosionSoundEffect = "DefaultExplosion";
+        effectFly = "";
+    };
     class R_230mm_HE;
-	class CUP_R_GRAD_HE : R_230mm_HE {
-		submunitionAmmo = "";
-		simulation = "shotShell";
-		indirectHitRange = 5;
-	};
-	class CUP_R_Techical_HE : CUP_R_GRAD_HE {
-		indirectHitRange = 5;
-	};
-	class CUP_R_S8_techical_HE : CUP_R_GRAD_HE{
-		hit = 150;
-		indirectHit = 40;
-		indirectHitRange = 12;
-		suppressionRadiusHit = 30;
-		
-		model = "\CUP\Weapons\CUP_Weapons_Ammunition\Generic_70mm_Rocket\CUP_70mmRocket.p3d";
-		proxyShape = "\CUP\Weapons\CUP_Weapons_Ammunition\Generic_70mm_Rocket\CUP_70mmRocket.p3d";
-		CraterEffects = "HERocketCrater";
-		effectsMissile = "missile1";
-		explosioneffects = "HERocketExplosion";
-		explosionSoundEffect = "DefaultExplosion";
-	};
+    class CUP_R_GRAD_HE : R_230mm_HE {
+        submunitionAmmo = QGVARMAIN(R_GRAD_HE_fly);
+    };
+    class CUP_R_Techical_HE : CUP_R_GRAD_HE {
+        submunitionAmmo = QGVARMAIN(R_Techical_HE_fly);
+    };
+    class CUP_R_S8_techical_HE : CUP_R_GRAD_HE { // Actually an S5 missile / launcher
+        submunitionAmmo = QGVARMAIN(R_S5_techical_HE_fly);
+        model = "\A3\Weapons_F\Ammo\Rocket_02_fly_F";
+        proxyShape = "\A3\Weapons_F\Ammo\Rocket_02_fly_F";
+    };
 };

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -359,7 +359,7 @@ class CfgWeapons {
             };
         };
     };
-    
+
     // CUP MLRS Fix - accuracy buff for technical rocket pods
     // Credit to martin509 via the CUP discord for the fix
     class RocketPods;


### PR DESCRIPTION
This PR balanced the projectiles against their equivalent projectiles (122mm rounds from RHS and GM, S5s and Hydras against CUP and GM values).