### PR TITLE
vehicleCoasting - Forget Targets on Bail

### DIFF
--- a/addons/vehicleCoasting/XEH_PREP.hpp
+++ b/addons/vehicleCoasting/XEH_PREP.hpp
@@ -4,4 +4,5 @@ PREP(dev_cleanDraw);
 PREP(dev_debugDraw);
 PREP(driverDeathHandle);
 PREP(forceBail);
+PREP(forgetTargets);
 PREP(vehicleCookOffHandle);

--- a/addons/vehicleCoasting/XEH_postInit.sqf
+++ b/addons/vehicleCoasting/XEH_postInit.sqf
@@ -6,6 +6,8 @@
     if (GVAR(chance) > 0) then {
         addMissionEventHandler ["EntityKilled", {call FUNC(driverDeathHandle);}];
         ["ace_cookoff_cookOff",{call FUNC(vehicleCookOffHandle)}] call CBA_fnc_addEventHandler;
+        [QACEGVAR(vehicle_damage,bailOut),{call FUNC(forgetTargets)}] call CBA_fnc_addEventHandler;
+
 
         #ifdef DEBUG_MODE_DRAW_EH
         GVAR(dev_draw3DEH) = addMissionEventHandler ["Draw3D", {[] call FUNC(dev_debugDraw)}];

--- a/addons/vehicleCoasting/functions/fnc_forgetTargets.sqf
+++ b/addons/vehicleCoasting/functions/fnc_forgetTargets.sqf
@@ -1,0 +1,27 @@
+#include "..\script_component.hpp"
+/***************************************************************************//*
+* Author: Lambda.Tiger
+*
+* Description:
+* This function attempts to stop crew from dismounting from a burning vic while
+* actively engaging infantry within seconds.
+*
+*
+* Arguments:
+* _vehicle - A vehicle suffering a cook-off or engine fire event
+* _unit - A unit in a vehicle that should bail out.
+*
+* Return:
+* None
+*
+* Example:
+* [objNull, _unit] call potato_vehicleCoasting_fnc_forgetTargets;
+*//***************************************************************************/
+params ["", ["_unit", objNull, [objNull]]];
+
+if (isNull _unit) exitWith {};
+
+private _targetInfo = _unit targets [true, -1, [], 10];
+{
+    _unit forgetTarget _x;
+} forEach _targetInfo;


### PR DESCRIPTION
This PR forces AI bailing out from vehicles to forget all target info within the last ten seconds. The goal is to stop AI crew from popping out of vehicles and simultaneously spraying down players.