### PR TITLE
miscFixes - Various - Added Hilux (Dragon) and Vickers Tracers Magazines

### DIFF
--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -698,7 +698,11 @@ class CfgWeapons {
     };
 
     // 40mm HEDP
-    class CUP_Vhmg_AGS30_veh;
+    class GMG_20mm;
+    class CUP_Vhmg_AGS30_veh: GMG_20mm {
+        aiDispersionCoefY = 6;
+        aiDispersionCoefX = 5;
+    };
     class CUP_Vgmg_MK19_veh: CUP_Vhmg_AGS30_veh {
         magazineWell[] += {"potato_HV_40x53mm"};
     };

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -302,18 +302,14 @@ class CfgVehicles {
     };
     class CUP_Hilux_metis_Base: CUP_Hilux_Base {
         class AnimationSources;
-        class Turrets: Turrets {
-            class MainTurret;
-        };
+        class Turrets: Turrets {};
     };
     class CUP_I_Hilux_metis_IND_G_F: CUP_Hilux_metis_Base {
         class AnimationSources: AnimationSources {
             class Reload;
         };
         class Turrets: Turrets {
-            class MainTurret: MainTurret {
-                class ViewOptics;
-            };
+            class MainTurret;
         };
     };
     class GVARMAIN(CUP_I_Hilux_dragon): CUP_I_Hilux_metis_IND_G_F {
@@ -328,20 +324,34 @@ class CfgVehicles {
                 allowTabLock = 0;
                 gunnerOpticsModel = "\z\ace\addons\dragon\models\optics_m47";
                 magazines[] = {
-                    "CUP_Dragon_EP1_M_AI",
-                    "CUP_Dragon_EP1_M_AI",
-                    "CUP_Dragon_EP1_M_AI",
-                    "CUP_Dragon_EP1_M_AI",
-                    "CUP_Dragon_EP1_M_AI",
-                    "CUP_Dragon_EP1_M_AI",
-                    "CUP_Dragon_EP1_M_AI",
-                    "CUP_Dragon_EP1_M_AI"
+                    "CUP_Dragon_EP1_AI_M",
+                    "CUP_Dragon_EP1_AI_M",
+                    "CUP_Dragon_EP1_AI_M",
+                    "CUP_Dragon_EP1_AI_M",
+                    "CUP_Dragon_EP1_AI_M",
+                    "CUP_Dragon_EP1_AI_M",
+                    "CUP_Dragon_EP1_AI_M",
+                    "CUP_Dragon_EP1_AI_M"
                 };
                 weapons[] = {QGVARMAIN(CUP_launch_M47_veh)};
-                class ViewOptics: ViewOptics {
-                    opticsZoomInit = 0.055;
-                    opticsZoomMax = 0.055;
-                    opticsZoomMin = 0.055;
+                class ViewOptics {
+                    initAngleX = 0;
+                    initAngleY = 0;
+                    initFov = 0.055;
+                    maxAngleX = 30;
+                    maxAngleY = 100;
+                    maxFov = 0.055;
+                    maxMoveX = 0;
+                    maxMoveY = 0;
+                    maxMoveZ = 0;
+                    minAngleX = -30;
+                    minAngleY = -100;
+                    minFov = 0.055;
+                    minMoveX = 0;
+                    minMoveY = 0;
+                    minMoveZ = 0;
+                    speedZoomMaxFOV = 0;
+                    speedZoomMaxSpeed = 1e+10;
                     thermalMode[] = {};
                     visionMode[] = {"Normal"};
                 };

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -297,12 +297,10 @@ class CfgVehicles {
         };
     };
     /// Hilux with Dragon (metis model)
-    class CUP_Hilux_Base: Car_F {
-        class Turrets: Turrets {};
-    };
+    class CUP_Hilux_Base;
     class CUP_Hilux_metis_Base: CUP_Hilux_Base {
         class AnimationSources;
-        class Turrets: Turrets {};
+        class Turrets;
     };
     class CUP_I_Hilux_metis_IND_G_F: CUP_Hilux_metis_Base {
         class AnimationSources: AnimationSources {

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -322,14 +322,14 @@ class CfgVehicles {
                 allowTabLock = 0;
                 gunnerOpticsModel = "\z\ace\addons\dragon\models\optics_m47";
                 magazines[] = {
-                    "CUP_Dragon_EP1_AI_M",
-                    "CUP_Dragon_EP1_AI_M",
-                    "CUP_Dragon_EP1_AI_M",
-                    "CUP_Dragon_EP1_AI_M",
-                    "CUP_Dragon_EP1_AI_M",
-                    "CUP_Dragon_EP1_AI_M",
-                    "CUP_Dragon_EP1_AI_M",
-                    "CUP_Dragon_EP1_AI_M"
+                    "CUP_Dragon_EP1_M",
+                    "CUP_Dragon_EP1_M",
+                    "CUP_Dragon_EP1_M",
+                    "CUP_Dragon_EP1_M",
+                    "CUP_Dragon_EP1_M",
+                    "CUP_Dragon_EP1_M",
+                    "CUP_Dragon_EP1_M",
+                    "CUP_Dragon_EP1_M"
                 };
                 weapons[] = {QGVARMAIN(CUP_launch_M47_veh)};
                 class ViewOptics {

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -795,9 +795,15 @@ class CfgWeapons {
         autoReload = 0;
         displayName = "$STR_CUP_DN_M47";
         magazines[] = {"CUP_Dragon_EP1_M","CUP_Dragon_EP1_AI_M"};
+        sound[] = {"A3\Sounds_F\weapons\Launcher\rocket_launcher_5",1,1,800};
         soundFly[] = {"CUP\Weapons\CUP_Weapons_M47\data\sfx\rocket_fly.wss","db40",1.5,700};
         reloadTime = 10;
         recoil = "recoil_single_titan";
+        class StandardSound {
+            begin1[] = {"CUP\Weapons\CUP_Weapons_M47\data\sfx\M47_1","db10",1,1200};
+            soundBegin[] = {"begin1",1};
+            weaponSoundEffect = "DefaultRifle";
+        };
     };
     class GVARMAIN(CUP_launch_M47_loaded): CUP_launch_M47 {
         baseWeapon = QGVARMAIN(CUP_launch_M47);

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -4,8 +4,11 @@
 
 class CfgPatches {
     class ADDON {
-        units[] = {};
+        units[] = {
+            QGVARMAIN(CUP_I_Hilux_dragon)
+        };
         weapons[] = {
+            QGVARMAIN(CUP_launch_M47_veh),
             QGVARMAIN(CUP_launch_M47),
             QGVARMAIN(CUP_launch_M47_used),
             QGVARMAIN(CUP_launch_M47_loaded)
@@ -290,6 +293,58 @@ class CfgVehicles {
             };
             class RightTurret: RightTurret {
                 dontCreateAI = 1;
+            };
+        };
+    };
+    /// Hilux with Dragon (metis model)
+    class CUP_Hilux_Base: Car_F {
+        class Turrets: Turrets {};
+    };
+    class CUP_Hilux_metis_Base: CUP_Hilux_Base {
+        class AnimationSources;
+        class Turrets: Turrets {
+            class MainTurret;
+        };
+    };
+    class CUP_I_Hilux_metis_IND_G_F: CUP_Hilux_metis_Base {
+        class AnimationSources: AnimationSources {
+            class Reload;
+        };
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                class ViewOptics;
+            };
+        };
+    };
+    class GVARMAIN(CUP_I_Hilux_dragon): CUP_I_Hilux_metis_IND_G_F {
+        displayName = "Hilux (Dragon)";
+        class AnimationSources: AnimationSources {
+            class Reload: Reload {
+                weapon = QGVARMAIN(CUP_launch_M47_veh);
+            };
+        };
+        class Turrets: Turrets {
+            class MainTurret: MainTurret {
+                allowTabLock = 0;
+                gunnerOpticsModel = "\z\ace\addons\dragon\models\optics_m47";
+                magazines[] = {
+                    "CUP_Dragon_EP1_M_AI",
+                    "CUP_Dragon_EP1_M_AI",
+                    "CUP_Dragon_EP1_M_AI",
+                    "CUP_Dragon_EP1_M_AI",
+                    "CUP_Dragon_EP1_M_AI",
+                    "CUP_Dragon_EP1_M_AI",
+                    "CUP_Dragon_EP1_M_AI",
+                    "CUP_Dragon_EP1_M_AI"
+                };
+                weapons[] = {QGVARMAIN(CUP_launch_M47_veh)};
+                class ViewOptics: ViewOptics {
+                    opticsZoomInit = 0.055;
+                    opticsZoomMax = 0.055;
+                    opticsZoomMin = 0.055;
+                    thermalMode[] = {};
+                    visionMode[] = {"Normal"};
+                };
             };
         };
     };
@@ -713,7 +768,7 @@ class CfgWeapons {
         modelOptics = "\z\ace\addons\dragon\models\optics_m47";
         displayName = "M47 Dragon (AI)";
         class OpticsModes {
-            class  StepScope {
+            class StepScope {
                 opticsZoomInit = 0.055;
                 opticsZoomMax = 0.055;
                 opticsZoomMin = 0.055;
@@ -721,6 +776,20 @@ class CfgWeapons {
             };
         };
         class WeaponSlotsInfo;
+    };
+    class CUP_Vmlauncher_AT13_single_veh;
+    class GVARMAIN(CUP_launch_M47_veh): CUP_Vmlauncher_AT13_single_veh {
+        aimTransitionSpeed = 0.4;
+        aiRateOfFire = 5;
+        aiRateOfFireDistance = 1000;
+        maxRange = 1000;
+        midRange = 600;
+        autoReload = 0;
+        displayName = "$STR_CUP_DN_M47";
+        magazines[] = {"CUP_Dragon_EP1_M","CUP_Dragon_EP1_AI_M"};
+        soundFly[] = {"CUP\Weapons\CUP_Weapons_M47\data\sfx\rocket_fly.wss","db40",1.5,700};
+        reloadTime = 10;
+        recoil = "recoil_single_titan";
     };
     class GVARMAIN(CUP_launch_M47_loaded): CUP_launch_M47 {
         baseWeapon = QGVARMAIN(CUP_launch_M47);

--- a/addons/miscFixes/patchCWR/config.cpp
+++ b/addons/miscFixes/patchCWR/config.cpp
@@ -29,12 +29,20 @@ class CfgMagazines {
         displayName = "40x46mm 12Rnd M433 (HEDP) Grenade";
         displayNameshort = "M433 HEDP";
     };
+    class cwr3_500rnd_vickers_m;
+    class GVARMAIN(cwr3_500rnd_vickers_t): cwr3_500rnd_vickers_m {
+        tracersEvery = 1;
+    };
 };
 
 class CfgWeapons {
     class Rifle_Base_F;
     class cwr3_glaunch_mm1: Rifle_Base_F {
         magazines[] += {"potato_12Rnd_40mm_M433_HEDP"};
+    };
+    class MGun;
+    class cwr3_hmg_vickers_veh: MGun {
+        magazines[] += {QGVARMAIN(cwr3_500rnd_vickers_t)};
     };
 };
 

--- a/addons/miscFixes/patchRHSAFRF/CfgAmmo.hpp
+++ b/addons/miscFixes/patchRHSAFRF/CfgAmmo.hpp
@@ -33,26 +33,31 @@ class CfgAmmo {
             enabled = 0;
         };
     };
-    
+
+    class rhs_ammo_rpgShell_base;
+    class rhs_ammo_pg9v: rhs_ammo_rpgShell_base {
+        effectsMissile = "Missile3_vanilla";
+    };
+
     // Base Classes
     class Sh_125mm_APFSDS;
     class rhs_ammo_ap_penetrator: Sh_125mm_APFSDS {};
-    
+
     // 3BM42 - used by T-72B (original)
     class rhs_ammo_3bm42_penetrator: rhs_ammo_ap_penetrator {
         hit = 520; // was 250
     };
-    
+
     // 3BM42M "Mango" - used by T-72B (1985)
     class rhs_ammo_3bm42m_penetrator: rhs_ammo_ap_penetrator {
         hit = 542.2; // was 270
     };
-    
-    // 3BM46 - used by T-72B3  
+
+    // 3BM46 - used by T-72B3
     class rhs_ammo_3bm46_penetrator: rhs_ammo_ap_penetrator {
         hit = 626.8; // was 300
     };
-    
+
     // 3BM69 - used by T90+
     class rhs_ammo_3bm69_penetrator: rhs_ammo_ap_penetrator {
         hit = 858.16; // was 300


### PR DESCRIPTION
This PR,

- Adds a Hilux (Dragon) to Indi FIA (player used only)
- Adds a tracers only magazine for the vickers used with the Sopwith Camel
- Increases AI AGL dispersion.