### PR TITLE
miscFixes - patchJAM - Fix Launcher Inventory Image Error

### DIFF
--- a/addons/miscFixes/patchJAM/config.cpp
+++ b/addons/miscFixes/patchJAM/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "potato_core", "JAM_Supplies_AE_Bags" };
+        requiredAddons[] = { "potato_core", "JAM_Supplies_AE_Bags", "JAM_Weapons_AE_Launchers_DZJ08" };
         skipWhenMissingDependencies = 1;
         author = "Bourbon Warfare";
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
@@ -24,4 +24,12 @@ class CfgVehicles {
     class JAM_AE_B_RallyPoint_t07_des: Land_JAM_AE_Prop_RallyPoint_PLA_t07_des { XEH_ENABLED; }; // "Rally Point [PLA] (Desert)" 3460736810
     class Land_JAM_AE_Prop_RallyPoint_ROCA;
     class JAM_AE_B_RallyPoint_ROCA: Land_JAM_AE_Prop_RallyPoint_ROCA { XEH_ENABLED; }; // "Rally Point [ROCA]" 3460736810
+};
+
+class CfgWeapons {
+    class Launcher_Base_f;
+    class JAM_AE_Launch_DZAII_grn_F: Launcher_Base_f {
+        // not right, but gets rid of the error
+        picture = "\A3\Weapons_F\launchers\RPG32\data\UI\gear_RPG32_X_CA.paa";
+    };
 };


### PR DESCRIPTION
This PR fixes the inventory popup for the JAM launchers, unsure why the vanilla path doesn't work but didn't want to unpack the vanilla weapons pbo's to check.