### PR TITLE
missionMaking - Export Equipement Storage to Box for CfgLoadouts

### DIFF
--- a/addons/missionMaking/Cfg3DEN.hpp
+++ b/addons/missionMaking/Cfg3DEN.hpp
@@ -1,4 +1,23 @@
 class Cfg3DEN {
+    class Attributes {
+        class Default;
+        class TitleWide: Default {
+            class Controls;
+        };
+        class AmmoBox: TitleWide {
+            class Controls: Controls {
+                class ButtonClear;
+                class CopyToClipboard: ButtonClear {
+                    idc = 20260512;
+                    text = "Copy to Clipboard";
+                    tooltip = "Copy loadout to clipboard for use with class SupplyBoxes in CfgLoadouts";
+                    onButtonClick = QUOTE(call compile preprocessFileLineNumbers QUOTE(QPATHTOF(functions\fnc_exportBox.sqf)););
+                    x = "5 * (pixelW * pixelGrid * 0.50)";
+                    w = "50 * (pixelW * pixelGrid * 0.50)";
+                };
+            };
+        };
+    };
     class EventHandlers {
         class ADDON {
             onMissionSave = QUOTE(call compile preprocessFileLineNumbers QUOTE(QPATHTOF(functions\fnc_onMissionSave.sqf)));

--- a/addons/missionMaking/Cfg3DEN.hpp
+++ b/addons/missionMaking/Cfg3DEN.hpp
@@ -9,9 +9,9 @@ class Cfg3DEN {
                 class ButtonClear;
                 class CopyToClipboard: ButtonClear {
                     idc = 20260512;
-                    text = "Copy to Clipboard";
-                    tooltip = "Copy loadout to clipboard for use with class SupplyBoxes in CfgLoadouts";
-                    onButtonClick = QUOTE(call compile preprocessFileLineNumbers QUOTE(QPATHTOF(functions\fnc_exportBox.sqf)););
+                    text = "Copy for BWMF";
+                    tooltip = "Copy loadout to clipboard for use with CfgLoadouts or a faction loadout";
+                    onButtonClick = QUOTE(call compileScript [QUOTE(QPATHTOF(functions\fnc_exportBox.sqf))];);
                     x = "5 * (pixelW * pixelGrid * 0.50)";
                     w = "50 * (pixelW * pixelGrid * 0.50)";
                 };

--- a/addons/missionMaking/functions/fnc_exportBox.sqf
+++ b/addons/missionMaking/functions/fnc_exportBox.sqf
@@ -1,12 +1,12 @@
 // Based on "A3\3den\UI\attributes\AmmoBox.sqf"
 // Gathers current box info and exports it to text
-private _attributeInvent = uinamespace getvariable ["RscAttributeInventory_cargo", [[],[]]];
+private _attributeInvent = uiNamespace getVariable ["RscAttributeInventory_cargo", [[],[]]];
 private _itemHash = (_attributeInvent#0) createHashMapFromArray (_attributeInvent#1);
 private _weapons = [];
 private _magazines = [];
 private _items = [];
 private _backpacks = [];
-private _cfgWeps = configfile >> "CfgWeapons";
+private _cfgWeps = configFile >> "CfgWeapons";
 private _cfgMags = configFile >> "CfgMagazines";
 private _cfgVics = configFile >> "CfgVehicles";
 private _cfgGlass = configFile >> "CfgGlasses";
@@ -19,22 +19,20 @@ private _cfgGlass = configFile >> "CfgGlasses";
         _x
     };
     switch (true) do {
-        case (getnumber (_cfgWeps >> _class >> "type") in [4096, 131072]): {
-            _items pushback _format;
+        case (isClass (_cfgGlass >> _class));
+        case (getNumber (_cfgWeps >> _class >> "type") in [4096, 131072]): {
+            _items pushBack _format;
         };
-        case (isclass (_cfgWeps >> _class)): {
-            _weapons pushback _format;
+        case (isClass (_cfgWeps >> _class)): {
+            _weapons pushBack _format;
         };
-        case (isclass (_cfgMags >> _class)): {
-            _magazines pushback _format;
+        case (isClass (_cfgMags >> _class)): {
+            _magazines pushBack _format;
         };
-        case (isclass (_cfgVics >> _class)): {
-            _backpacks pushback _format;
+        case (isClass (_cfgVics >> _class)): {
+            _backpacks pushBack _format;
         };
-        case (isclass (_cfgGlass >> _class)): {
-            _items pushback _format;
-        };
-        default {-1};
+        default {};
     };
 } forEach _itemHash;
 // Create the output text lines

--- a/addons/missionMaking/functions/fnc_exportBox.sqf
+++ b/addons/missionMaking/functions/fnc_exportBox.sqf
@@ -37,8 +37,6 @@ private _cfgGlass = configFile >> "CfgGlasses";
         default {-1};
     };
 } forEach _itemHash;
-
-
 // Create the output text lines
 private _lines = [
     "class <boxClassname> {",

--- a/addons/missionMaking/functions/fnc_exportBox.sqf
+++ b/addons/missionMaking/functions/fnc_exportBox.sqf
@@ -1,0 +1,80 @@
+// Based on "A3\3den\UI\attributes\AmmoBox.sqf"
+// Gathers current box info and exports it to text
+private _attributeInvent = uinamespace getvariable ["RscAttributeInventory_cargo", [[],[]]];
+private _itemHash = (_attributeInvent#0) createHashMapFromArray (_attributeInvent#1);
+private _weapons = [];
+private _magazines = [];
+private _items = [];
+private _backpacks = [];
+private _cfgWeps = configfile >> "CfgWeapons";
+private _cfgMags = configFile >> "CfgMagazines";
+private _cfgVics = configFile >> "CfgVehicles";
+private _cfgGlass = configFile >> "CfgGlasses";
+{
+    if (_y <= 0) then {continue};
+    private _class = _x;
+    private _format = if (_y > 1) then {
+        format ["%1:%2",_x,_y];
+    } else {
+        _x
+    };
+    switch (true) do {
+        case (getnumber (_cfgWeps >> _class >> "type") in [4096, 131072]): {
+            _items pushback _format;
+        };
+        case (isclass (_cfgWeps >> _class)): {
+            _weapons pushback _format;
+        };
+        case (isclass (_cfgMags >> _class)): {
+            _magazines pushback _format;
+        };
+        case (isclass (_cfgVics >> _class)): {
+            _backpacks pushback _format;
+        };
+        case (isclass (_cfgGlass >> _class)): {
+            _items pushback _format;
+        };
+        default {-1};
+    };
+} forEach _itemHash;
+
+
+// Create the output text lines
+private _lines = [
+    "    class <boxClassname> {",
+    "      boxCustomName = ""Resupply Box"";"
+];
+if (_weapons isNotEqualTo []) then {
+    _lines pushBack "      class TransportWeapons[] = {";
+    {
+        _lines pushBack format ["        %1,", str _x];
+    } forEach _weapons;
+    _lines pushBack "      };";
+};
+if (_magazines isNotEqualTo []) then {
+    _lines pushBack "      class TransportMagazines[] = {";
+    {
+        _lines pushBack format ["        %1,", str _x];
+    } forEach _magazines;
+    _lines pushBack "      };";
+};
+if (_items isNotEqualTo []) then {
+    _lines pushBack "      class TransportItems[] = {";
+    {
+        _lines pushBack format ["        %1,", str _x];
+    } forEach _items;
+    _lines pushBack "      };";
+};
+if (_backpacks isNotEqualTo []) then {
+    _lines pushBack "      class TransportBackpacks[] = {";
+    {
+        _lines pushBack format ["        %1,", str _x];
+    } forEach _backpacks;
+    _lines pushBack "      };";
+};
+_lines pushBack "    };";
+// Use ace extensions to put it in the clipboard
+{
+    "ace" callExtension ["clipboard:append", [_x + endl]];
+} forEach _lines;
+"ace" callExtension ["clipboard:complete", []];

--- a/addons/missionMaking/functions/fnc_exportBox.sqf
+++ b/addons/missionMaking/functions/fnc_exportBox.sqf
@@ -41,38 +41,38 @@ private _cfgGlass = configFile >> "CfgGlasses";
 
 // Create the output text lines
 private _lines = [
-    "    class <boxClassname> {",
-    "      boxCustomName = ""Resupply Box"";"
+    "class <boxClassname> {",
+    "  boxCustomName = ""Resupply Box"";"
 ];
 if (_weapons isNotEqualTo []) then {
-    _lines pushBack "      class TransportWeapons[] = {";
+    _lines pushBack "  class TransportWeapons[] = {";
     {
-        _lines pushBack format ["        %1,", str _x];
+        _lines pushBack format ["    %1,", str _x];
     } forEach _weapons;
-    _lines pushBack "      };";
+    _lines pushBack "  };";
 };
 if (_magazines isNotEqualTo []) then {
-    _lines pushBack "      class TransportMagazines[] = {";
+    _lines pushBack "  class TransportMagazines[] = {";
     {
-        _lines pushBack format ["        %1,", str _x];
+        _lines pushBack format ["    %1,", str _x];
     } forEach _magazines;
-    _lines pushBack "      };";
+    _lines pushBack "  };";
 };
 if (_items isNotEqualTo []) then {
-    _lines pushBack "      class TransportItems[] = {";
+    _lines pushBack "  class TransportItems[] = {";
     {
-        _lines pushBack format ["        %1,", str _x];
+        _lines pushBack format ["    %1,", str _x];
     } forEach _items;
-    _lines pushBack "      };";
+    _lines pushBack "  };";
 };
 if (_backpacks isNotEqualTo []) then {
-    _lines pushBack "      class TransportBackpacks[] = {";
+    _lines pushBack "  class TransportBackpacks[] = {";
     {
-        _lines pushBack format ["        %1,", str _x];
+        _lines pushBack format ["    %1,", str _x];
     } forEach _backpacks;
-    _lines pushBack "      };";
+    _lines pushBack "  };";
 };
-_lines pushBack "    };";
+_lines pushBack "};";
 // Use ace extensions to put it in the clipboard
 {
     "ace" callExtension ["clipboard:append", [_x + endl]];


### PR DESCRIPTION
This PR adds a button to export a formatted string for resupply boxes from the "Equipment Storage" interface in the editor.