### PR TITLE
arsenalExport - Partial Loadout Sanitizing and Potato GP-25 Rounds

### DIFF
--- a/addons/arsenalExport/functions/fnc_export.sqf
+++ b/addons/arsenalExport/functions/fnc_export.sqf
@@ -91,9 +91,9 @@ private _glMuzzle = (getArray (configFile >> "CfgWeapons" >> GVAR(loadout_glrifl
 private _glMags = [configFile >> "CfgWeapons" >> GVAR(loadout_glrifle) >> _glMuzzle] call CBA_fnc_compatibleMagazines;
 switch (true) do {
     case (({"CUP_1Rnd_HE_GP25_M" == _x} count _glMags) > 0): {
-        _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "CUP_1Rnd_SMOKE_GP25_M:2","CUP_1Rnd_SmokeRed_GP25_M:2"'];
-        _lines pushBack format ['#define GLRIFLE_MAG_HE "CUP_1Rnd_HE_GP25_M:5"'];
-        _lines pushBack format ['#define GLRIFLE_MAG_FLARE "CUP_FlareYellow_GP25_M:4"'];
+        _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "1Rnd_Smoke_GRD40_shell:2","1Rnd_SmokeRed_GRD40_shell:2"'];
+        _lines pushBack format ['#define GLRIFLE_MAG_HE "1Rnd_HE_VOG25_shell:5"'];
+        _lines pushBack format ['#define GLRIFLE_MAG_FLARE "1Rnd_FlareYellow_Illum_VG40OP_shell:4"'];
     };
     case (({"1Rnd_Smoke_Grenade_shell" == _x} count _glMags) > 0):{
         _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "1Rnd_Smoke_Grenade_shell:2","1Rnd_SmokeRed_Grenade_shell:2"'];

--- a/addons/arsenalExport/functions/fnc_export.sqf
+++ b/addons/arsenalExport/functions/fnc_export.sqf
@@ -1,4 +1,5 @@
 #include "script_component.hpp"
+#define SANATIZE_EXPORT(var) [str var, ""] select (var == "NotSet")
 
 TRACE_1("export",_this);
 
@@ -89,6 +90,11 @@ _lines pushBack format ['#define GLRIFLE_MAG %1', [GVAR(loadout_glrifle), GVAR(l
 private _glMuzzle = (getArray (configFile >> "CfgWeapons" >> GVAR(loadout_glrifle) >> "muzzles")) param [1, "no2ndMuzzle"];
 private _glMags = [configFile >> "CfgWeapons" >> GVAR(loadout_glrifle) >> _glMuzzle] call CBA_fnc_compatibleMagazines;
 switch (true) do {
+    case (({"CUP_1Rnd_HE_GP25_M" == _x} count _glMags) > 0): {
+        _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "CUP_1Rnd_SMOKE_GP25_M:2","CUP_1Rnd_SmokeRed_GP25_M:2"'];
+        _lines pushBack format ['#define GLRIFLE_MAG_HE "CUP_1Rnd_HE_GP25_M:5"'];
+        _lines pushBack format ['#define GLRIFLE_MAG_FLARE "CUP_FlareYellow_GP25_M:4"'];
+    };
     case (({"1Rnd_Smoke_Grenade_shell" == _x} count _glMags) > 0):{
         _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "1Rnd_Smoke_Grenade_shell:2","1Rnd_SmokeRed_Grenade_shell:2"'];
         _lines pushBack format ['#define GLRIFLE_MAG_HE "1Rnd_HE_Grenade_shell:5"'];
@@ -115,46 +121,46 @@ _lines pushBack format ['#define AT "%1"', GVAR(loadout_at)];
 _lines pushBack format ['#define AT_MAG %1', [GVAR(loadout_at), GVAR(loadout_atMags), AT_ROUNDS] call _fnc_getMags];
 
 _lines pushBack format ["// MMG"];
-_lines pushBack format ['#define MMG "%1"', GVAR(loadout_mmg)];
+_lines pushBack format ['#define MMG %1', SANATIZE_EXPORT(GVAR(loadout_mmg))];
 _lines pushBack format ['#define MMG_MAG %1', [GVAR(loadout_mmg), GVAR(loadout_mmgMags), MMG_ROUNDS] call _fnc_getMags];
 
 _lines pushBack format ["// MAT"];
-_lines pushBack format ['#define MAT "%1"', GVAR(loadout_mat)];
+_lines pushBack format ['#define MAT %1', SANATIZE_EXPORT(GVAR(loadout_mat))];
 _lines pushBack format ['#define MAT_MAG %1', [GVAR(loadout_mat), GVAR(loadout_matMags), MAT_ROUNDS] call _fnc_getMags];
 _lines pushBack format ['#define MAT_OPTIC %1', [GVAR(loadout_matAttachments)] call _fnc_formatList];
 
 _lines pushBack format ["// HMG"];
-_lines pushBack format ['#define HMG "%1"', GVAR(loadout_hmg)];
-_lines pushBack format ['#define HMG_TRI_HI "%1"', GVAR(loadout_hmg_tri_1)];
-_lines pushBack format ['#define HMG_TRI_LO "%1"', [GVAR(loadout_hmg_tri_2),GVAR(loadout_hmg_tri_1)] call _fnc_default];
+_lines pushBack format ['#define HMG %1', SANATIZE_EXPORT(GVAR(loadout_hmg))];
+_lines pushBack format ['#define HMG_TRI_HI %1', SANATIZE_EXPORT(GVAR(loadout_hmg_tri_1))];
+_lines pushBack format ['#define HMG_TRI_LO %1', [SANATIZE_EXPORT(GVAR(loadout_hmg_tri_2)),SANATIZE_EXPORT(GVAR(loadout_hmg_tri_1))] call _fnc_default];
 _lines pushBack format ['#define HMG_MAG %1', [GVAR(loadout_hmg), GVAR(loadout_hmgMags), HMG_ROUNDS] call _fnc_getMags];
 
 _lines pushBack format ["// HAT"];
-_lines pushBack format ['#define HAT "%1"', GVAR(loadout_hat)];
-_lines pushBack format ['#define HAT_TRI_HI "%1"', GVAR(loadout_hat_tri_1)];
-_lines pushBack format ['#define HAT_TRI_LO "%1"', [GVAR(loadout_hat_tri_2),GVAR(loadout_hat_tri_1)] call _fnc_default];
+_lines pushBack format ['#define HAT %1', SANATIZE_EXPORT(GVAR(loadout_hat))];
+_lines pushBack format ['#define HAT_TRI_HI %1', SANATIZE_EXPORT(GVAR(loadout_hat_tri_1))];
+_lines pushBack format ['#define HAT_TRI_LO %1', [SANATIZE_EXPORT(GVAR(loadout_hat_tri_2)),SANATIZE_EXPORT(GVAR(loadout_hat_tri_1))] call _fnc_default];
 _lines pushBack format ['#define HAT_MAG %1', [GVAR(loadout_hat), GVAR(loadout_hatMags), HAT_ROUNDS] call _fnc_getMags];
 
 _lines pushBack format ["// SAM"];
-_lines pushBack format ['#define SAM "%1"', GVAR(loadout_sam)];
+_lines pushBack format ['#define SAM %1', SANATIZE_EXPORT(GVAR(loadout_sam))];
 _lines pushBack format ['#define SAM_MAG %1', [GVAR(loadout_sam), GVAR(loadout_samMags), SAM_ROUNDS] call _fnc_getMags];
 
 _lines pushBack format ["// Sniper"];
-_lines pushBack format ['#define SNIPER "%1"', GVAR(loadout_sniper)];
+_lines pushBack format ['#define SNIPER %1', SANATIZE_EXPORT(GVAR(loadout_sniper))];
 _lines pushBack format ['#define SNIPER_MAG %1', [GVAR(loadout_sniper), GVAR(loadout_sniperMags), SNIPER_ROUNDS] call _fnc_getMags];
 _lines pushBack format ['#define SNIPER_ATTACHMENTS %1', [GVAR(loadout_sniperAttachments)] call _fnc_formatList];
 
 _lines pushBack format ["// Spotter"];
-_lines pushBack format ['#define SPOTTER "%1"', GVAR(loadout_spotter)];
+_lines pushBack format ['#define SPOTTER %1', SANATIZE_EXPORT(GVAR(loadout_spotter))];
 _lines pushBack format ['#define SPOTTER_MAG %1', [GVAR(loadout_spotter), GVAR(loadout_spotterMags), RIFLE_ROUNDS] call _fnc_getMags];
 _lines pushBack format ['#define SPOTTER_ATTACHMENTS %1', [GVAR(loadout_spotterAttachments)] call _fnc_formatList];
 
 _lines pushBack format ["// SMG"];
-_lines pushBack format ['#define SMG "%1"', GVAR(loadout_smg)];
+_lines pushBack format ['#define SMG %1', SANATIZE_EXPORT(GVAR(loadout_smg))];
 _lines pushBack format ['#define SMG_MAG %1', [GVAR(loadout_smg), GVAR(loadout_smgMags), SMG_ROUNDS] call _fnc_getMags];
 
 _lines pushBack format ["// Pistol"];
-_lines pushBack format ['#define PISTOL "%1"', GVAR(loadout_pistol)];
+_lines pushBack format ['#define PISTOL %1', SANATIZE_EXPORT(GVAR(loadout_pistol))];
 _lines pushBack format ['#define PISTOL_MAG %1', [GVAR(loadout_pistol), GVAR(loadout_pistolMags), PISTOL_ROUNDS] call _fnc_getMags];
 _lines pushBack format ['#define PISTOL_ATTACHMENTS %1', [GVAR(loadout_pistolAttachments)] call _fnc_formatList];
 

--- a/addons/customGear/CfgMagazineWells.hpp
+++ b/addons/customGear/CfgMagazineWells.hpp
@@ -8,8 +8,18 @@ class CfgMagazineWells {
 
     class CBA_40mm_GP {
         MAGWELL_ENTRY_NAME[] = {
-            QMAGAZINE(1Rnd_40mm_M433_HEDP),
-            QMAGAZINE(1Rnd_40mm_M576_MP)
+            QMAGAZINE(1Rnd_HE_VOG25_shell),
+            QMAGAZINE(1Rnd_Smoke_GRD40_shell),
+            QMAGAZINE(1Rnd_SmokeBlue_GRD40_shell),
+            QMAGAZINE(1Rnd_SmokeGreen_GRD40_shell),
+            QMAGAZINE(1Rnd_SmokeOrange_GRD40_shell),
+            QMAGAZINE(1Rnd_SmokePurple_GRD40_shell),
+            QMAGAZINE(1Rnd_SmokeRed_GRD40_shell),
+            QMAGAZINE(1Rnd_SmokeYellow_GRD40_shell),
+            QMAGAZINE(1Rnd_Flare_Illum_VG40OP_shell),
+            QMAGAZINE(1Rnd_FlareRed_Illum_VG40OP_shell),
+            QMAGAZINE(1Rnd_FlareGreen_Illum_VG40OP_shell),
+            QMAGAZINE(1Rnd_FlareYellow_Illum_VG40OP_shell)
         };
     };
     class CBA_40mm_M203 {

--- a/addons/customGear/CfgMagazines.hpp
+++ b/addons/customGear/CfgMagazines.hpp
@@ -1,5 +1,5 @@
 class CfgMagazines {
-    // LV 40x46mm grenade magazines (M203, EGLM)
+    //// LV 40x46mm grenade magazines (M203, EGLM)
     class 1Rnd_HE_Grenade_shell;
     class MAGAZINE(1Rnd_40mm_M433_HEDP): 1Rnd_HE_Grenade_shell {
         ammo = QAMMO(40x46mm_HEDP_M433);
@@ -17,7 +17,7 @@ class CfgMagazines {
         mass = 2.4;
     };
 
-    /// HV 40x53mm grenade launcher
+    //// HV 40x53mm grenade launcher
     class 200Rnd_40mm_G_belt;
     class MAGAZINE(96Rnd_40mm_MK19_M430A1_HEDP): 200Rnd_40mm_G_belt {
         ammo = QAMMO(40x53mm_HEDP_M430A1);
@@ -39,7 +39,7 @@ class CfgMagazines {
     class MAGAZINE(48Rnd_40mm_MK19_M384_HE): MAGAZINE(96Rnd_40mm_MK19_M384_HE) {
         count = 48;
     };
-    // HV 40x53mm grenade CSW
+    //// HV 40x53mm grenade CSW
     class MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP_csw): MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP) {
         displayName = "[CSW] 48Rnd 40x53mm M430A1 HEDP (Mk19)";
         displayNameShort = "[CSW] 48Rnd M430A1 HEDP (Mk19)";
@@ -62,4 +62,96 @@ class CfgMagazines {
         ACE_isBelt = 1;
         mass = 40;
     };
+    //// GP-25 magazines
+    // HE rounds
+    class MAGAZINE(1Rnd_HE_VOG25_shell): 1Rnd_HE_Grenade_shell {
+        descriptionShort = "Type: High Explosive Grenade Round<br />Caliber: 40 mm<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "VOG-25 40mm HE Grenade";
+        displayNameShort = "HE Grenade";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    // Smoke Rounds
+    class 1Rnd_Smoke_Grenade_shell;
+    class MAGAZINE(1Rnd_Smoke_GRD40_shell): 1Rnd_Smoke_Grenade_shell {
+        descriptionShort = "Type: Smoke Round - White<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "GRD-40 Smoke Round (White)";
+        displayNameShort = "White Smoke (White)";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    class 1Rnd_SmokeBlue_Grenade_shell;
+    class MAGAZINE(1Rnd_SmokeBlue_GRD40_shell): 1Rnd_SmokeBlue_Grenade_shell {
+        descriptionShort = "Type: Smoke Round - Blue<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "GRD-40 Smoke Round (Blue)";
+        displayNameShort = "Smoke Round (Blue)";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    class 1Rnd_SmokeGreen_Grenade_shell;
+    class MAGAZINE(1Rnd_SmokeGreen_GRD40_shell): 1Rnd_SmokeGreen_Grenade_shell {
+        descriptionShort = "Type: Smoke Round - Green<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "GRD-40 Smoke Round (Green)";
+        displayNameShort = "Smoke Round (Green)";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    class 1Rnd_SmokeOrange_Grenade_shell;
+    class MAGAZINE(1Rnd_SmokeOrange_GRD40_shell): 1Rnd_SmokeOrange_Grenade_shell {
+        descriptionShort = "Type: Smoke Round - Orange<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "GRD-40 Smoke Round (Orange)";
+        displayNameShort = "Smoke Round (Orange)";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    class 1Rnd_SmokePurple_Grenade_shell;
+    class MAGAZINE(1Rnd_SmokePurple_GRD40_shell): 1Rnd_SmokePurple_Grenade_shell {
+        descriptionShort = "Type: Smoke Round - Purple<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "GRD-40 Smoke Round (Purple)";
+        displayNameShort = "Smoke Round (Purple)";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    class 1Rnd_SmokeRed_Grenade_shell;
+    class MAGAZINE(1Rnd_SmokeRed_GRD40_shell): 1Rnd_SmokeRed_Grenade_shell {
+        descriptionShort = "Type: Smoke Round - Red<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "GRD-40 Smoke Round (Red)";
+        displayNameShort = "Smoke Round (Red)";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    class 1Rnd_SmokeYellow_Grenade_shell;
+    class MAGAZINE(1Rnd_SmokeYellow_GRD40_shell): 1Rnd_SmokeYellow_Grenade_shell {
+        descriptionShort = "Type: Smoke Round - Yellow<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "GRD-40 Smoke Round (Yellow)";
+        displayNameShort = "Smoke Round (Yellow )";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    // Flare rounds
+    class UGL_FlareWhite_Illumination_F;
+    class MAGAZINE(1Rnd_Flare_Illum_VG40OP_shell): UGL_FlareWhite_Illumination_F {
+        count = 1;
+        descriptionShort = "Type: Illumination Rounds - White<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "VG-40OP Illumination (White)";
+        displayNameShort = "White Illumination";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    class UGL_FlareRed_Illumination_F;
+    class MAGAZINE(1Rnd_FlareRed_Illum_VG40OP_shell): UGL_FlareRed_Illumination_F {
+        count = 1;
+        descriptionShort = "Type: Illumination Rounds - Red<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "VG-40OP Illumination (Red)";
+        displayNameShort = "Red Illumination";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    class UGL_FlareGreen_Illumination_F;
+    class MAGAZINE(1Rnd_FlareGreen_Illum_VG40OP_shell): UGL_FlareGreen_Illumination_F {
+        count = 1;
+        descriptionShort = "Type: Illumination Rounds - Green<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "VG-40OP Illumination (Green)";
+        displayNameShort = "Green Illumination";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+    class UGL_FlareYellow_Illumination_F;
+    class MAGAZINE(1Rnd_FlareYellow_Illum_VG40OP_shell): UGL_FlareYellow_Illumination_F {
+        count = 1;
+        descriptionShort = "Type: Illumination Rounds - Yellow<br />Rounds: 1<br />Used in: GP-25, GP-30, GP-34";
+        displayName = "VG-40OP Illumination (Yellow)";
+        displayNameShort = "Yellow Illumination";
+        model = "\A3\weapons_F\ammo\mag_univ.p3d";
+    };
+
 };

--- a/addons/zeusHC/functions/fnc_garrisonLocal.sqf
+++ b/addons/zeusHC/functions/fnc_garrisonLocal.sqf
@@ -16,6 +16,10 @@
 #include "script_component.hpp"
 TRACE_1("Params",_this);
 
+if (isNil QGVAR(lastGarrisonEnableLambs)) then {
+    GVAR(lastGarrisonEnableLambs) = false;
+};
+
 _this spawn {
     params ["_unitsToAdd","_unitPositions","_side"];
 


### PR DESCRIPTION
This PR removes the "NotSet" strings for MMG/HMG/MAT/HAT/Sniper/Spotter/Pistol/SMG from the arsenal export if a mission maker does not define them. In addition, it defaults to CUP GP-25 rounds for compatible rifles first.