### PR TITLE
assignGear - Fix Incorrect ACE Addon Reference

### DIFF
--- a/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
+++ b/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
@@ -28,5 +28,5 @@ if (_boxName != "") then {
 
 private _overrideCarryWeight = 1 == (getNumber (_path >> "forceAllowCarry"));
 private _overrideDragWeight = 1 == (getNumber (_path >> "forceAllowDrag"));
-_theBox setVariable [QACEGVAR(cargo,ignoreWeightCarry), _overrideCarryWeight, true];
-_theBox setVariable [QACEGVAR(cargo,ignoreWeightDrag), _overrideCarryWeight || _overrideDragWeight, true];
+_theBox setVariable [QACEGVAR(dragging,ignoreWeightCarry), _overrideCarryWeight, true];
+_theBox setVariable [QACEGVAR(dragging,ignoreWeightDrag), _overrideCarryWeight || _overrideDragWeight, true];


### PR DESCRIPTION
This PR will fix the `forceAllowCarry` and `forceAllowDrag` settings not setting the proper variable.