### PR TITLE
markers - Replace Unit Only with Occluded Version

### DIFF
--- a/addons/markers/defaultMarkerDefines.hpp
+++ b/addons/markers/defaultMarkerDefines.hpp
@@ -7,6 +7,15 @@
 #define BLACK_ARRAY [0,0,0,1]
 #define PINK_ARRAY [1,0.753,0.796,1]
 
+#define RED_ARRAY_A(alpha) [0.9,0,0,alpha]
+#define YELLOW_ARRAY_A(alpha) [0.9,0.9,0,alpha]
+#define GREEN_ARRAY_A(alpha) [0,0.8,0,alpha]
+#define BLUE_ARRAY_A(alpha) [0,0,1,alpha]
+#define WHITE_ARRAY_A(alpha) [1,1,1,alpha]
+#define ORANGE_ARRAY_A(alpha) [1,0.647,0,alpha]
+#define BLACK_ARRAY_A(alpha) [0,0,0,alpha]
+#define PINK_ARRAY_A(alpha) [1,0.753,0.796,alpha]
+
 #define GROUP_MARKER_ID_GROUPSTRING_GROUP(group) str side group + groupId group
 #define GROUP_MARKER_ID_GROUPSTRING_UNIT(unit) str side group unit + groupId group unit
 #define GROUP_MARKER_ID_UNITSTRING_UNIT(unit) str side unit + str unit

--- a/addons/markers/functions/fnc_drawMarkers.sqf
+++ b/addons/markers/functions/fnc_drawMarkers.sqf
@@ -13,8 +13,8 @@
  */
 
 #include "..\script_component.hpp"
-// acos ~35 degrees
-#define OCCLUSION_COS_ANGLE 0.8
+// acos ~50 degrees
+#define OCCLUSION_COS_ANGLE 0.7
 // 1 - 0.6 * frame time (0.1)
 #define OCCLUSION_FADE_ALPHA 0.94
 // 1 + 3 * frame time (0.1)
