### PR TITLE
adminMenu - Add Testing Menu Radio Output and Callsigns

### DIFF
--- a/addons/adminMenu/Interrupt_adminMenu.hpp
+++ b/addons/adminMenu/Interrupt_adminMenu.hpp
@@ -458,7 +458,7 @@ class GVAR(adminMenuDialog) {
                     y = QUOTE(0.22 * safezoneH);
                     w = QUOTE(0.52 * safezoneW);
                     h = QUOTE(0.05 * safezoneH);
-                    action = QUOTE(call compileScript [QUOTE(QPATHTOF(functions\fnc_uihook_listRadioChannels.sqf))]);
+                    action = QUOTE(call FUNC(uihook_listRadioChannels.sqf));
                 };
                 class RscButton_160055444: RscButton {
                     idc = -1;

--- a/addons/adminMenu/Interrupt_adminMenu.hpp
+++ b/addons/adminMenu/Interrupt_adminMenu.hpp
@@ -451,11 +451,20 @@ class GVAR(adminMenuDialog) {
                     h = QUOTE(0.05 * safezoneH);
                     action = QUOTE([] call FUNC(uihook_unitGroupSideBrief));
                 };
+                class RscButton_MissionRadios: RscButton {
+                    idc = -1;
+                    text = "Output Current Radios"; //--- ToDo: Localize;
+                    x = QUOTE(0.01 * safezoneW);
+                    y = QUOTE(0.22 * safezoneH);
+                    w = QUOTE(0.52 * safezoneW);
+                    h = QUOTE(0.05 * safezoneH);
+                    action = QUOTE(call compileScript [QUOTE(QPATHTOF(functions\fnc_uihook_listRadioChannels.sqf))]);
+                };
                 class RscButton_160055444: RscButton {
                     idc = -1;
                     text = "Weapons Test"; //--- ToDo: Localize;
                     x = QUOTE(0.01 * safezoneW);
-                    y = QUOTE(0.22 * safezoneH);
+                    y = QUOTE(0.29 * safezoneH);
                     w = QUOTE(0.52 * safezoneW);
                     h = QUOTE(0.05 * safezoneH);
                     action = QUOTE([] call FUNC(uihook_weaponTest));
@@ -464,7 +473,7 @@ class GVAR(adminMenuDialog) {
                     idc = -1;
                     text = "Enable Mission Checklist"; //--- ToDo: Localize;
                     x = QUOTE(0.01 * safezoneW);
-                    y = QUOTE(0.29 * safezoneH);
+                    y = QUOTE(0.36 * safezoneH);
                     w = QUOTE(0.52 * safezoneW);
                     h = QUOTE(0.05 * safezoneH);
                     action = QUOTE([] call FUNC(uihook_enableMissionTesting));

--- a/addons/adminMenu/Interrupt_adminMenu.hpp
+++ b/addons/adminMenu/Interrupt_adminMenu.hpp
@@ -453,7 +453,7 @@ class GVAR(adminMenuDialog) {
                 };
                 class RscButton_MissionRadios: RscButton {
                     idc = -1;
-                    text = "Output Current Radios"; //--- ToDo: Localize;
+                    text = "List Radio Channel Settings"; //--- ToDo: Localize;
                     x = QUOTE(0.01 * safezoneW);
                     y = QUOTE(0.22 * safezoneH);
                     w = QUOTE(0.52 * safezoneW);

--- a/addons/adminMenu/Interrupt_adminMenu.hpp
+++ b/addons/adminMenu/Interrupt_adminMenu.hpp
@@ -458,7 +458,7 @@ class GVAR(adminMenuDialog) {
                     y = QUOTE(0.22 * safezoneH);
                     w = QUOTE(0.52 * safezoneW);
                     h = QUOTE(0.05 * safezoneH);
-                    action = QUOTE(call FUNC(uihook_listRadioChannels.sqf));
+                    action = QUOTE(call FUNC(uihook_listRadioChannels));
                 };
                 class RscButton_160055444: RscButton {
                     idc = -1;

--- a/addons/adminMenu/XEH_PREP.hpp
+++ b/addons/adminMenu/XEH_PREP.hpp
@@ -20,6 +20,7 @@ PREP(uihook_missionHint);
 PREP(uihook_openEndMission);
 PREP(uihook_giveAdminGun);
 PREP(uihook_handleMarkerDialogUI);
+PREP(uihook_listRadioChannels);
 PREP(uihook_tabChange);
 PREP(uihook_safeStart);
 PREP(uihook_supplySpawn);

--- a/addons/adminMenu/functions/fnc_reloadMarkersTab.sqf
+++ b/addons/adminMenu/functions/fnc_reloadMarkersTab.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Examples:
- * [] call potato_adminMenu_reloadMarkersTab;
+ * [] call potato_adminMenu_fnc_reloadMarkersTab;
  *
  * Public: No
  */

--- a/addons/adminMenu/functions/fnc_uihook_attachMarkerGroup.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_attachMarkerGroup.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Examples:
- * [] call potato_adminMenu_uihook_attachMarkerGroup;
+ * [] call potato_adminMenu_fnc_uihook_attachMarkerGroup;
  *
  * Public: No
  */

--- a/addons/adminMenu/functions/fnc_uihook_attachMarkerUnit.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_attachMarkerUnit.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Examples:
- * [] call potato_adminMenu_uihook_attachMarkerUnit;
+ * [] call potato_adminMenu_fnc_uihook_attachMarkerUnit;
  *
  * Public: No
  */

--- a/addons/adminMenu/functions/fnc_uihook_deleteMarker.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_deleteMarker.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Examples:
- * [] call potato_adminMenu_uihook_attachMarkerUnit;
+ * [] call potato_adminMenu_fnc_uihook_attachMarkerUnit;
  *
  * Public: No
  */

--- a/addons/adminMenu/functions/fnc_uihook_detachMarker.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_detachMarker.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Examples:
- * [] call potato_adminMenu_uihook_attachMarkerUnit;
+ * [] call potato_adminMenu_fnc_uihook_detachMarker;
  *
  * Public: No
  */

--- a/addons/adminMenu/functions/fnc_uihook_handleMarkerDialogUI.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_handleMarkerDialogUI.sqf
@@ -27,7 +27,7 @@
  * None
  *
  * Examples:
- * [false] call potato_adminMenu_uihook_handleMarkerDialogUI;
+ * [false] call potato_adminMenu_fnc_uihook_handleMarkerDialogUI;
  *
  * Public: No
  */

--- a/addons/adminMenu/functions/fnc_uihook_listRadioChannels.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_listRadioChannels.sqf
@@ -61,7 +61,7 @@ private _diaryBuilder = ["<font size=28 face=""PuristaBold"">Radio Channels</fon
         } forEach _channels;
         _diaryBuilder pushBack format [
             "<font size=12>%1<br/>  SR: %2 | MR: %3 | LR: %4</font>",
-            groupID _x,
+            groupId _x,
             _channels#0,
             _channels#1,
             _channels#2

--- a/addons/adminMenu/functions/fnc_uihook_listRadioChannels.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_listRadioChannels.sqf
@@ -11,7 +11,7 @@
 * None
 *
 * Examples:
-* [] call potato_radios_fnc_uihook_listRadioChannels.sqf
+* [] call potato_adminMenu_fnc_uihook_listRadioChannels
 *
 * Public: No
 */

--- a/addons/adminMenu/functions/fnc_uihook_listRadioChannels.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_listRadioChannels.sqf
@@ -1,0 +1,114 @@
+#include "..\script_component.hpp"
+/*
+* Author: Lambda.Tiger
+* This function handle outputs all unit and group radio channels for groups
+* and units that currently exist in a mission.
+*
+* Arguments:
+* None
+*
+* Return Value:
+* None
+*
+* Examples:
+* [] call potato_radios_fnc_uihook_listRadioChannels.sqf
+*
+* Public: No
+*/
+private _debugMsg = format ["Added Potato Radio Channels List"];
+["potato_adminMsg", [_debugMsg, profileName]] call CBA_fnc_globalEvent;
+
+// Needs a player to add to breifing:
+if ((isNull player) || {!alive player}) exitWith {};
+
+private _diaryBuilder = ["<font size=28 face=""PuristaBold"">Radio Channels</font>"];
+{
+    private _groups = (groups _x) select {[_x getVariable [QEGVAR(radios,srchannel),-1], _x getVariable [QEGVAR(radios,mrchannel),-1], _x getVariable [QEGVAR(radios,lrchannel),-1]] isNotEqualTo [-1,-1,-1]};
+    private _units = (units _x) select {[_x getVariable [QEGVAR(radios,srchannel),-1], _x getVariable [QEGVAR(radios,mrchannel),-1], _x getVariable [QEGVAR(radios,lrchannel),-1]] isNotEqualTo [-1,-1,-1]};
+    private _sideStr = "Indy";
+    private _color = switch (_x) do {
+        case (west): {
+            _sideStr = "BluFor";
+           "#0088EE" //0,0.45,0.9,1
+        };
+        case (east): {
+            _sideStr = "OpFor";
+            "#DD0000" //0,0.45,0.9,1
+        };
+        case (resistance): {
+            "#00DD00" //0,0.45,0.9,1
+        };
+        default {
+            "#880099" //0,0.45,0.9,1
+        };
+    };
+    if (_groups isEqualTo [] && _units isEqualTo []) then {continue};
+    _diaryBuilder pushBack format ["<font color=""%1"" size=20 face=""PuristaBold"">%2 Radios Channels</font>", _color, _sideStr];
+    _diaryBuilder pushBack "<font size=16 face=""PuristaBold"">Group Default Channels</font>";
+    private _groupHash = createHashMap;
+    {
+        private _channels = [
+            _x getVariable [QEGVAR(radios,srchannel),-1],
+            _x getVariable [QEGVAR(radios,mrchannel),-1],
+            _x getVariable [QEGVAR(radios,lrchannel),-1]
+        ];
+        {
+            if (_x < 10) then {
+                _channels set [_forEachIndex, "0" + str _x];
+            } else {
+                _channels set [_forEachIndex, str _x];
+            };
+        } forEach _channels;
+        _diaryBuilder pushBack format [
+            "<font size=12>%1<br/>  SR: %2 | MR: %3 | LR: %4</font>",
+            groupID _x,
+            _channels#0,
+            _channels#1,
+            _channels#2
+        ];
+    } forEach _groups;
+
+    _diaryBuilder pushBack "<font size=16 face=""PuristaBold"">Specific Unit Channels</font>";
+    private _unitHash = createHashMap;
+    {
+        private _channels = [
+            _x getVariable [QEGVAR(radios,srchannel),-1],
+            _x getVariable [QEGVAR(radios,mrchannel),-1],
+            _x getVariable [QEGVAR(radios,lrchannel),-1]
+        ];
+        {
+            if (_x < 10) then {
+                _channels set [_forEachIndex, "0" + str _x];
+            } else {
+                _channels set [_forEachIndex, str _x];
+            };
+        } forEach _channels;
+        _diaryBuilder pushBack format [
+            "<font size=12>%1<br/>  SR: %2 | MR: %3 | LR: %4</font>",
+            ((roleDescription _x) splitString "@")#0,
+            _channels#0,
+            _channels#1,
+            _channels#2
+        ];
+    } forEach _units;
+} forEach [west, east, resistance];
+
+if !(player diarySubjectExists "POTATO") then {
+    player createDiarySubject ["POTATO", "POTATO"];
+};
+// find the diary
+private _diaryEntries = player allDiaryRecords "POTATO";
+// find and replace existing orbat pages
+private _noOrbatFound = true;
+{
+    _x params ["_idx", "_title", "", "", "", "", "", "", "_record"];
+    if (_title == "Radio Report") then {
+        player setDiaryRecordText [["POTATO", _record], ["Radio Report", _diaryBuilder joinString "<br/>"]];
+        _noOrbatFound = false;
+    };
+} forEach _diaryEntries;
+
+// if we didn't find and replace, add one
+if (_noOrbatFound) then {
+    player createDiaryRecord ["POTATO", ["Radio Report", _diaryBuilder joinString "<br/>"], taskNull, "NONE", false];
+};

--- a/addons/missionMaking/functions/fnc_onMissionSave.sqf
+++ b/addons/missionMaking/functions/fnc_onMissionSave.sqf
@@ -246,6 +246,14 @@ private _checkMedical = [];
 
 } forEach _allUnits;
 
+private _checkGroupIDs = [];
+{
+  private _groupID = groupID _x;
+  if ("-" in _groupID && {"Alpha" in _groupID || {"Bravo" in _groupID} || {"Charlie" in _groupID}} && {playableUnits arrayIntersect  units _x isNotEqualTo []}) then {
+	_checkGroupIDs pushBack _groupID;
+  };
+} forEach allGroups;
+
 if (_checkWeapons isNotEqualTo []) then {
     _problems pushBack ["Units missing weapons", _checkWeapons];
 };
@@ -254,6 +262,9 @@ if (_checkMagazines isNotEqualTo []) then {
 };
 if (_checkMedical isNotEqualTo []) then {
     _problems pushBack ["Units missing medical", _checkMedical];
+};
+if (_checkGroupIDs isNotEqualTo []) then {
+    _problems pushBack ["Set group callsigns (e.g., Blufor ASL)", _checkGroupIDs];
 };
 
 private _fortifies = (all3DENEntities select 3) select {_x isKindOf "potato_fortify_setupModule"};
@@ -282,7 +293,7 @@ if (_problems isEqualTo []) then {
                 _errorArray resize 5;
                 _errorArray pushBack format [" + %1 more", _errorCount - 5];
             };
-            private _msg = format ["[%1/%2] %3:%4", (_forEachIndex + 1), count _problems, _errorCode, _errorArray];
+            private _msg = format ["[%1/%2] %3: %4", (_forEachIndex + 1), count _problems, _errorCode, _errorArray];
             systemChat _msg;
             [_msg] call BIS_fnc_3DENNotification;
             INFO_1("%1",_msg);

--- a/addons/missionMaking/functions/fnc_onMissionSave.sqf
+++ b/addons/missionMaking/functions/fnc_onMissionSave.sqf
@@ -248,7 +248,7 @@ private _checkMedical = [];
 
 private _checkGroupIDs = [];
 {
-  private _groupID = groupID _x;
+  private _groupID = groupId _x;
   if ("-" in _groupID && {"Alpha" in _groupID || {"Bravo" in _groupID} || {"Charlie" in _groupID}} && {playableUnits arrayIntersect  units _x isNotEqualTo []}) then {
 	_checkGroupIDs pushBack _groupID;
   };
@@ -264,7 +264,7 @@ if (_checkMedical isNotEqualTo []) then {
     _problems pushBack ["Units missing medical", _checkMedical];
 };
 if (_checkGroupIDs isNotEqualTo []) then {
-    _problems pushBack ["Set group callsigns (e.g., Blufor ASL)", _checkGroupIDs];
+    _problems pushBack ["Set group callsign(s) (e.g., Blufor ASL)", _checkGroupIDs];
 };
 
 private _fortifies = (all3DENEntities select 3) select {_x isKindOf "potato_fortify_setupModule"};


### PR DESCRIPTION
This PR adds an admin menu button to output all radio settings for present groups and units (as set by unit variables). In addition, this PR adds a check for properly set callsigns (groupIDs) on mission save for all groups with playable units (avoid issue with how the Orbat is generated).