### PR TITLE
assignGear - Switch Box Dragging and Carrying to API

### DIFF
--- a/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
+++ b/addons/assignGear/functions/fnc_setBoxContentsFromConfig.sqf
@@ -28,5 +28,5 @@ if (_boxName != "") then {
 
 private _overrideCarryWeight = 1 == (getNumber (_path >> "forceAllowCarry"));
 private _overrideDragWeight = 1 == (getNumber (_path >> "forceAllowDrag"));
-_theBox setVariable [QACEGVAR(dragging,ignoreWeightCarry), _overrideCarryWeight, true];
-_theBox setVariable [QACEGVAR(dragging,ignoreWeightDrag), _overrideCarryWeight || _overrideDragWeight, true];
+[_theBox, true, nil, nil, _overrideCarryWeight, true] call ACEFUNC(dragging,setCarryable);
+[_theBox, true, nil, nil, _overrideDragWeight, true] call ACEFUNC(dragging,setDraggable);


### PR DESCRIPTION
This PR moves the `forceAllowCarry` and `forceAllowDrag` flags to API calls instead of variables.