### PR TITLE
various - Spectate Update and New CSW Magazines 

### DIFF
--- a/addons/artillery/functions/fnc_localArtilleryHandler.sqf
+++ b/addons/artillery/functions/fnc_localArtilleryHandler.sqf
@@ -56,7 +56,7 @@ switch (_newStatus) do {
         ];
         _holdTime = _holdTime + CBA_missionTime;
         {
-            _x setVariable  [QGVAR(artyMission), [
+            _x setVariable [QGVAR(artyMission), [
                 _missionID,
                 ARTILLERY_MISSION_STATUS_WAIT,
                 _holdTime
@@ -70,7 +70,7 @@ switch (_newStatus) do {
         ];
         _holdTime = _holdTime + CBA_missionTime;
         {
-            _x setVariable  [QGVAR(artyMission), [
+            _x setVariable [QGVAR(artyMission), [
                 _missionID,
                 ARTILLERY_MISSION_STATUS_ASSIGN,
                 _holdTime,
@@ -105,7 +105,7 @@ switch (_newStatus) do {
             }, true]) params ["_weapon"];
             private _reloadTime = [_weapon] call FUNC(getArtyReloadTime);
             private _holdTime = CBA_missionTime + 2 * (_reloadTime + 5) * _rounds;
-            _gun setVariable  [QGVAR(artyMission), [
+            _gun setVariable [QGVAR(artyMission), [
                 _missionID,
                 ARTILLERY_MISSION_STATUS_FIRING,
                 _holdTime,
@@ -130,7 +130,7 @@ switch (_newStatus) do {
                 "_missionName", "_status", "_holdTime"
             ];
             if (_missionName == _missionID) then {
-                _x setVariable  [QGVAR(artyMission), nil];
+                _x setVariable [QGVAR(artyMission), nil];
             };
         } forEach _artyPieces;
     };

--- a/addons/customGear/ACE_CSW_Groups.hpp
+++ b/addons/customGear/ACE_CSW_Groups.hpp
@@ -1,9 +1,15 @@
 class ace_csw_groups {
     //// MK-19
-    class MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP_csw) {
-        MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP) = 1;
+    class MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP_csw) { // Same name as the carryable magazine
+        MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP) = 1; // Vehicle magazine that will be loaded when loading this magazine
     };
-    class MAGAZINE(48Rnd_40mm_MK19_M384_HE_csw) { // Same name as the carryable magazine
-        MAGAZINE(48Rnd_40mm_MK19_M384_HE) = 1;    // Vehicle magazine that will be loaded when loading this magazine
+    class MAGAZINE(48Rnd_40mm_MK19_M384_HE_csw) {
+        MAGAZINE(48Rnd_40mm_MK19_M384_HE) = 1;
+    };
+    class MAGAZINE(32Rnd_40mm_MK19_M430A1_HEDP_csw) {
+        MAGAZINE(32Rnd_40mm_MK19_M430A1_HEDP) = 1;
+    };
+    class MAGAZINE(32Rnd_40mm_MK19_M384_HE_csw) {
+        MAGAZINE(32Rnd_40mm_MK19_M384_HE) = 1;
     };
 };

--- a/addons/customGear/CfgMagazineWells.hpp
+++ b/addons/customGear/CfgMagazineWells.hpp
@@ -32,8 +32,10 @@ class CfgMagazineWells {
         MAGWELL_ENTRY_NAME[] = {
             QMAGAZINE(96Rnd_40mm_MK19_M430A1_HEDP),
             QMAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP),
+            QMAGAZINE(32Rnd_40mm_MK19_M430A1_HEDP),
             QMAGAZINE(96Rnd_40mm_MK19_M384_HE),
-            QMAGAZINE(48Rnd_40mm_MK19_M384_HE)
+            QMAGAZINE(48Rnd_40mm_MK19_M384_HE),
+            QMAGAZINE(32Rnd_40mm_MK19_M384_HE)
         };
     };
 };

--- a/addons/customGear/CfgMagazines.hpp
+++ b/addons/customGear/CfgMagazines.hpp
@@ -29,6 +29,9 @@ class CfgMagazines {
     class MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP): MAGAZINE(96Rnd_40mm_MK19_M430A1_HEDP) {
         count = 48;
     };
+    class MAGAZINE(32Rnd_40mm_MK19_M430A1_HEDP): MAGAZINE(96Rnd_40mm_MK19_M430A1_HEDP) {
+        count = 32;
+    };
     class MAGAZINE(96Rnd_40mm_MK19_M384_HE): 200Rnd_40mm_G_belt {
         ammo = QAMMO(40x53mm_HE_M384);
         count = 96;
@@ -38,6 +41,9 @@ class CfgMagazines {
     };
     class MAGAZINE(48Rnd_40mm_MK19_M384_HE): MAGAZINE(96Rnd_40mm_MK19_M384_HE) {
         count = 48;
+    };
+    class MAGAZINE(32Rnd_40mm_MK19_M384_HE): MAGAZINE(96Rnd_40mm_MK19_M384_HE) {
+        count = 32;
     };
     //// HV 40x53mm grenade CSW
     class MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP_csw): MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP) {
@@ -51,6 +57,12 @@ class CfgMagazines {
         ACE_isBelt = 1;
         mass = 40;
     };
+    class MAGAZINE(32Rnd_40mm_MK19_M430A1_HEDP_csw): MAGAZINE(48Rnd_40mm_MK19_M430A1_HEDP_csw) {
+        displayName = "[CSW] 32Rnd 40x53mm M430A1 HEDP (Mk19)";
+        displayNameShort = "[CSW] 32Rnd M430A1 HEDP (Mk19)";
+        count = 32;
+        mass = 28;
+    };
     class MAGAZINE(48Rnd_40mm_MK19_M384_HE_csw): MAGAZINE(48Rnd_40mm_MK19_M384_HE) {
         displayName = "[CSW] 48Rnd 40x53mm M384 HE (Mk19)";
         displayNameShort = "[CSW] 48Rnd M384 HE (Mk19)";
@@ -61,6 +73,12 @@ class CfgMagazines {
         picture = "\z\ace\addons\csw\UI\ammoBox_50bmg_ca.paa";
         ACE_isBelt = 1;
         mass = 40;
+    };
+    class MAGAZINE(32Rnd_40mm_MK19_M384_HE_csw): MAGAZINE(48Rnd_40mm_MK19_M384_HE_csw) {
+        displayName = "[CSW] 32Rnd 40x53mm M384 HE (Mk19)";
+        displayNameShort = "[CSW] 32Rnd M384 HE (Mk19)";
+        count = 32;
+        mass = 28;
     };
     //// GP-25 magazines
     // HE rounds

--- a/addons/spectate/XEH_postClientInit.sqf
+++ b/addons/spectate/XEH_postClientInit.sqf
@@ -50,7 +50,7 @@ if (GVAR(enabled) && hasInterface) then {
     GVAR(deathHash) = createHashMap;
     addMissionEventHandler ["EntityKilled", {
         params ["_unit"];
-        if (isPlayer _unit) then {
+        if (isPlayer _unit && {_unit isKindOf "CAManBase"}) then {
             GVAR(deathHash) set [name _unit + str time, [ASLToAGL getPosASL _unit, name _unit, side group _unit]];
         };
     }];

--- a/addons/spectate/functions/fnc_setup.sqf
+++ b/addons/spectate/functions/fnc_setup.sqf
@@ -139,7 +139,7 @@ GVAR(drawProjectiles) = false;
 
 // init misc GVARS
 GVAR(curList) = [];
-GVAR(drawDeaths) = false;
+GVAR(drawDeaths) = DEATH_VISIBLE_MODE_NONE;
 GVAR(mapOpen) = false;
 GVAR(fullMapOpen) = false;
 GVAR(needToAddBriefings) = true;

--- a/addons/spectate/functions/fnc_ui_handleDraw3D.sqf
+++ b/addons/spectate/functions/fnc_ui_handleDraw3D.sqf
@@ -192,23 +192,25 @@ if !(GVAR(mapOpen) || GVAR(fullMapOpen)) then {
     };
 
     // Draw bodies on map
-    if (GVAR(drawDeaths)) then {
+    if (GVAR(drawDeaths) != DEATH_VISIBLE_MODE_NONE) then {
+        private _drawName = GVAR(drawDeaths) == DEATH_VISIBLE_MODE_MARK;
         private _cameraPosAGL = positionCameraToWorld [0,0,0];
         {
             _y params ["_pos", "_name", ["_side", civilian]];
             private _color = switch (_side) do {
-                case (west): {[0, 0, 0.7, 0.5]};
-                case (east): {[0.7, 0, 0, 0.5]};
-                case (resistance): {[0, 0.7, 0, 0.5]};
-                case (civilian): {[0.5,0,0.5,0.5]};
-                default {[0.7, 0.7, 0.7, 0.5]};
+                case (west): {[0, 0, 0.7, 0.6]};
+                case (east): {[0.7, 0, 0, 0.6]};
+                case (resistance): {[0, 0.7, 0, 0.6]};
+                case (civilian): {[0.5,0,0.5,0.6]};
+                default {[0.7, 0.7, 0.7, 0.6]};
             };
-            private _k = 1 min (2 / (1 max log (_cameraPosAGL distance _pos)));
+            private _dist = _cameraPosAGL distance _pos;
+            private _k = 1 min (2 / (1 max log _dist));
             drawIcon3D [
-                "\A3\ui_f\data\map\markers\military\dot_CA.paa",
-                _color, _pos, 1 * _k, 1 * _k, 0, _name,
+                "\z\ace\addons\medical_gui\ui\grave.paa",
+                _color, _pos, 0.7 * _k, 0.7 * _k, 0, ["", _name] select (_drawName && _dist < 350),
                 2, 0.04 * _k, "RobotoCondensed", "right",
-                false, 0.002 * _k, -0.023 * _k
+                false, 0.002 * _k, -0.019 * _k
             ];
         } forEach GVAR(deathHash);
     };

--- a/addons/spectate/functions/fnc_ui_handleKeyDown.sqf
+++ b/addons/spectate/functions/fnc_ui_handleKeyDown.sqf
@@ -196,7 +196,7 @@ if ((_key == DIK_F5) && {_this select 2} && {_this select 3}) exitWith {
 };
 
 if (_key == DIK_LBRACKET) exitWith {
-    GVAR(drawDeaths) = !GVAR(drawDeaths);
+    GVAR(drawDeaths) = (GVAR(drawDeaths) + 1) mod DEATH_VISIBLE_MODE_COUNT;
 };
 
 false // default to unhandled

--- a/addons/spectate/script_component.hpp
+++ b/addons/spectate/script_component.hpp
@@ -208,8 +208,13 @@ Left Brace ('[') to toggle showing player death locations<br/>\
 </t>
 
 #define TAGS_VISIBLE_MODE_COUNT 3
-#define TAGS_VISIBLE_MODE_NAMES 2
 #define TAGS_VISIBLE_MODE_MARKS 1
 #define TAGS_VISIBLE_MODE_NONE  0
+#define TAGS_VISIBLE_MODE_NAMES 2
+
+#define DEATH_VISIBLE_MODE_COUNT 3
+#define DEATH_VISIBLE_MODE_NONE 0
+#define DEATH_VISIBLE_MODE_ALL  1
+#define DEATH_VISIBLE_MODE_MARK 2
 
 #include "\z\potato\addons\core\script_macros.hpp"

--- a/addons/zeusUtils/XEH_postInit.sqf
+++ b/addons/zeusUtils/XEH_postInit.sqf
@@ -11,10 +11,3 @@ if (isServer && isMultiplayer) then {
 
 if !(hasInterface) exitWith {};
 #include "initKeybinds.inc.sqf"
-
-["CBA_SettingsInitialized", {
-    TRACE_4("CBA_SettingsInitialized EH Client",_this,GVAR(fpsDisplayEH),GVAR(fpsAvgCalcEH),GVAR(fpsAvgCalc));
-    if (isMultiplayer && GVAR(missionFPSEnable)) then {
-        [] call FUNC(initLocalFPSEH);
-    };
-}] call CBA_fnc_addEventHandler;

--- a/addons/zeusUtils/XEH_postInit.sqf
+++ b/addons/zeusUtils/XEH_postInit.sqf
@@ -14,7 +14,7 @@ if !(hasInterface) exitWith {};
 
 ["CBA_SettingsInitialized", {
     TRACE_4("CBA_SettingsInitialized EH Client",_this,GVAR(fpsDisplayEH),GVAR(fpsAvgCalcEH),GVAR(fpsAvgCalc));
-    if (isMultiplayer) then {
+    if (isMultiplayer && GVAR(missionFPSEnable)) then {
         [] call FUNC(initLocalFPSEH);
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/zeusUtils/initSettings.inc.sqf
+++ b/addons/zeusUtils/initSettings.inc.sqf
@@ -1,5 +1,5 @@
 //***************** Player FPS Display *********************/
-/// User settings
+// User settings
 [
     QGVAR(clientFPSEnable), "CHECKBOX",
     ["Report client FPS to Zeus", "Report your FPS to the Zanes for performance management."],
@@ -7,9 +7,15 @@
     true,
     2,
     {
-        if (GVAR(clientFPSEnable)) then {
-            [] call FUNC(initLocalFPSEH);
-        };
+        params ["_value"];
+        [{
+         !isNil QGVAR(missionFPSEnable)
+        }, {
+            params ["_value"];
+            if (_value && GVAR(missionFPSEnable)) then {
+                [] call FUNC(initLocalFPSEH);
+            };
+        }, _value, 5] call CBA_fnc_waitAndExecute;
     },
     false
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
This PR
- Disable players reporting their FPS to the server if a MM does not enable it (previously inaccessible unless turned on)
- Adds a 32 round 40x53mm CSW magazine for Potato ammos
- Updates the spectate death drawing system to be a bit visually cleaner.