### PR TITLE
miscFixes - patchGM - Add White, Green, and Yellow MG3 tracers

### DIFF
--- a/addons/miscFixes/patchGM/CfgAmmo.hpp
+++ b/addons/miscFixes/patchGM/CfgAmmo.hpp
@@ -104,4 +104,16 @@ class CfgAmmo {
     class gm_shell_artillery_Base: gm_shell_base {
         effectFly = "";
     };
+
+    // what if there were colors
+    class gm_bullet_762x51mm_B_T_DM21;
+    class gm_bullet_762x51mm_B_T_DM21_white: gm_bullet_762x51mm_B_T_DM21 {
+        model = "\A3\Weapons_f\Data\bullettracer\tracer_white";
+    };
+    class gm_bullet_762x51mm_B_T_DM21_green: gm_bullet_762x51mm_B_T_DM21 {
+        model = "\A3\Weapons_f\Data\bullettracer\tracer_green";
+    };
+    class gm_bullet_762x51mm_B_T_DM21_yellow: gm_bullet_762x51mm_B_T_DM21 {
+        model = "\A3\Weapons_f\Data\bullettracer\tracer_yellow";
+    };
 };

--- a/addons/miscFixes/patchGM/CfgMagazineWells.hpp
+++ b/addons/miscFixes/patchGM/CfgMagazineWells.hpp
@@ -1,0 +1,16 @@
+class CfgMagazineWells {
+    class gm_magazineWell_762x51mm_mg3 {
+        GVAR(magazines)[] = {
+            "gm_120Rnd_762x51mm_B_T_DM21_mg3_grn_wht",
+            "gm_120Rnd_762x51mm_B_T_DM21_mg3_grn_grn",
+            "gm_120Rnd_762x51mm_B_T_DM21_mg3_grn_ylw"
+        };
+    };
+    class gm_magazineWell_762x51mm_mg3_veh {
+        GVAR(magazines)[] = {
+            "gm_120Rnd_762x51mm_B_T_DM21_mg3_grn_wht",
+            "gm_120Rnd_762x51mm_B_T_DM21_mg3_grn_grn",
+            "gm_120Rnd_762x51mm_B_T_DM21_mg3_grn_ylw"
+        };
+    };
+};

--- a/addons/miscFixes/patchGM/CfgMagazines.hpp
+++ b/addons/miscFixes/patchGM/CfgMagazines.hpp
@@ -21,4 +21,17 @@ class CfgMagazines {
         modelSpecial = "\gm\gm_weapons\gm_machineguns\gm_pk\gm_100rnd_762x54mm_pk_modelspecial";
         modelSpecialIsProxy = 1;
     };
+    class gm_120Rnd_762x51mm_B_T_DM21_mg3_grn;
+    class gm_120Rnd_762x51mm_B_T_DM21_mg3_grn_wht: gm_120Rnd_762x51mm_B_T_DM21_mg3_grn {
+        ammo = "gm_bullet_762x51mm_B_T_DM21_white";
+        displayName = "7.62mm 120Rnd MG3 Ball-T DM21 Green Mag (White)";
+    };
+    class gm_120Rnd_762x51mm_B_T_DM21_mg3_grn_grn: gm_120Rnd_762x51mm_B_T_DM21_mg3_grn {
+        ammo = "gm_bullet_762x51mm_B_T_DM21_green";
+        displayName = "7.62mm 120Rnd MG3 Ball-T DM21 Green Mag (Green)";
+    };
+    class gm_120Rnd_762x51mm_B_T_DM21_mg3_grn_ylw: gm_120Rnd_762x51mm_B_T_DM21_mg3_grn {
+        ammo = "gm_bullet_762x51mm_B_T_DM21_yellow";
+        displayName = "7.62mm 120Rnd MG3 Ball-T DM21 Green Mag (Yellow)";
+    };
 };

--- a/addons/miscFixes/patchGM/config.cpp
+++ b/addons/miscFixes/patchGM/config.cpp
@@ -60,6 +60,7 @@ class CfgPatches {
 #include "CfgEventHandlers.hpp"
 #include "CfgGlasses.hpp"
 #include "CfgMagazines.hpp"
+#include "CfgMagazineWells.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
 


### PR DESCRIPTION
This PR adds tracers in White, Green, and Yellow for GM vehicles.