### PR TITLE
zeus - make zeus keybind safe if not used

### DIFF
--- a/addons/zeusUtils/initKeybinds.inc.sqf
+++ b/addons/zeusUtils/initKeybinds.inc.sqf
@@ -5,9 +5,11 @@
     [false] call acre_api_fnc_setSpectator;
     [-1] call acre_sys_core_fnc_handleMultiPttKeyPress;
 }, {
+    if (isNil QGVAR(wasSpec)) exitWith {};
     [-1] call acre_sys_core_fnc_handleMultiPttKeyPressUp;
     if (GVAR(wasSpec)) then {
         GVAR(wasSpec) = false;
         [true] call acre_api_fnc_setSpectator;
-    }
+    };
+    GVAR(wasSpec) = nil;
 }, [DIK_CAPSLOCK, [false, false, false]]] call CBA_fnc_addKeybind; // Default Caps Lock


### PR DESCRIPTION
if we exited on line 3, we would still hit line 9 on release
I'm not actualy sure if this would cause problems, but I think it's safer to not call the acre pressUp
in case someone has capslock bound to something else