### PR TITLE
Various - Update Fixes

### DIFF
--- a/addons/assignGear/XEH_preInit.sqf
+++ b/addons/assignGear/XEH_preInit.sqf
@@ -12,6 +12,7 @@ if (GVAR(usePotato)) then {
     GVAR(loadoutCache) = createHashMap;
     GVAR(classnameCache) = createHashMap;
     GVAR(magnifiedOpticCache) = createHashMap;
+    GVAR(customLoadoutPaths) = createHashMap;
 
     GVAR(allowMagnifiedOptics) = [missionConfigFile >> "CfgLoadouts" >> "allowMagnifiedOptics"] call CFUNC(getBool);
     GVAR(allowChangeableOptics) = [missionConfigFile >> "CfgLoadouts" >> "allowChangeableOptics"] call CFUNC(getBool);

--- a/addons/assignGear/functions/fnc_assignGearMan.sqf
+++ b/addons/assignGear/functions/fnc_assignGearMan.sqf
@@ -24,10 +24,11 @@ private _faction = faction _unit;
 private _typeOf = typeOf _unit;
 private _unitClassname = [_typeOf] call FUNC(cleanPrefix);
 private _loadout = _unit getVariable ["F_Gear", _unitClassname]; //Check variable f_gear, otherwise default to typeof
-private _path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+private _basePath = GVAR(customLoadoutPaths) getOrDefault [_faction, missionConfigFile >> "CfgLoadouts" >> _faction, true];
+private _path = _basePath >> _loadout;
 
 if ((!isClass(_path)) && GVAR(useFallback)) then {
-    _path = missionConfigFile >> "CfgLoadouts" >> _faction >> "fallback";
+    _path = _basePath >> "fallback";
 };
 
 // Temp? BWC for older missions

--- a/addons/dui_goby/initSettings.inc.sqf
+++ b/addons/dui_goby/initSettings.inc.sqf
@@ -18,7 +18,7 @@ private _category = ["POTATO - User", "Go By (DUI Nametags)"];
     "LIST",
     ["Show", "When to show other's info on their DUI-Nametags."],
     _category,
-    [[0, 1, 2], ["Disabled", "During Safe-Start", "Always"], 1],
+    [[0, 1, 2], ["Disabled", "During Safe-Start", "Always"], 2],
     false
 ] call CBA_fnc_addSetting;
 

--- a/addons/missionTesting/functions/fnc_displayMenu.sqf
+++ b/addons/missionTesting/functions/fnc_displayMenu.sqf
@@ -178,10 +178,10 @@ _openForumFinishedMissions ctrlCommit 0;
 private _missionMaker = getMissionConfigValue ["author","????"];
 private _missionName = getMissionConfigValue ["onLoadName", getMissionConfigValue ["briefingName","????"]];
 private _missionType = A_MISSION_TYPE select (getMissionConfigValue QGVAR(missionType));
-private _missionVersion = getMissionConfigValue QGVAR(missionVersion);
-private _missionPlayerCountMax = getMissionConfigValue QGVAR(playerCountMaximum);
-private _missionPlayerCountMin = getMissionConfigValue QGVAR(playerCountMinimum);
-private _missionPlayerCountRec = getMissionConfigValue QGVAR(playerCountRecommended);
+private _missionVersion = str getMissionConfigValue QGVAR(missionVersion);
+private _missionPlayerCountMax = str getMissionConfigValue QGVAR(playerCountMaximum);
+private _missionPlayerCountMin = str getMissionConfigValue QGVAR(playerCountMinimum);
+private _missionPlayerCountRec = str getMissionConfigValue QGVAR(playerCountRecommended);
 
 private _missionSSTime = str getMissionConfigValue QGVAR(SSTimeGiven);
 private _missionSSForceEnd = ["Admin start", "Forced once SS time elapses"] select getMissionConfigValue [QEGVAR(missionTesting,SSForceEnd), false];

--- a/addons/radios/CfgEden.hpp
+++ b/addons/radios/CfgEden.hpp
@@ -341,8 +341,8 @@ class Cfg3DEN {
             class acre_attributes {
                 class Attributes {
                     class acre_sys_radio_edenSetup {
+                        condition = 0;
                         defaultValue = "[]";
-                        expression = "";
                     };
                 };
             };

--- a/addons/radios/CfgEden.hpp
+++ b/addons/radios/CfgEden.hpp
@@ -338,6 +338,14 @@ class Cfg3DEN {
                     };
                 };
             };
