### PR TITLE
miscFixes - patchCWR - Backblasat

### DIFF
--- a/addons/miscFixes/patchCWR/config.cpp
+++ b/addons/miscFixes/patchCWR/config.cpp
@@ -50,6 +50,12 @@ class CfgWeapons {
         ACEGVAR(overpressure,offset) = 1.35;
         ACEGVAR(overpressure,range) = 28;
     };
+    class Launcher_Base_F;
+    class cwr3_launch_rpg75_loaded: Launcher_Base_F {
+        ACEGVAR(overpressure,angle) = 33.7; // based on czech wikipedia backblast zone
+        ACEGVAR(overpressure,offset) = 0.8;
+        ACEGVAR(overpressure,range) = 20;
+    };
 };
 
 class CfgVehicles {

--- a/addons/miscFixes/patchCWR/config.cpp
+++ b/addons/miscFixes/patchCWR/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "potato_core", "potato_customGear", "cwr3_intro", "cwr3_vehicle_m41", "cwr3_soldiers_us", "cwr3_vehicle_m113" };
+        requiredAddons[] = { "potato_core", "potato_customGear", "cwr3_intro", "cwr3_vehicle_m41", "cwr3_soldiers_us", "cwr3_vehicle_m113", "cwr3_weapon_config" };
         skipWhenMissingDependencies = 1;
         author = "Bourbon Warfare";
         authorUrl = "https://github.com/BourbonWarfare/POTATO";
@@ -43,6 +43,12 @@ class CfgWeapons {
     class MGun;
     class cwr3_hmg_vickers_veh: MGun {
         magazines[] += {QGVARMAIN(cwr3_500rnd_vickers_t)};
+    };
+    class CUP_launch_MAAWS;
+    class cwr3_launch_m67_rcl: CUP_launch_MAAWS {
+        ACEGVAR(overpressure,angle) = 60;
+        ACEGVAR(overpressure,offset) = 1.35;
+        ACEGVAR(overpressure,range) = 28;
     };
 };
 

--- a/addons/miscFixes/patchEMCUP/config.cpp
+++ b/addons/miscFixes/patchEMCUP/config.cpp
@@ -1,0 +1,23 @@
+#include "\z\potato\addons\miscFixes\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT miscFixes_patchEMCUP
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = { "potato_core", "za_enhancedmaawsCUP" };
+        skipWhenMissingDependencies = 1;
+        author = "Bourbon Warfare";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+class CfgWeapons {
+    class Launcher_Base_F;
+    class CUP_launch_MAAWS: Launcher_Base_F {
+        ACEGVAR(overpressure,angle) = 45; // they overrride ace because they hate us
+    };
+};


### PR DESCRIPTION
This PR:
- Fixed M67 & RPG75 backblast to match data found online (US Army training and Czech wikipedia, respectively)
- Fixed Enhanced MAAWS increasing backbast to too high of a value.