### PR TITLE
aiCfgFixes - RPG7 Ammo and Weapons

### DIFF
--- a/addons/aiCfgFixes/CfgAmmo.hpp
+++ b/addons/aiCfgFixes/CfgAmmo.hpp
@@ -332,7 +332,15 @@ class CfgAmmo {
         cost = 50;
     };
     class cwr3_r_rpg75_at: R_PG32V_F {
+        aiAmmoUsageFlags = 704;
         audibleFire = 16;
+    };
+    class R_PG7_F: RocketBase {
+        aiAmmoUsageFlags = 704;
+    };
+    class R_PG7VL: R_PG7_F {};
+    class R_PG7VR: R_PG7VL {
+        aiAmmoUsageFlags = 640;
     };
     class GrenadeBase;
     class FlareCore;

--- a/addons/aiCfgFixes/aiWeapons/CfgWeapons.hpp
+++ b/addons/aiCfgFixes/aiWeapons/CfgWeapons.hpp
@@ -30,7 +30,6 @@ class CfgWeapons {
     };
     // Untrained RPG7
     class GVARMAIN(launch_RPG7V_untrained): CUP_launch_RPG7V {
-        scope = 1;
         scopeArsenal = 1;
         class Single: Single {
             aiDispersionCoefY = 2.2;

--- a/addons/aiCfgFixes/aiWeapons/CfgWeapons.hpp
+++ b/addons/aiCfgFixes/aiWeapons/CfgWeapons.hpp
@@ -15,7 +15,7 @@ class CfgWeapons {
             minRangeProbab = 0.4;
         };
     };
-    class CUP_launch_RPG7V_optic: CUP_launch_RPG7V {
+    class GVARMAIN(launch_RPG7V_optic): CUP_launch_RPG7V {
         maxRange = 500;
         class Single: Single { // higher AI range with optics
             aiRateOfFire = 5;
@@ -29,7 +29,7 @@ class CfgWeapons {
         };
     };
     // Untrained RPG7
-    class CUP_launch_RPG7V_untrained: CUP_launch_RPG7V {
+    class GVARMAIN(launch_RPG7V_untrained): CUP_launch_RPG7V {
         scope = 1;
         scopeArsenal = 1;
         class Single: Single {
@@ -40,7 +40,7 @@ class CfgWeapons {
             minRangeProbab = 0.25;
         };
     };
-    class CUP_launch_RPG7V_untrained_optic: CUP_launch_RPG7V_optic {
+    class GVARMAIN(launch_RPG7V_untrained_optic): GVARMAIN(launch_RPG7V_optic) {
         maxRange = 500;
         class Single: Single {
             aiDispersionCoefY = 1.6;

--- a/addons/aiCfgFixes/aiWeapons/CfgWeapons.hpp
+++ b/addons/aiCfgFixes/aiWeapons/CfgWeapons.hpp
@@ -1,0 +1,77 @@
+class Mode_SemiAuto;
+class CfgWeapons {
+    // Base vanilla includes
+    //class ItemCore;
+    class Launcher_Base_F;
+    //class InventoryOpticsItem_Base_F;
+    // Dumb down AI accuracy
+    class CUP_launch_RPG7V: Launcher_Base_F {
+        maxRange = 350;
+        class Single: Mode_SemiAuto { // lower AI range without optics
+            aiRateOfFireDistance = 350;
+            maxRange = 350;
+            maxRangeProbab = 0.1;
+            midRange = 200;
+            midRangeProbab = 0.8;
+            minRange = 10;
+            minRangeProbab = 0.4;
+        };
+        /*class Single_Optic2_AI: Single { // AI optic mode where they hit farther
+            aiRateOfFireDistance = 500;
+            maxRange = 500;
+            maxRangeProbab = 0.1;
+            midRange = 300;
+            midRangeProbab = 0.8;
+            minRange = 10;
+            minRangeProbab = 0.3;
+            requiredOpticType = 2;
+            showToPlayer = 0;
+        };*/
+        //modes[] = {"Single", "Single_Optic2_AI"};
+    };
+    class CUP_launch_RPG7V_optic: CUP_launch_RPG7V {
+        maxRange = 500;
+        class Single: Single { // lower AI range without optics
+            aiRateOfFire = 5;
+            aiRateOfFireDistance = 500;
+            maxRange = 500;
+            maxRangeProbab = 0.1;
+            midRange = 350;
+            midRangeProbab = 0.8;
+            minRange = 10;
+            minRangeProbab = 0.3;
+        };
+    };
+    class CUP_launch_RPG7V_untrained: CUP_launch_RPG7V {
+        scope = 1;
+        scopeArsenal = 1;
+        class Single: Single {
+            aiDispersionCoefY = 2.2;
+            aiRateOfFire = 10;
+            dispersion = 0.002;
+            midRangeProbab = 0.4;
+            minRangeProbab = 0.25;
+        };
+        /*class Single_Optic2_AI: Single_Optic2_AI {
+            aiDispersionCoefY = 2.2;
+            dispersion = 0.002;
+            midRangeProbab = 0.4;
+        };*/
+        //modes[] = {"Single", "Single_Optic2_AI"};
+    };
+    class CUP_launch_RPG7V_untrained_optic: CUP_launch_RPG7V_optic {
+        maxRange = 500;
+        class Single: Single { // lower AI range without optics
+            aiDispersionCoefY = 1.6;
+            aiRateOfFire = 8;
+            midRange = 200;
+            midRangeProbab = 0.7;
+        };
+    };
+    // Update PGO-7 sights
+    /*class CUP_optic_PGO7V: ItemCore {
+        class ItemInfo: InventoryOpticsItem_Base_F {
+            opticType = 2;
+        };
+    };*/
+};

--- a/addons/aiCfgFixes/aiWeapons/CfgWeapons.hpp
+++ b/addons/aiCfgFixes/aiWeapons/CfgWeapons.hpp
@@ -1,9 +1,7 @@
 class Mode_SemiAuto;
 class CfgWeapons {
     // Base vanilla includes
-    //class ItemCore;
     class Launcher_Base_F;
-    //class InventoryOpticsItem_Base_F;
     // Dumb down AI accuracy
     class CUP_launch_RPG7V: Launcher_Base_F {
         maxRange = 350;
@@ -16,22 +14,10 @@ class CfgWeapons {
             minRange = 10;
             minRangeProbab = 0.4;
         };
-        /*class Single_Optic2_AI: Single { // AI optic mode where they hit farther
-            aiRateOfFireDistance = 500;
-            maxRange = 500;
-            maxRangeProbab = 0.1;
-            midRange = 300;
-            midRangeProbab = 0.8;
-            minRange = 10;
-            minRangeProbab = 0.3;
-            requiredOpticType = 2;
-            showToPlayer = 0;
-        };*/
-        //modes[] = {"Single", "Single_Optic2_AI"};
     };
     class CUP_launch_RPG7V_optic: CUP_launch_RPG7V {
         maxRange = 500;
-        class Single: Single { // lower AI range without optics
+        class Single: Single { // higher AI range with optics
             aiRateOfFire = 5;
             aiRateOfFireDistance = 500;
             maxRange = 500;
@@ -42,6 +28,7 @@ class CfgWeapons {
             minRangeProbab = 0.3;
         };
     };
+    // Untrained RPG7
     class CUP_launch_RPG7V_untrained: CUP_launch_RPG7V {
         scope = 1;
         scopeArsenal = 1;
@@ -52,26 +39,14 @@ class CfgWeapons {
             midRangeProbab = 0.4;
             minRangeProbab = 0.25;
         };
-        /*class Single_Optic2_AI: Single_Optic2_AI {
-            aiDispersionCoefY = 2.2;
-            dispersion = 0.002;
-            midRangeProbab = 0.4;
-        };*/
-        //modes[] = {"Single", "Single_Optic2_AI"};
     };
     class CUP_launch_RPG7V_untrained_optic: CUP_launch_RPG7V_optic {
         maxRange = 500;
-        class Single: Single { // lower AI range without optics
+        class Single: Single {
             aiDispersionCoefY = 1.6;
             aiRateOfFire = 8;
             midRange = 200;
             midRangeProbab = 0.7;
         };
     };
-    // Update PGO-7 sights
-    /*class CUP_optic_PGO7V: ItemCore {
-        class ItemInfo: InventoryOpticsItem_Base_F {
-            opticType = 2;
-        };
-    };*/
 };

--- a/addons/aiCfgFixes/aiWeapons/config.cpp
+++ b/addons/aiCfgFixes/aiWeapons/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
     class ADDON {
         units[] = {};
         weapons[] = {
-            "CUP_launch_RPG7V_untrained"
+            QGVARMAIN(launch_RPG7V_optic),
+            QGVARMAIN(launch_RPG7V_untrained),
+            QGVARMAIN(launch_RPG7V_untrained_optic)
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {

--- a/addons/aiCfgFixes/aiWeapons/config.cpp
+++ b/addons/aiCfgFixes/aiWeapons/config.cpp
@@ -1,0 +1,23 @@
+#include "\z\potato\addons\aiCfgFixes\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT aiCfgFixes_aiWeapons
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {
+            "CUP_launch_RPG7V_untrained"
+        };
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "potato_core", "ACE_ai",
+            "CUP_Weapons_LoadOrder"
+        };
+        skipWhenMissingDependencies = 1;
+        author = "Bourbon Warfare";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/addons/aiCfgFixes/gm/CfgAmmo.hpp
+++ b/addons/aiCfgFixes/gm/CfgAmmo.hpp
@@ -1,0 +1,10 @@
+class CfgAmmo {
+    class gm_rocket_40mm_HEAT_base;
+    class gm_rocket_40mm_HEAT_pg7v: gm_rocket_40mm_HEAT_base {
+        aiAmmoUsageFlags = 704;
+    };
+    class gm_rocket_40mm_HEAT_pg7vl: gm_rocket_40mm_HEAT_base {
+        aiAmmoUsageFlags = 704;
+    };
+};
+

--- a/addons/aiCfgFixes/gm/config.cpp
+++ b/addons/aiCfgFixes/gm/config.cpp
@@ -1,0 +1,21 @@
+#include "\z\potato\addons\aiCfgFixes\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT aiCfgFixes_gm
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "potato_core", "ACE_ai",
+            "gm_weapons_launchers_rpg7"
+        };
+        skipWhenMissingDependencies = 1;
+        author = "Bourbon Warfare";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgAmmo.hpp"

--- a/addons/aiCfgFixes/rhs_hlc/CfgAmmo.hpp
+++ b/addons/aiCfgFixes/rhs_hlc/CfgAmmo.hpp
@@ -27,6 +27,7 @@ class CfgAmmo {
     };
     class R_PG32V_F;
     class rhs_ammo_rpg75_rocket: R_PG32V_F {
+        aiAmmoUsageFlags = 704;
         audibleFire = 16;
     };
     class rhs_rpg26_rocket: R_PG32V_F {
@@ -274,6 +275,7 @@ class CfgAmmo {
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
     };
     class rhs_rpg7v2_pg7vl: rhs_rpg26_rocket {
+        aiAmmoUsageFlags = 960;
         audibleFire = AI_AUDIBLE_FIRE_0;
         GVAR(macroUsed) = "AI_AUDIBLE_FIRE_0";
     };


### PR DESCRIPTION
This PR allows certain PG-7 rounds to be use against infantry. In addition, it adds 3 variants of the CUP RPG-7V launcher intended for AI use. These launchers change AI engagement ranges and round dispersion in an attempt to allow AI to have RPG-7s and not hit everything within 500m in one shot.

TODO

- [x] Find out if secondary weapon fire mode config entry `requiredOpticType` is actually broken
- [x] Either remove or uncomment extra code with respect to RPG-7 weapon variants.