### PR TITLE
core - add fix for `acre_sys_radio_setup` errors

### DIFF
--- a/.hemtt/lints.toml
+++ b/.hemtt/lints.toml
@@ -36,3 +36,8 @@ enabled = false
 
 [sqf.not_private]
 enabled = true
+
+[inspector]
+header_regex = "ace"
+vars_to_ignore = []
+check_function_calls = true

--- a/addons/core/XEH_postInit.sqf
+++ b/addons/core/XEH_postInit.sqf
@@ -1,5 +1,19 @@
 #include "script_component.hpp"
 
+// this is in core because potato_radios will run after acre
+if (isServer) then {
+    private _list = allUnits select { !((_x getVariable ["acre_sys_radio_setup", ""]) isEqualType "") } apply { [_x, vehicleVarName _x] };
+    [{
+        {
+            _x params ["_unit", "_varName"];
+            ["potato_adminMsg", [format ["Warning: Bad acre var on slot %1 (%2)", _varName, name _unit]]] call CBA_fnc_globalEvent;
+        } forEach _this;
+    }, _list, 5] call CBA_fnc_waitAndExecute;
+};
+if (hasInterface) then {
+    player setVariable ["acre_sys_radio_setup", nil];
+};
+
 if (isServer) then {
     [QGVAR(addToCurator), LINKFUNC(addToCuratorServer)] call CBA_fnc_addEventHandler;
 };

--- a/addons/core/XEH_postInit.sqf
+++ b/addons/core/XEH_postInit.sqf
@@ -1,19 +1,5 @@
 #include "script_component.hpp"
 
-// this is in core because potato_radios will run after acre
-if (isServer) then {
-    private _list = allUnits select { !((_x getVariable ["acre_sys_radio_setup", ""]) isEqualType "") } apply { [_x, vehicleVarName _x] };
-    [{
-        {
-            _x params ["_unit", "_varName"];
-            ["potato_adminMsg", [format ["Warning: Bad acre var on slot %1 (%2)", _varName, name _unit]]] call CBA_fnc_globalEvent;
-        } forEach _this;
-    }, _list, 5] call CBA_fnc_waitAndExecute;
-};
-if (hasInterface) then {
-    player setVariable ["acre_sys_radio_setup", nil];
-};
-
 if (isServer) then {
     [QGVAR(addToCurator), LINKFUNC(addToCuratorServer)] call CBA_fnc_addEventHandler;
 };
@@ -109,3 +95,10 @@ if (hasInterface) then {
 }] call CBA_fnc_addEventHandler;
 
 call FUNC(playerJipHint);
+
+// this is in core because potato_radios will run after acre, this should run first (ref https://github.com/BourbonWarfare/POTATO/pull/888)
+if (isServer) then {
+    private _list = allUnits select { !((_x getVariable ["acre_sys_radio_setup", ""]) isEqualType "") };
+    { WARNING_2("Unit %1 (%2) has bad acre var",vehicleVarName _x,name _x); } forEach _list;
+};
+if (hasInterface) then { player setVariable ["acre_sys_radio_setup", nil]; };

--- a/addons/missionMaking/functions/fnc_onMissionLoad.sqf
+++ b/addons/missionMaking/functions/fnc_onMissionLoad.sqf
@@ -30,3 +30,13 @@ if (!(_current_uuid isEqualType "") || { _current_uuid isEqualTo "" }) then {
    diag_log format["POTATO - setting mission uuid: %1", _current_uuid];
    set3DENMissionAttributes [[QEGVAR(missiontesting,missionTestingInfo), QGVAR(uuid), _current_uuid]];
 };
+
+all3DENEntities params ["_objects"];
+{
+   private _at = _x get3DENAttribute "acre_sys_radio_edenSetup";
+   if (!isNil "_at" && {_at isNotEqualTo [[]]}) then {
+      INFO_1("Removing acre attrib from object %1",_x);
+      systemChat "Cleaning up acre attrib - Make sure to save the mission after this";
+      _x clear3DENAttribute "acre_sys_radio_edenSetup";
+   };
+} forEach _objects;

--- a/addons/respawn/functions/fnc_ui_handleAdminLoad.sqf
+++ b/addons/respawn/functions/fnc_ui_handleAdminLoad.sqf
@@ -57,7 +57,7 @@ _ctrlNoMarkerCheckBox ctrlAddEventHandler ["CheckedChanged", {
 
 
 // validate user
-if (!([] call EFUNC(core,isAuthorized)) && !(ZEUS_ENABLED && !((getPlayerUID player) in BLACK_LIST_UIDS) && profileNamespace getVariable [EULA_CHECK, false])) exitWith {
+if (!([] call EFUNC(core,isAuthorized)) && !(ZEUS_ENABLED && !((getPlayerUID player) in BLACK_LIST_UIDS) && (true isEqualTo (profileNamespace getVariable [EULA_CHECK, false])))) exitWith {
     WARNING("Not authorized for respawn");
     [] call FUNC(closeAdminRespawn);
 };

--- a/addons/steamEvents/XEH_postClientInit.sqf
+++ b/addons/steamEvents/XEH_postClientInit.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-if (!hasInterface || profileNamespace getVariable [QGVAR(disable), false]) exitWith {};
+if (!hasInterface || (true isEqualTo (profileNamespace getVariable [QGVAR(disable), false]))) exitWith {};
 
 GVAR(delayedEvents) = [];
 DFUNC(addDelayedEvents) = {


### PR DESCRIPTION
can't put in potato_radios because that runs after acre_sys_radios because of requiredAddons load order
I'm not sure if potato_core is guaranteed to run first, but this seems to fix the issue
