### PR TITLE
Potato Startup Config FIxes

### DIFF
--- a/addons/customGear/fauxC7/CfgWeapons.hpp
+++ b/addons/customGear/fauxC7/CfgWeapons.hpp
@@ -34,7 +34,7 @@ class CfgWeapons {
         displayName = "C7";
         modes[] = {"Single","FullAuto","Burst_medium","single_medium_optics1","single_medium_optics2"};
         class FullAuto: Mode_FullAuto {
-            class BaseSoundModeType;
+            class BaseSoundModeType {};
             class StandardSound: BaseSoundModeType {
                 soundsetshot[] = {"jsrs_m16a4_shot_soundset","jsrs_5x56mm_reverb_soundset"};
             };
@@ -64,7 +64,7 @@ class CfgWeapons {
         displayName = "C7A2";
         modes[] = {"Single","FullAuto","Burst_medium","single_medium_optics1","single_medium_optics2"};
         class FullAuto: Mode_FullAuto {
-            class BaseSoundModeType;
+            class BaseSoundModeType {};
             class StandardSound: BaseSoundModeType {
                 soundsetshot[] = {"jsrs_m16a4_shot_soundset","jsrs_5x56mm_reverb_soundset"};
             };
@@ -89,7 +89,7 @@ class CfgWeapons {
         displayName = "C7A2 M203";
         modes[] = {"Single","FullAuto","Burst_medium","single_medium_optics1","single_medium_optics2"};
         class FullAuto: Mode_FullAuto {
-            class BaseSoundModeType;
+            class BaseSoundModeType {};
             class StandardSound: BaseSoundModeType {
                 soundsetshot[] = {"jsrs_m16a4_shot_soundset","jsrs_5x56mm_reverb_soundset"};
             };

--- a/addons/customGear/launchers/CfgWeapons.hpp
+++ b/addons/customGear/launchers/CfgWeapons.hpp
@@ -73,7 +73,7 @@ class CfgWeapons {
         displayName = "AT4CS LMAW";
         baseWeapon = QWEAPON(launch_AT4CS_LMAW);
         jsrs_soundeffect = "JSRS2_Distance_Effects_Launcher";
-        magazines[] = {QMAGAZINE(AT4CS_RS)};
+        magazines[] = {QMAGAZINE(AT4CS_LMAW)};
         class WeaponSlotsInfo: WeaponSlotsInfo {
             mass = 108;
         };

--- a/addons/miscFixes/patchBettIR/config.cpp
+++ b/addons/miscFixes/patchBettIR/config.cpp
@@ -21,7 +21,7 @@ class BettIR_Config {
         class CUP_NVG_PVS14_WP: CUP_NVG_PVS14 {};
         class CUP_NVG_PVS15_black;
         class CUP_NVG_PVS15_black_WP: CUP_NVG_PVS15_black {};
-        class CUP_NVG_PVS15_green;
+        class CUP_NVG_PVS15_green: CUP_NVG_PVS15_black {};
         class CUP_NVG_PVS15_green_WP: CUP_NVG_PVS15_green {};
         class CUP_NVG_PVS15_tan;
         class CUP_NVG_PVS15_tan_WP: CUP_NVG_PVS15_tan {};


### PR DESCRIPTION
- Fixed  FauxC7 `BaseSoundModeType` errors
- Fixes bad magazine on AT4 LMAW
- Fixes missing BetterIR entry for `CUP_NVG_PVS15_green`