### PR TITLE
Safe Start - Safe Start Menu Abbrev Fix

### DIFF
--- a/addons/missionTesting/script_macros.hpp
+++ b/addons/missionTesting/script_macros.hpp
@@ -8,4 +8,5 @@
     The type is defined as `-1` and will thus select the last value always.
 */
 #define A_MISSION_TYPE ["Other","COOP","TVT","Long COOP","Unconventional TVT", "Unconventional COOP", "Invalid - Don't pass"]
+#define A_MISSION_TYPE_ABBREV ["Other","COOP","TVT","Long COOP","Unconv TVT", "Unconv COOP", "Invalid - Don't pass"]
 #define A_MISSION_TAGS ["NONE","NIGHT","DAWN","MSV","TvT1","TvT2","AH","FOG","BRIEF ON MAP"]

--- a/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
+++ b/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
@@ -84,7 +84,7 @@ if (_menuxPos > 0.5) then {
     private _title = _ctrlGroup controlsGroupCtrl IDC_SAFESTARTEQUIP_TITLE;
     _title ctrlSetStructuredText parseText "<t align='right'>Safe Start Info</t>"
 };
-private _missionType = A_MISSION_TYPE#_missionTypeEnum;
+private _missionType = A_MISSION_TYPE_ABBREV#_missionTypeEnum;
 
 _textArr pushBack format ["Mission Type: %1", _missionType];
 //// Timings


### PR DESCRIPTION
This PR adds abbreviated text for the mission type texts.