### PR TITLE
miscFixes - patchCelle - Fix Bad Preview Cutscene

### DIFF
--- a/addons/miscFixes/patchCelle/config.cpp
+++ b/addons/miscFixes/patchCelle/config.cpp
@@ -15,6 +15,7 @@ class CfgPatches {
     };
 };
 
+// Buff some buildings
 class CfgVehicles {
     class House;
     class Land_MBG_GER_HUS_1: House {
@@ -34,6 +35,15 @@ class CfgVehicles {
     };
     class LAND_MBG_Fachwerk_A: House {
         armor = 1000;
+    };
+};
+
+// Fix intro mission using ArmA 2 units
+class CfgMissions {
+    class Cutscenes {
+        class Celle2Intro1 {
+            directory = "z\potato\addons\miscFixes\patchCelle\data\cutscenes\celleIntro.mbg_celle2";
+        };
     };
 };
 

--- a/addons/miscFixes/patchCelle/data/cutscenes/celleIntro.mbg_celle2/initintro.sqf
+++ b/addons/miscFixes/patchCelle/data/cutscenes/celleIntro.mbg_celle2/initintro.sqf
@@ -1,0 +1,53 @@
+// Based on intro cutscene for MGB Celle 2 by Mondkalb
+bw_celle_introCam = "camera" camCreate getPosATL player;
+private _infoArray = [[[2375,1152,0],[2355,1141,2],[2364,1183,11], 10],
+[[7449,1466,0],[7794,1458,8],[7585,1196,13], 10],
+[[8775,2100,0],[9009,2275,58],[8995,2104,5], 10],
+[[8465,6246,0],[8637,6245,7],[8434,6410,12], 20],
+[[11106,11176,0],[10421,10652,12],[10785,10777,52], 20],
+[[6679,7907,0],[6882,7931,11],[6764,8159,11], 20],
+[[5777,4049,0],[5463,4050,9],[5642,3757,9], 20],
+[[1624,4146,0],[1350,3929,6],[1546,3872,6], 10],
+[[1709,9235,0],[1522,8441,6],[1634,9020,2], 20],
+[[6051,5720,0],[6271,5835,0.5],[6081,5731,149], 10],
+[[6932,6571,0],[7241,6743,10],[7007,6848,10], 20],
+[[7106,5946,0],[7508,6230,1],[7425,6300,1], 20],
+[[4249,8396,0],[3856,6545,7],[3864,6543,7], 10]];
+[_infoArray, true] call CBA_fnc_shuffle;
+private _fnc_camMove = {
+    params [
+        ["_focusPointAGL", [0, 0, 0], [[]]],
+        ["_cameraGoalAGL", [0, 0, 0], [[]]],
+        ["_transitionTime", 0, [0]]
+    ];
+    bw_celle_introCam camPrepareTarget _focusPointAGL;
+    bw_celle_introCam camPreparePos _cameraGoalAGL;
+    bw_celle_introCam camCommitPrepared _transitionTime;
+};
+bw_celle_introCam camPrepareFOV 0.7;
+bw_celle_introCam cameraEffect ["Internal", "BACK"];
+titleText ["", "BLACK FADED"];
+showCinemaBorder false;
+bw_celle_introCam camCommitPrepared 0;
+
+
+private _countIdx = 0;
+while {missionNameSpace getVariable ["BW_celle2IntroExit", true]} do {
+    [_infoArray, true] call CBA_fnc_shuffle;
+    {
+        _x params ["_focus", "_startPosAGL", "_endPosAGL", "_baseTransTime"];
+        private _transitionTime = _baseTransTime + random 3;
+        [_focus, _startPosAGL] call _fnc_camMove;
+        sleep 1;
+        titleText ["", "BLACK IN"];
+        sleep 0.5;
+        [_focus, _endPosAGL, _transitionTime] call _fnc_camMove;
+        sleep _transitionTime;
+        titleText ["", "BLACK OUT"];
+        sleep 1;
+    } forEach _infoArray;
+};
+bw_celle_introCam cameraEffect ["terminate", "back"];
+camDestroy bw_celle_introCam;
+titleFadeOut 0;
+

--- a/addons/miscFixes/patchCelle/data/cutscenes/celleIntro.mbg_celle2/mission.sqm
+++ b/addons/miscFixes/patchCelle/data/cutscenes/celleIntro.mbg_celle2/mission.sqm
@@ -1,0 +1,110 @@
+version=54;
+class EditorData
+{
+	moveGridStep=1;
+	angleGridStep=0.2617994;
+	scaleGridStep=1;
+	autoGroupingDist=10;
+	toggles=9;
+	class ItemIDProvider
+	{
+		nextID=82;
+	};
+	class MarkerIDProvider
+	{
+		nextID=1;
+	};
+	class Camera
+	{
+		pos[]={6983.7285,41.467003,6661.0801};
+		dir[]={0.89781028,-0.29768944,0.32454103};
+		up[]={0.27996373,0.95465904,0.10120102};
+		aside[]={0.33995274,-2.4330802e-08,-0.94044685};
+	};
+};
+binarizationWanted=0;
+sourceName="celleIntro";
+addons[]=
+{
+	"A3_Characters_F"
+};
+class AddonsMetaData
+{
+	class List
+	{
+		items=1;
+		class Item0
+		{
+			className="A3_Characters_F";
+			name="Arma 3 Alpha - Characters and Clothing";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+	};
+};
+randomSeed=8435048;
+class ScenarioData
+{
+	author="Lambda.Tiger";
+};
+class CustomAttributes
+{
+};
+class Mission
+{
+	class Intel
+	{
+		timeOfChanges=1800.0002;
+		startWeather=0.40000001;
+		startWind=0.1;
+		startWaves=0.1;
+		forecastWeather=0.1;
+		forecastWind=0.1;
+		forecastWaves=0.1;
+		forecastLightnings=0.1;
+		wavesForced=1;
+		windForced=1;
+		year=2011;
+		month=6;
+		day=9;
+		hour=13;
+		minute=0;
+		startFogBase=-1000;
+		forecastFogBase=-1000;
+		startFogDecay=0;
+		forecastFogDecay=0;
+	};
+	class Entities
+	{
+		items=1;
+		class Item0
+		{
+			dataType="Group";
+			side="West";
+			class Entities
+			{
+				items=1;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3183,46.257278,6497.0498};
+					};
+					side="West";
+					flags=7;
+					class Attributes
+					{
+						isPlayer=1;
+					};
+					id=66;
+					type="B_Soldier_F";
+				};
+			};
+			class Attributes
+			{
+			};
+			id=65;
+		};
+	};
+};


### PR DESCRIPTION
The current preview cutscene for Celle 2 uses an ArmA 2 unit classname. This alternative does not.