@@ -38,18 +38,16 @@ if (GVAR(intraFireteam_occlude) && {isNil QGVAR(intraAlphaPFEH)}) then {
             if (_x == player) then {continue};
             private _unitPosition = getPosASLVisual _x;
             private _distance = _unitPosition distance2D _posPlayerASL;
+            private _seen = _x getVariable [QGVAR(intraSeen), false];
+            if (_x getVariable [QGVAR(nextAlpha), 0] < _time) then {
+                _seen = _distance < 200 && {_distance < 100 ||
+                {OCCLUSION_COS_ANGLE < _dirVecPlayer vectorDotProduct (_posPlayerASL vectorFromTo _unitPosition)}} &&
+                {[] isEqualTo lineIntersectsObjs [_posPlayerASL, _x modelToWorldVisualWorld (_x selectionPosition  "pelvis"), _x, player, false, 20]};
+                _x setVariable [QGVAR(nextAlpha), _time + 0.4 + random 0.4];
+                _x setVariable [QGVAR(intraSeen), _seen];
+            };
             private _alpha = _x getVariable [QGVAR(intraAlpha), 1];
-            _alpha = if ( _distance > 200 || {_distance > 100 && {
-                OCCLUSION_COS_ANGLE > _dirVecPlayer vectorDotProduct (_posPlayerASL vectorFromTo _unitPosition)
-            }} || {
-                private _seen = _x getVariable [QGVAR(intraSeen), false];
-                if (_x getVariable [QGVAR(nextAlpha), 0] < _time) then {
-                    _seen = 0.2 < [_x, "GEOM", player] checkVisibility [_posPlayerASL, _x modelToWorldVisualWorld (_x selectionPosition  "pelvis")];
-                    _x setVariable [QGVAR(nextAlpha), _time + 0.6 + random 0.4];
-                    _x setVariable [QGVAR(intraSeen), _seen];
-                };
-                !_seen
-            }) then {
+            _alpha = if (!_seen) then {
                 if (_alpha < MIN_VALUE_CONSIDERED) then {
                     0
                 } else {

--- a/addons/markers/functions/fnc_drawMarkers.sqf
+++ b/addons/markers/functions/fnc_drawMarkers.sqf
@@ -13,6 +13,13 @@
  */
 
 #include "..\script_component.hpp"
+// acos ~35 degrees
+#define OCCLUSION_COS_ANGLE 0.8
+// 1 - 0.6 * frame time (0.1)
+#define OCCLUSION_FADE_ALPHA 0.94
+// 1 + 3 * frame time (0.1)
+#define OCCLUSION_DEFADE_ALPHA 1.3
+#define MIN_VALUE_CONSIDERED 5e-2
 //TRACE_1("Params",_this);
 
 BEGIN_COUNTER(drawMarkers);
@@ -20,6 +27,45 @@ BEGIN_COUNTER(drawMarkers);
 params ["_mapControl"];
 
 if ((player != player) || {!alive player} || {side player == sideLogic}) exitWith {};
+
+// Add alpha EH if needed
+if (GVAR(intraFireteam_occlude) && {isNil QGVAR(intraAlphaPFEH)}) then {
+    GVAR(intraAlphaPFEH) = [{
+        private _time = time;
+        private _posPlayerASL = eyePos player;
+        private _dirVecPlayer = eyeDirection player;
+        {
+            if (_x == player) then {continue};
+            private _unitPosition = getPosASLVisual _x;
+            private _distance = _unitPosition distance2D _posPlayerASL;
+            private _alpha = _x getVariable [QGVAR(intraAlpha), 1];
+            _alpha = if ( _distance > 200 || {_distance > 100 && {
+                OCCLUSION_COS_ANGLE > _dirVecPlayer vectorDotProduct (_posPlayerASL vectorFromTo _unitPosition)
+            }} || {
+                private _seen = _x getVariable [QGVAR(intraSeen), false];
+                if (_x getVariable [QGVAR(nextAlpha), 0] < _time) then {
+                    _seen = 0.2 < [_x, "GEOM", player] checkVisibility [_posPlayerASL, _x modelToWorldVisualWorld (_x selectionPosition  "pelvis")];
+                    _x setVariable [QGVAR(nextAlpha), _time + 0.6 + random 0.4];
+                    _x setVariable [QGVAR(intraSeen), _seen];
+                };
+                !_seen
+            }) then {
+                if (_alpha < MIN_VALUE_CONSIDERED) then {
+                    0
+                } else {
+                    0 max (_alpha * OCCLUSION_FADE_ALPHA)
+                };
+            } else {
+                if (_alpha < MIN_VALUE_CONSIDERED) then {
+                    MIN_VALUE_CONSIDERED
+                } else {;
+                    1 min (_alpha * OCCLUSION_DEFADE_ALPHA)
+                };
+            };
+            _x setVariable [QGVAR(intraAlpha), _alpha];
+        } forEach units group player;
+    }, 0.1] call CBA_fnc_addPerFrameHandler;
+};
 
 //Map's height / Screen height:
 private _mapSize = ((ctrlPosition _mapControl) select 3) / (getResolution select 4);
@@ -37,8 +83,7 @@ if (GVAR(groupAndUnitEnabled)) then {
         private _newDrawHash = createHashMap;
         private _sideArray = [] call FUNC(getSideArray);
         {
-            private _side = _y#6;
-            if (_side in _sideArray) then {
+            if ((_y#6) in _sideArray) then {
                 _newDrawHash set [_x, _y];
             };
         } forEach GVAR(markerHash);
@@ -61,8 +106,6 @@ if (GVAR(groupAndUnitEnabled)) then {
                 };
                 _y set [5, _posATL];
                 TRACE_2("Updating position",_drawObject,_posATL);
-            } else {
-                TRACE_1("Updating position, skip",_drawObject);
             };
         };
 
@@ -84,35 +127,35 @@ if (GVAR(groupAndUnitEnabled)) then {
 };
 
 if (GVAR(intraFireteamEnabled) && {(ctrlMapScale _mapControl) < 0.5}) then {
+    private _textScale = [0, 0.02 * _sizeFactor] select ((ctrlMapScale _mapControl) * _mapSize < 0.005);
+    private _size = UNIT_MARKER_SIZE * _sizeFactor;
     {
-        if !(isNull _x) then {
-            private _color = switch (assignedTeam _x) do {
-                case "RED": { RED_ARRAY };
-                case "YELLOW": { YELLOW_ARRAY };
-                case "GREEN": { GREEN_ARRAY };
-                case "BLUE": { BLUE_ARRAY };
-                default { WHITE_ARRAY };
-            };
-            if (isNil "_color") exitWith {};
+        if (isNull _x) then {continue};
+        private _alpha = _x getVariable [QGVAR(intraAlpha), 1];
 
-            private _unitPosition = position _x;
-            private _unitName = if (alive _x) then { name _x } else { "" };
-
-            _mapControl drawIcon [
-                UNIT_MARKER_ICON,
-                _color,
-                _unitPosition,
-                UNIT_MARKER_SIZE * _sizeFactor,
-                UNIT_MARKER_SIZE * _sizeFactor,
-                direction _x,
-                _unitName,
-                1,
-                (([0,0.02] select (((ctrlMapScale _mapControl) * _mapSize) < 0.005)) * _sizeFactor),
-                'TahomaB',
-                "left"
-            ];
+        private _color = switch (assignedTeam _x) do {
+            case "RED": { RED_ARRAY_A(_alpha) };
+            case "YELLOW": { YELLOW_ARRAY_A(_alpha) };
+            case "GREEN": { GREEN_ARRAY_A(_alpha) };
+            case "BLUE": { BLUE_ARRAY_A(_alpha) };
+            default { WHITE_ARRAY_A(_alpha) };
         };
-    } forEach ([units (group player), [player]] select GVAR(intraFireteam_playerOnly));
+        if (isNil "_color") then {continue};
+
+        _mapControl drawIcon [
+            UNIT_MARKER_ICON,
+            _color,
+             getPosASLVisual _x,
+            _size,
+            _size,
+            direction _x,
+            ["", name _x] select alive _x,
+            1,
+            _textScale ,
+            'TahomaB',
+            "left"
+        ];
+    } forEach units group player;
 };
 
 END_COUNTER(drawMarkers);

--- a/addons/markers/initSettings.inc.sqf
+++ b/addons/markers/initSettings.inc.sqf
@@ -25,7 +25,7 @@
     false, // default value
     true, // isGlobal
     {
-        if (!isNil QGVAR(intraAlphaPFEH) && {GVAR(intraAlphaPFEH) >= 0}) then {
+        if !(isNil QGVAR(intraAlphaPFEH)) then {
             [GVAR(intraAlphaPFEH)] call CBA_fnc_removePerFrameHandler;
             GVAR(intraAlphaPFEH) = nil;
         };

--- a/addons/markers/initSettings.inc.sqf
+++ b/addons/markers/initSettings.inc.sqf
@@ -19,13 +19,18 @@
 ] call CBA_fnc_addSetting;
 
 [
-    QGVAR(intraFireteam_playerOnly), "CHECKBOX",
-    ["intraFireteam - player only"],
+    QGVAR(intraFireteam_occlude), "CHECKBOX",
+    ["intraFireteam - Occlude Marks"],
     ["POTATO - Mission Maker", "Markers"],
     false, // default value
     true, // isGlobal
-    {},
-    true // Needs mission restart
+    {
+        if (!isNil QGVAR(intraAlphaPFEH) && {GVAR(intraAlphaPFEH) >= 0}) then {
+            [GVAR(intraAlphaPFEH)] call CBA_fnc_removePerFrameHandler;
+            GVAR(intraAlphaPFEH) = nil;
+        };
+    },
+    false
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/markers/initSettings.inc.sqf
+++ b/addons/markers/initSettings.inc.sqf
@@ -20,7 +20,7 @@
 
 [
     QGVAR(intraFireteam_occlude), "CHECKBOX",
-    ["intraFireteam - Occlude Marks"],
+    ["intraFireteam - Occlude Markers", "Occlusion and distance causes intra fireteam markers to fade"],
     ["POTATO - Mission Maker", "Markers"],
     false, // default value
     true, // isGlobal

--- a/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
+++ b/addons/safeStart/functions/fnc_fillSafeStartEquip.sqf
@@ -159,8 +159,8 @@ if (EGVAR(markers,groupAndUnitEnabled)) then {
 };
 // inter group markers
 if (EGVAR(markers,intraFireteamEnabled)) then {
-    if (EGVAR(markers,intraFireteam_playerOnly)) then {
-        _textArr pushBack QUOTE(<t color=QUOTE(ATTENTION_COLOR)>Unit Map Markers: Player Only</t>);
+    if (EGVAR(markers,intraFireteam_occlude)) then {
+        _textArr pushBack QUOTE(<t color=QUOTE(ATTENTION_COLOR)>Unit Map Markers: Occluded</t>);
     } else {
         _textArr pushBack QUOTE(<t color=QUOTE(STANDARD_COLOR)>Unit Map Markers: On</t>);
     };


### PR DESCRIPTION
This PR replaces the "unit only" setting with a occlusion-fading method for intra-group markers.