### PR TITLE
miscFixes - patchSOG - Override SOG Editor Defaults

### DIFF
--- a/addons/miscFixes/patchSOG/config.cpp
+++ b/addons/miscFixes/patchSOG/config.cpp
@@ -15,6 +15,8 @@ class CfgPatches {
     };
 };
 
+#include "display3DEN.hpp"
+
 class CfgMissions {
   class Cutscenes { // restore the load menus
         class Stratis_intro1 {

--- a/addons/miscFixes/patchSOG/display3DEN.hpp
+++ b/addons/miscFixes/patchSOG/display3DEN.hpp
@@ -1,0 +1,66 @@
+class ctrlControlsGroupNoScrollbars;
+class ctrlTree;
+class Display3DEN {
+    class Controls {
+        class PanelRight: ctrlControlsGroupNoScrollbars {
+            class Controls {
+                class PanelRightCreate: ctrlControlsGroupNoScrollbars {
+                    class Controls {
+                        class Create: ctrlControlsGroupNoScrollbars {
+                            class Controls {
+                                // Units
+                                class CreateObjectWEST: ctrlTree {
+                                    defaultItem[] = {
+                                        QUOTE(DOUBLES(PREFIX,W)),
+                                        "Fireteam"
+                                    };
+                                };
+                                class CreateObjectEAST: CreateObjectWEST {
+                                    defaultItem[] = {
+                                        QUOTE(DOUBLES(PREFIX,E)),
+                                        "Fireteam"
+                                    };
+                                };
+                                class CreateObjectGUER: CreateObjectWEST {
+                                    defaultItem[] = {
+                                        QUOTE(DOUBLES(PREFIX,I)),
+                                        "Fireteam"
+                                    };
+                                };
+                                class CreateObjectCIV: CreateObjectWEST {
+                                    defaultItem[] = {
+                                        "CIV_F",
+                                        "EdSubcat_Personnel"
+                                    };
+                                };
+                                class CreateObjectEMPTY: CreateObjectWEST {};
+                                // Groups
+                                class CreateGroupWEST: CreateObjectEMPTY {
+                                    defaultItem[] = {
+                                        QUOTE(DOUBLES(PREFIX,W)),
+                                        "Infantry"
+                                    };
+                                };
+                                class CreateGroupEAST: CreateObjectEMPTY {
+                                    defaultItem[] = {
+                                        QUOTE(DOUBLES(PREFIX,E)),
+                                        "Infantry"
+                                    };
+                                };
+                                class CreateGroupGUER: CreateObjectEMPTY {
+                                    defaultItem[] = {
+                                        QUOTE(DOUBLES(PREFIX,I)),
+                                        "Infantry"
+                                    };
+                                };
+                                class CreateGroupCiv: CreateObjectEMPTY {
+                                    defaultItem[] = {};
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
+};


### PR DESCRIPTION
This PR replaces the default unit/groups from SOG's edit to Potato units/groups.