+            class acre_attributes {
+                class Attributes {
+                    class acre_sys_radio_edenSetup {
+                        defaultValue = "[]";
+                        expression = "";
+                    };
+                };
+            };
         };
     };
     class Mission {

--- a/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
+++ b/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
@@ -83,7 +83,7 @@ if (_menuxPos > 0.5) then {
     private _title = _ctrlGroup controlsGroupCtrl IDC_SAFESTARTEQUIP_TITLE;
     _title ctrlSetStructuredText parseText "<t align='right'>Safe Start Info</t>"
 };
-private _missionType = ["Other", "Coop", "TvT", "After Hours"]#_missionTypeEnum;
+private _missionType = ["After-Hours","Coop","TVT","Long Coop","Unconventional TVT", "Unconventional Coop"]#_missionTypeEnum;
 
 _textArr pushBack format ["Mission Type: %1", _missionType];
 //// Timings

--- a/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
+++ b/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
@@ -24,7 +24,7 @@ params [["_ctrlGroup", controlNull, [controlNull]]];
 
 if (isNull _ctrlGroup) exitWith {};
 private _missionTypeEnum = getMissionConfigValue [QEGVAR(missionTesting,missionType), 0];
-if (GVAR(showTimer) != 2 || (_missionTypeEnum != 1 && _missionTypeEnum != 2 && !is3DENPreview)) exitWith {
+if (GVAR(showTimer) != 2) exitWith {
     _ctrlGroup ctrlShow false;
     private _ctrlGroupParent = ctrlParentControlsGroup _ctrlGroup;
     (_ctrlGroupParent controlsGroupCtrl IDC_SAFESTARTEQUIP_BACKGROUND) ctrlShow false;
@@ -94,11 +94,17 @@ private _missionLengthInBounds = true;
 if !(_safeStartLength isEqualType 0) then {_safeStartLength = 0};
 if !(_missionLength isEqualType 0) then {_missionLength = 0};
 switch (_missionTypeEnum) do {
-    case 1: { // Coop
+    case 1;
+    case 5: { // Coop
         _safeStartInBounds = _safeStartLength == 15;
         _missionLengthInBounds = _missionLength >= 60 && _missionLength <= 75;
     };
-    case 2: { // TvT
+    case 3: { // LC
+        _safeStartInBounds = _safeStartLength == 15;
+        _missionLengthInBounds = _missionLength >= 90 && _missionLength <= 120;
+    };
+    case 2;
+    case 4: { // TvT
         _safeStartInBounds = _safeStartLength == 10;
         _missionLengthInBounds = _missionLength >= 30 && _missionLength <= 40;
     };

--- a/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
+++ b/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
@@ -83,7 +83,7 @@ if (_menuxPos > 0.5) then {
     private _title = _ctrlGroup controlsGroupCtrl IDC_SAFESTARTEQUIP_TITLE;
     _title ctrlSetStructuredText parseText "<t align='right'>Safe Start Info</t>"
 };
-private _missionType = ["After-Hours","Coop","TVT","Long Coop","Unconventional TVT", "Unconventional Coop"]#_missionTypeEnum;
+private _missionType = ["Other","Coop","TVT","Long Coop","Unconventional TVT", "Unconventional Coop"]#_missionTypeEnum;
 
 _textArr pushBack format ["Mission Type: %1", _missionType];
 //// Timings

--- a/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
+++ b/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
@@ -83,7 +83,7 @@ if (_menuxPos > 0.5) then {
     private _title = _ctrlGroup controlsGroupCtrl IDC_SAFESTARTEQUIP_TITLE;
     _title ctrlSetStructuredText parseText "<t align='right'>Safe Start Info</t>"
 };
-private _missionType = ["Other","Coop","TVT","Long Coop","Unconventional TVT", "Unconventional Coop"]#_missionTypeEnum;
+private _missionType = ["Other","Coop","TVT","Long Coop","Unconventional TVT", "Unconventional Coop","Undefined"]#_missionTypeEnum;
 
 _textArr pushBack format ["Mission Type: %1", _missionType];
 //// Timings


### PR DESCRIPTION
This PR:

- Added a hashmap to allow factions to indicate base loadout setting to allow for future changes to loadout path.
- Fix mission testing menu type issue.
- Set's goBy to default to always show (still changeable in settings)
- Disable ACRE `acre_sys_radio_edenSetup`
- Update safe start menu for future mission type settings