### PR TITLE
miscFixes - patchCWRBAF - Fix Potato FV432

### DIFF
--- a/addons/miscFixes/patchCWRBAF/CfgVehicles.hpp
+++ b/addons/miscFixes/patchCWRBAF/CfgVehicles.hpp
@@ -106,23 +106,62 @@ class CfgVehicles {
     class CUP_B_FV432_GB_GPMG;
     class cwr3_fv432_gpmg_base: CUP_B_FV432_GB_GPMG {
         class Turrets;
+        class UserActions;
     };
     class cwr3_b_uk_fv432_gpmg: cwr3_fv432_gpmg_base {
         class Turrets: Turrets {
             class MainTurret;
+            class Commander;
+            class CargoTurret_04;
+            class CargoTurret_05;
+            class CargoTurret_07;
+        };
+        class UserActions: UserActions {
+            class stow_gpmg;
         };
     };
     class GVARMAIN(cwr3_b_uk_fv432_gpmg_unstab): cwr3_b_uk_fv432_gpmg {
         displayName = "FV432 (GPMG, Unstab)";
+        magazines[] = {"SmokeLauncherMag"};
+        weapons[] = {"SmokeLauncher"};
         class Turrets: Turrets {
             class MainTurret: MainTurret {
+                forceHideGunner = 0;
+                gunnerAction = "CUP_FV432_GunnerOut";
+                gunnerInAction = "CUP_FV432_GunnerIn";
+                gunnerOutOpticsModel = "\A3\weapons_f\reticle\optics_empty";
+                gunnerDoor = "";
+                inGunnerMayFire = 0;
+                outGunnerMayFire = 1;
+                magazines[] = {
+                    "CUP_200Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M",
+                    "CUP_200Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M",
+                    "CUP_200Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M",
+                    "CUP_200Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M",
+                    "CUP_200Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M"
+                };
+                memoryPointGunnerOptics = "gunnerviewin";
+                memoryPointGunnerOutOptics = "gunnerview";
                 stabilizedInAxes = 0;
+                weapons[] = {"CUP_Vlmg_L7A2_veh"};
+            };
+            class Commander: Commander {
+                stabilizedInAxes = 0;
+            };
+            class CargoTurret_04: CargoTurret_04 {};
+            class CargoTurret_05: CargoTurret_05 {};
+            class CargoTurret_07: CargoTurret_07 {};
+        };
+        class UserActions: UserActions {
+            class stow_gpmg: stow_gpmg {
+                condition = "this turretUnit [0] == player";
             };
         };
     };
     // Peak Turret
     class cwr3_b_uk_fv432_peak: cwr3_fv432_gpmg_base {
         class Turrets: Turrets {
+            class Commander;
             class MainTurret;
         };
     };
@@ -132,6 +171,7 @@ class CfgVehicles {
             class MainTurret: MainTurret {
                 stabilizedInAxes = 0;
             };
+            class Commander: Commander {};
         };
     };
     // FV510

--- a/addons/miscFixes/patchGM/CfgAmmo.hpp
+++ b/addons/miscFixes/patchGM/CfgAmmo.hpp
@@ -104,5 +104,4 @@ class CfgAmmo {
     class gm_shell_artillery_Base: gm_shell_base {
         effectFly = "";
     };
-
 };


### PR DESCRIPTION
This PR 

- Fixed the FFV seats not working for the Potato FV432
- Allowed turning in on the Potato FV432 (some animation clipping)