### PR TITLE
customGear - CUP - Add WP versions of 1PN138 and HMNVS

### DIFF
--- a/addons/customGear/CUP/CfgWeapons.hpp
+++ b/addons/customGear/CUP/CfgWeapons.hpp
@@ -1,0 +1,12 @@
+class CfgWeapons {
+    class CUP_NVG_1PN138;
+    class CUP_NVG_1PN138_WP: CUP_NVG_1PN138 {
+        ACEGVAR(nightvision,colorPreset)[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {1.1, 0.8, 1.9, 0.9}, {1, 1, 6, 0.0}};
+        displayname = "1PN138 (WP)";
+    };
+    class CUP_NVG_HMNVS;
+    class CUP_NVG_HMNVS_WP: CUP_NVG_HMNVS {
+        ACEGVAR(nightvision,colorPreset)[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {1.1, 0.8, 1.9, 0.9}, {1, 1, 6, 0.0}};
+        displayname = "HMNVS (WP)";
+    };
+};

--- a/addons/customGear/CUP/config.cpp
+++ b/addons/customGear/CUP/config.cpp
@@ -1,0 +1,23 @@
+#include "\z\potato\addons\customGear\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT customGear_CUP
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {
+            "CUP_NVG_1PN138_WP",
+            "CUP_NVG_HMNVS_WP"
+        };
+        magazines[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = { "potato_core", "CUP_Weapons_LoadOrder", "ace_nightvision"};
+        skipWhenMissingDependencies = 1;
+        author = "Potato";
+        authors[] = {"Lambda.Tiger"};
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"


### PR DESCRIPTION
This PR adds two non-extant versions of CUP NVG monoculars for eyestrain relief. 