### PR TITLE
miscFixes - patchCUP - Add Disposable CUP M47 Dragon

### DIFF
--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -5,7 +5,11 @@
 class CfgPatches {
     class ADDON {
         units[] = {};
-        weapons[] = {};
+        weapons[] = {
+            QGVARMAIN(CUP_launch_M47),
+            QGVARMAIN(CUP_launch_M47_used),
+            QGVARMAIN(CUP_launch_M47_loaded)
+        };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
             "potato_core",
@@ -699,6 +703,8 @@ class CfgWeapons {
     class Launcher_Base_F;
     class CUP_launch_M47: Launcher_Base_F {
         modelOptics = "\z\ace\addons\dragon\models\optics_m47";
+        scope = 1;
+        scopeArsenal = 1;
         class OpticsModes {
             class  StepScope {
                 opticsZoomInit = 0.055;
@@ -706,6 +712,33 @@ class CfgWeapons {
                 opticsZoomMin = 0.055;
                 visionMode[] = {"Normal"};
             };
+        };
+        class WeaponSlotsInfo;
+    };
+    class GVARMAIN(CUP_launch_M47_loaded): CUP_launch_M47 {
+        baseWeapon = QGVARMAIN(CUP_launch_M47);
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 142.98;
+        };
+        class EventHandlers {
+            fired = "_this call CBA_fnc_firedDisposable";
+        };
+    };
+    class GVARMAIN(CUP_launch_M47): GVARMAIN(CUP_launch_M47_loaded) {
+        baseWeapon = QGVARMAIN(CUP_launch_M47);
+        scope = 2;
+        scopeArsenal = 2;
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 142.98 + 235.4;
+        };
+    };
+    class GVARMAIN(CUP_launch_M47_used): GVARMAIN(CUP_launch_M47_loaded) {
+        displayName = "M47 Dragon (Used)";
+        baseWeapon = QGVARMAIN(CUP_launch_M47_Used);
+        magazines[] = {"CBA_FakeLauncherMagazine"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 142.98;
         };
     };
 
@@ -1123,3 +1156,8 @@ class gm_slotOptic_risrail: CowsSlot_Rail {
         CUP_optic_SERedDot = 1;
     };
 };
+
+class CBA_DisposableLaunchers {
+    GVARMAIN(CUP_launch_M47_loaded)[] = {QGVARMAIN(CUP_launch_M47),QGVARMAIN(CUP_launch_M47_used)};
+};
+

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -703,8 +703,7 @@ class CfgWeapons {
     class Launcher_Base_F;
     class CUP_launch_M47: Launcher_Base_F {
         modelOptics = "\z\ace\addons\dragon\models\optics_m47";
-        scope = 1;
-        scopeArsenal = 1;
+        displayName = "M47 Dragon (AI)";
         class OpticsModes {
             class  StepScope {
                 opticsZoomInit = 0.055;
@@ -717,6 +716,10 @@ class CfgWeapons {
     };
     class GVARMAIN(CUP_launch_M47_loaded): CUP_launch_M47 {
         baseWeapon = QGVARMAIN(CUP_launch_M47);
+        displayName = "$STR_CUP_DN_M47";
+        magazineReloadTime = 0;
+        scope = 1;
+        scopeArsenal = 1;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             mass = 142.98;
         };

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -356,6 +356,10 @@ class CfgMagazines {
         displayName = "40x46mm 6Rnd M433 (HEDP) Grenade";
         displayNameshort = "M433 HEDP";
     };
+    class CA_LauncherMagazine;
+    class CUP_Dragon_EP1_M: CA_LauncherMagazine {
+        mass = 222.01;
+    };
 };
 
 class CfgMagazineWells {
@@ -721,7 +725,7 @@ class CfgWeapons {
         scope = 1;
         scopeArsenal = 1;
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            mass = 142.98;
+            mass = 99.86;
         };
         class EventHandlers {
             fired = "_this call CBA_fnc_firedDisposable";
@@ -733,7 +737,7 @@ class CfgWeapons {
         scopeArsenal = 2;
         magazines[] = {"CBA_FakeLauncherMagazine"};
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            mass = 142.98 + 235.4;
+            mass = 99.86 + 222.01;
         };
     };
     class GVARMAIN(CUP_launch_M47_used): GVARMAIN(CUP_launch_M47_loaded) {
@@ -741,7 +745,7 @@ class CfgWeapons {
         baseWeapon = QGVARMAIN(CUP_launch_M47_Used);
         magazines[] = {"CBA_FakeLauncherMagazine"};
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            mass = 142.98;
+            mass = 99.86;
         };
     };
 


### PR DESCRIPTION
This PR adds a CBA disposable version of the CUP M47 Dragon.