### PR TITLE
spectate - Draw locations of player deaths

### DIFF
--- a/addons/spectate/XEH_postClientInit.sqf
+++ b/addons/spectate/XEH_postClientInit.sqf
@@ -46,4 +46,12 @@ if (GVAR(enabled) && hasInterface) then {
         _patient setVariable [QGVAR(checked), [_patient, _name], true]; // self-unit to handle respawning units copying vars
      }] call CBA_fnc_addEventHandler;
 
+    // Player death
+    GVAR(deathHash) = createHashMap;
+    addMissionEventHandler ["EntityKilled", {
+        params ["_unit"];
+        if (isPlayer _unit) then {
+            GVAR(deathHash) set [name _unit + str time, [ASLToAGL getPosASL _unit, name _unit, side group _unit]];
+        };
+    }];
 };

--- a/addons/spectate/functions/fnc_setup.sqf
+++ b/addons/spectate/functions/fnc_setup.sqf
@@ -139,6 +139,7 @@ GVAR(drawProjectiles) = false;
 
 // init misc GVARS
 GVAR(curList) = [];
+GVAR(drawDeaths) = false;
 GVAR(mapOpen) = false;
 GVAR(fullMapOpen) = false;
 GVAR(needToAddBriefings) = true;

--- a/addons/spectate/functions/fnc_ui_handleDraw3D.sqf
+++ b/addons/spectate/functions/fnc_ui_handleDraw3D.sqf
@@ -190,6 +190,28 @@ if !(GVAR(mapOpen) || GVAR(fullMapOpen)) then {
         GVAR(grenades) = _grenadesNew;
         END_COUNTER(drawTracers);
     };
+
+    // Draw bodies on map
+    if (GVAR(drawDeaths)) then {
+        private _cameraPosAGL = positionCameraToWorld [0,0,0];
+        {
+            _y params ["_pos", "_name", ["_side", civilian]];
+            private _color = switch (_side) do {
+                case (west): {[0, 0, 0.7, 0.5]};
+                case (east): {[0.7, 0, 0, 0.5]};
+                case (resistance): {[0, 0.7, 0, 0.5]};
+                case (civilian): {[0.5,0,0.5,0.5]};
+                default {[0.7, 0.7, 0.7, 0.5]};
+            };
+            private _k = 1 min (2 / (1 max log (_cameraPosAGL distance _pos)));
+            drawIcon3D [
+                "\A3\ui_f\data\map\markers\military\dot_CA.paa",
+                _color, _pos, 1 * _k, 1 * _k, 0, _name,
+                2, 0.04 * _k, "RobotoCondensed", "right",
+                false, 0.002 * _k, -0.023 * _k
+            ];
+        } forEach GVAR(deathHash);
+    };
 };
 
 END_COUNTER(draw3D);

--- a/addons/spectate/functions/fnc_ui_handleKeyDown.sqf
+++ b/addons/spectate/functions/fnc_ui_handleKeyDown.sqf
@@ -195,4 +195,8 @@ if ((_key == DIK_F5) && {_this select 2} && {_this select 3}) exitWith {
     call EFUNC(missionTesting,displayMenu);
 };
 
+if (_key == DIK_LBRACKET) exitWith {
+    GVAR(drawDeaths) = !GVAR(drawDeaths);
+};
+
 false // default to unhandled

--- a/addons/spectate/script_component.hpp
+++ b/addons/spectate/script_component.hpp
@@ -204,6 +204,7 @@ Player stats (default 'P') to view the selected player's stats<br/>\
 Get over (default 'V') to toggle camera speed at ground level<br/>\
 Tasks/diary (default 'J') to open/close the briefings<br/>\
 Compass (default 'K') to open/close the compass<br/>\
+Left Brace ('[') to toggle showing player death locations<br/>\
 </t>
 
 #define TAGS_VISIBLE_MODE_COUNT 3


### PR DESCRIPTION
This PR adds an overlay that draws a marker where a player dies, may be worth choosing a custom icon instead of a dot.