### PR TITLE
customGear - Launcher - Carl Gustaf Rounds

### DIFF
--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -119,25 +119,28 @@ class CfgAmmo {
     };
 
     // Carl Gustaf time
-    class R_MRAAWS_HEAT_F;
+    class RocketBase;
+    class R_MRAAWS_HEAT_F: RocketBase {
+        class EventHandlers;
+    };
     class R_MRAAWS_HE_F: R_MRAAWS_HEAT_F {
         class EventHandlers;
     };
     class GVARMAIN(R_FFV448_he): R_MRAAWS_HE_F {
+        ACEGVAR(frag,skip) = 0;
+        ACEGVAR(frag,charge) = 400; // unpublished, 2.7 kg total
+        ACEGVAR(frag,metal) = 400; // unpublished, shell casing approx
+        ACEGVAR(frag,gurney_c) = 2800;
+        ACEGVAR(frag,gurney_k) = 0.5;
+        ACEGVAR(frag,fragCount) = 5000; // ACE FRAG, when implemented reduce explosion PFX
+        ACEGVAR(frag,classes)[] = {QACEGVAR(frag,small),QACEGVAR(frag,small),QACEGVAR(frag,small),QACEGVAR(frag,medium),QACEGVAR(frag,tiny)};
+        explosionEffects = "ATMissileExplosion";
+        hit = 100;
+        indirectHit = 40;
+        indirectHitRange = 5;
         class EventHandlers: EventHandlers {
-            ACEGVAR(frag,skip) = 0;
-            ACEGVAR(frag,charge) = 400; // unpublished, 2.7 kg total
-            ACEGVAR(frag,metal) = 400; // unpublished, shell casing approx
-            ACEGVAR(frag,gurney_c) = 2800;
-            ACEGVAR(frag,gurney_k) = 0.5;
-            ACEGVAR(frag,fragCount) = 5000; // ACE FRAG, when implemented reduce explosion PFX
-            ACEGVAR(frag,classes)[] = {QACEGVAR(frag,small),QACEGVAR(frag,small),QACEGVAR(frag,small),QACEGVAR(frag,medium),QACEGVAR(frag,tiny)};
-            explosionEffects = "ATMissileExplosion";
-            hit = 100;
-            indirectHit = 40;
-            indirectHitRange = 5;
             class ADDON {
-                init = QUOTE(_this call FUNC(carlGAB_DetonateLaser));
+                fired = QUOTE(_this call FUNC(carlGAB_DetonateLaser));
             };
         };
     };
@@ -151,29 +154,25 @@ class CfgAmmo {
     };
     class GVARMAIN(R_FFV469C_smoke): R_MRAAWS_HEAT_F {
         ACEGVAR(frag,skip) = 1;
-        caliber = 0.01;
+        caliber = 0.1;
         craterEffects = "ATRocketCrater";
-        explosive = 0.05;
+        explosive = 0.5;
         explosionEffects = "";
         explosionSoundEffect = "";
-        hit = 24;
-        indirectHit = 2;
+        hit = 20;
+        indirectHit = 0.5;
         indirectHitRange = 1;
         model = "\A3\Weapons_F_Tank\Launchers\MRAWS\rocket_MRAWS_HEAT55_F.p3d";
-        submunitionAmmo = QGVARMAIN(carlg_SmokeShell);
-        submunitionInitialOffset[] = {0,0,-1};
-        submunitionInitSpeed = 0.1;
-        submunitionParentSpeedCoef = 0;
-    };
-    // Smoke submunition
-    class smokeShell;
-    class GVARMAIN(carlg_SmokeShell): smokeShell {
-        model = "\A3\weapons_f\ammo\shell_smoke";
-        class EventHandlers {
+        class EventHandlers: EventHandlers {
             class ADDON {
                 init = QUOTE(_this call FUNC(carlGSmoke));
             };
         };
+    };
+    // Smoke submunition
+    class SmokeShellArty;
+    class GVARMAIN(carlg_SmokeShell): SmokeShellArty {
+        effectsSmoke = "potato_filledSmoke_bigSmoke";
         timeToLive = 30;
     };
 };

--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -103,7 +103,7 @@ class CfgAmmo {
         caliber = 40;
         hit = 400;
     };
-    
+
     // Custom Anti-Air Capable RPG rounds
     class CUP_R_PG7VL_AT;
     class CUP_R_PG7VM_AT;
@@ -116,5 +116,59 @@ class CfgAmmo {
     };
     class potato_R_PG7V_AA: CUP_R_PG7V_AT {
         airLock = 1;
+    };
+
+    // Carl Gustaf time
+    class R_MRAAWS_HEAT_F;
+    class R_MRAAWS_HE_F: R_MRAAWS_HEAT_F {
+        class EventHandlers;
+    };
+    class GVARMAIN(R_FFV448_he): R_MRAAWS_HE_F {
+        class EventHandlers: EventHandlers {
+            ACEGVAR(frag,skip) = 0;
+            ACEGVAR(frag,charge) = 400; // unpublished, 2.7 kg total
+            ACEGVAR(frag,metal) = 400; // unpublished, shell casing approx
+            ACEGVAR(frag,gurney_c) = 2800;
+            ACEGVAR(frag,gurney_k) = 0.5;
+            ACEGVAR(frag,fragCount) = 5000; // ACE FRAG, when implemented reduce explosion PFX
+            ACEGVAR(frag,classes)[] = {QACEGVAR(frag,small),QACEGVAR(frag,small),QACEGVAR(frag,small),QACEGVAR(frag,medium),QACEGVAR(frag,tiny)};
+            explosionEffects = "ATMissileExplosion";
+            hit = 100;
+            indirectHit = 40;
+            indirectHitRange = 5;
+            class ADDON {
+                init = QUOTE(_this call FUNC(carlGAB_DetonateLaser));
+            };
+        };
+    };
+    class GVARMAIN(R_ASM509_tb): R_MRAAWS_HE_F {
+        ACEGVAR(frag,skip) = 1; // thermobaric, no real details
+        ACEGVAR(frag,gurney_c) = 2745; // idk, PAX-42 or something
+        hit = 500;
+        indirectHit = 40;
+        indirectHitRange = 8;
+    };
+    class GVARMAIN(R_FFV469B_smoke): R_MRAAWS_HEAT_F {
+        ACEGVAR(frag,skip) = 1;
+        caliber = 0.01;
+        craterEffects = "ATRocketCrater";
+        explosive = 0.05;
+        hit = 24;
+        indirectHit = 2;
+        indirectHitRange = 1;
+        submunitionAmmo = QGVARMAIN(carlg_SmokeShell);
+        submunitionInitialOffset[] = {0,0,-1};
+        submunitionInitSpeed = 0.1;
+        submunitionParentSpeedCoef = 0;
+    };
+    // Smoke submunition
+    class smokeShell;
+    class GVARMAIN(carlg_SmokeShell): smokeShell {
+        class EventHandlers {
+            class ADDON {
+                init = QUOTE(_this call FUNC(carlGSmoke));
+            };
+        };
+        timeToLive = 30;
     };
 };

--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -147,15 +147,19 @@ class CfgAmmo {
         hit = 500;
         indirectHit = 40;
         indirectHitRange = 8;
+        model = "\A3\Weapons_F_Tank\Launchers\MRAWS\rocket_MRAWS_HEAT55_F.p3d";
     };
     class GVARMAIN(R_FFV469B_smoke): R_MRAAWS_HEAT_F {
         ACEGVAR(frag,skip) = 1;
         caliber = 0.01;
         craterEffects = "ATRocketCrater";
         explosive = 0.05;
+        explosionEffects = "";
+        explosionSoundEffect = "";
         hit = 24;
         indirectHit = 2;
         indirectHitRange = 1;
+        model = "\A3\Weapons_F_Tank\Launchers\MRAWS\rocket_MRAWS_HEAT55_F.p3d";
         submunitionAmmo = QGVARMAIN(carlg_SmokeShell);
         submunitionInitialOffset[] = {0,0,-1};
         submunitionInitSpeed = 0.1;
@@ -164,6 +168,7 @@ class CfgAmmo {
     // Smoke submunition
     class smokeShell;
     class GVARMAIN(carlg_SmokeShell): smokeShell {
+        model = "\A3\weapons_f\ammo\shell_smoke";
         class EventHandlers {
             class ADDON {
                 init = QUOTE(_this call FUNC(carlGSmoke));

--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -149,7 +149,7 @@ class CfgAmmo {
         indirectHitRange = 8;
         model = "\A3\Weapons_F_Tank\Launchers\MRAWS\rocket_MRAWS_HEAT55_F.p3d";
     };
-    class GVARMAIN(R_FFV469B_smoke): R_MRAAWS_HEAT_F {
+    class GVARMAIN(R_FFV469C_smoke): R_MRAAWS_HEAT_F {
         ACEGVAR(frag,skip) = 1;
         caliber = 0.01;
         craterEffects = "ATRocketCrater";

--- a/addons/customGear/launchers/CfgFunctions.hpp
+++ b/addons/customGear/launchers/CfgFunctions.hpp
@@ -1,0 +1,21 @@
+class CfgFunctions {
+    class ADDON {
+        class Carl_Gustaf {
+            class carlGAB_Cond {
+                file = "\z\potato\addons\customGear\launchers\functions\fnc_carlGAB_Cond.sqf";
+            };
+            class carlGAB_DetonateLaser {
+                file = "\z\potato\addons\customGear\launchers\functions\fnc_carlGAB_DetonateLaser.sqf";
+            };
+            class carlGAB_OffDelta {
+                file = "\z\potato\addons\customGear\launchers\functions\fnc_carlGAB_OffDelta.sqf";
+            };
+            class carlGAB_Toggle {
+                file = "\z\potato\addons\customGear\launchers\functions\fnc_carlGAB_Toggle.sqf";
+            };
+            class carlGSmoke {
+                file = "\z\potato\addons\customGear\launchers\functions\fnc_carlGSmoke.sqf";
+            };
+        };
+    };
+};

--- a/addons/customGear/launchers/CfgMagazineWells.hpp
+++ b/addons/customGear/launchers/CfgMagazineWells.hpp
@@ -2,4 +2,7 @@ class CfgMagazineWells {
     class RPG7 {
         potato_airlock[] = {"potato_PG7V_M","potato_PG7VM_M","potato_PG7VL_M"};
     };
+    class CBA_Carl_Gustaf {
+        ADDON[] = {QGVARMAIN(FFV448_he),QGVARMAIN(ASM509_tb),QGVARMAIN(FFV469B_smoke)};
+    };
 };

--- a/addons/customGear/launchers/CfgMagazineWells.hpp
+++ b/addons/customGear/launchers/CfgMagazineWells.hpp
@@ -3,6 +3,6 @@ class CfgMagazineWells {
         potato_airlock[] = {"potato_PG7V_M","potato_PG7VM_M","potato_PG7VL_M"};
     };
     class CBA_Carl_Gustaf {
-        ADDON[] = {QGVARMAIN(FFV448_he),QGVARMAIN(ASM509_tb),QGVARMAIN(FFV469B_smoke)};
+        ADDON[] = {QGVARMAIN(FFV448_he),QGVARMAIN(ASM509_tb),QGVARMAIN(FFV469C_smoke)};
     };
 };

--- a/addons/customGear/launchers/CfgMagazines.hpp
+++ b/addons/customGear/launchers/CfgMagazines.hpp
@@ -64,7 +64,7 @@ class CfgMagazines {
         initSpeed = 108;
         mass = 80.4;
     };
-    
+
     // Custom Anti-Air Capable RPG rounds
     class CUP_PG7V_M;
     class CUP_PG7VM_M;
@@ -80,5 +80,42 @@ class CfgMagazines {
     class potato_PG7VL_M: CUP_PG7VL_M {
         ammo = "potato_R_PG7V_AA";
         maxLeadSpeed = 150;
+    };
+
+    // Carl Gustaf time
+    class CA_LauncherMagazine;
+    class MRAWS_HEAT_F: CA_LauncherMagazine {
+        descriptionShort = "Type: FFV751 Tandem HEAT Rocket<br />Rounds: 1<br />Used in: MAAWS";
+        displayName = "FFV751 (Tandem HEAT) Round";
+        displayNameShort = "Tandem HEAT";
+    };
+    class MRAWS_HEAT55_F: MRAWS_HEAT_F {
+        descriptionShort = "Type: FFV551C RS HEAT Rocket<br />Rounds: 1<br />Used in: MAAWS";
+        displayName = "FFV551C RS (HEAT) Round";
+    };
+    class MRAWS_HE_F: MRAWS_HEAT_F {
+        descriptionShort = "Type: MAAWS HE 44 Rocket<br />Rounds: 1<br />Used in: MAAWS";
+        displayName = "FFV441D RS (HE) Round";
+    };
+    class GVARMAIN(FFV448_he): MRAWS_HE_F {
+        ammo = QGVARMAIN(R_FFV448_he);
+        author = "Bourbon Warfare";
+        descriptionShort = "Type: FFV448 HE Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
+        displayName = "FFV448 (Programmable HE/AB) Round";
+        displayNameShort = "HE";
+    };
+    class GVARMAIN(ASM509_tb): MRAWS_HE_F {
+        ammo = QGVARMAIN(R_ASM509_tb);
+        author = "Bourbon Warfare";
+        descriptionShort = "Type: ASM-509 HE Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
+        displayName = "ASM-509 (Thermobaric) Round";
+        displayNameShort = "Thermobaric";
+    };
+    class GVARMAIN(FFV469B_smoke): MRAWS_HEAT55_F {
+        ammo = QGVARMAIN(R_FFV469B_smoke);
+        author = "Bourbon Warfare";
+        descriptionShort = "Type: FFV469B Smoke Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
+        displayName = "FFV469B (Smoke) Round";
+        displayNameShort = "Smoke";
     };
 };

--- a/addons/customGear/launchers/CfgMagazines.hpp
+++ b/addons/customGear/launchers/CfgMagazines.hpp
@@ -103,6 +103,7 @@ class CfgMagazines {
         descriptionShort = "Type: FFV448 HE Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
         displayName = "FFV448 (Programmable HE/AB) Round";
         displayNameShort = "HE";
+        mass = 57.3;
     };
     class GVARMAIN(ASM509_tb): MRAWS_HE_F {
         ammo = QGVARMAIN(R_ASM509_tb);
@@ -110,12 +111,14 @@ class CfgMagazines {
         descriptionShort = "Type: ASM-509 HE Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
         displayName = "ASM-509 (Thermobaric) Round";
         displayNameShort = "Thermobaric";
+        mass = 92.6;
     };
-    class GVARMAIN(FFV469B_smoke): MRAWS_HEAT55_F {
-        ammo = QGVARMAIN(R_FFV469B_smoke);
+    class GVARMAIN(FFV469C_smoke): MRAWS_HEAT55_F {
+        ammo = QGVARMAIN(R_FFV469C_smoke);
         author = "Bourbon Warfare";
-        descriptionShort = "Type: FFV469B Smoke Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
-        displayName = "FFV469B (Smoke) Round";
+        descriptionShort = "Type: FFV469C Smoke Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
+        displayName = "FFV469C (Smoke) Round";
         displayNameShort = "Smoke";
+        mass = 68.3;
     };
 };

--- a/addons/customGear/launchers/CfgVehicles.hpp
+++ b/addons/customGear/launchers/CfgVehicles.hpp
@@ -1,0 +1,31 @@
+class CfgVehicles {
+    class Man;
+    class CAManBase: Man {
+        class ACE_SelfActions {
+            class ACE_Equipment {
+                class GVAR(carlG_AB_laser) {
+                    displayName = "Toggle HE Airburst";
+                    condition = QUOTE(call FUNC(carlGAB_Cond));
+                    statement = QUOTE(call FUNC(carlGAB_Toggle));
+                    showDisabled = 0;
+                    exceptions[] = {"notOnMap", "isNotUnconscious", "isNotSwimming"};
+                    class GVAR(carlG_IncLaserOffset) {
+                        displayName = "Increase Offset (5m)";
+                        condition = QUOTE(_player getVariable [ARR_2(QQGVAR(abCGRnd),false)]);
+                        statement = QUOTE([true] call FUNC(carlGAB_OffDelta));
+                    };
+                    class GVAR(carlG_resetLaserOffset) {
+                        displayName = "Reset Offset (5m)";
+                        condition = QUOTE(_player getVariable [ARR_2(QQGVAR(abCGRnd),false)]);
+                        statement = QUOTE(_player setVariable [ARR_2(QQGVAR(abOffset),5)]; [ARR_4(QQUOTE(Offset to laser set to 5m),true,5,2)] call ACEFUNC(common,displayText););
+                    };
+                    class GVAR(carlG_DecLaserOffset) {
+                        displayName = "Decrease Offset (5m)";
+                        condition = QUOTE(_player getVariable [ARR_2(QQGVAR(abCGRnd),false)]);
+                        statement = QUOTE([false] call FUNC(carlGAB_OffDelta));
+                    };
+                };
+            };
+        };
+    };
+};

--- a/addons/customGear/launchers/CfgVehicles.hpp
+++ b/addons/customGear/launchers/CfgVehicles.hpp
@@ -17,7 +17,7 @@ class CfgVehicles {
                     class GVAR(carlG_resetLaserOffset) {
                         displayName = "Reset Offset (5m)";
                         condition = QUOTE(_player getVariable [ARR_2(QQGVAR(abCGRnd),false)]);
-                        statement = QUOTE(_player setVariable [ARR_2(QQGVAR(abOffset),5)]; [ARR_4(QQUOTE(Offset to laser set to 5m),true,5,2)] call ACEFUNC(common,displayText););
+                        statement = QUOTE(_player setVariable [ARR_2(QQGVAR(abOffset),5)]; [ARR_4('Offset to laser set to 5m',true,5,2)] call ACEFUNC(common,displayText););
                     };
                     class GVAR(carlG_DecLaserOffset) {
                         displayName = "Decrease Offset (5m)";

--- a/addons/customGear/launchers/config.cpp
+++ b/addons/customGear/launchers/config.cpp
@@ -19,7 +19,7 @@ class CfgPatches {
         };
         magazines[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "potato_core", "CUP_Weapons_LoadOrder"};
+        requiredAddons[] = {  "A3_Weapons_F_Tank", "potato_core", "CUP_Weapons_LoadOrder" };
         skipWhenMissingDependencies = 1;
         author = "Potato";
         authors[] = {"AChesheireCat", "Lambda.Tiger"};
@@ -30,6 +30,8 @@ class CfgPatches {
 
 #include "CfgAmmo.hpp"
 #include "CfgDisposableLaunchers.hpp"
+#include "CfgFunctions.hpp"
 #include "CfgMagazines.hpp"
-#include "CfgWeapons.hpp"
 #include "CfgMagazineWells.hpp"
+#include "CfgVehicles.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/customGear/launchers/functions/fnc_carlGAB_Cond.sqf
+++ b/addons/customGear/launchers/functions/fnc_carlGAB_Cond.sqf
@@ -1,0 +1,20 @@
+#include "\z\potato\addons\customGear\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT customGear_launchers
+/***************************************************************************//*
+* Author: Lambda.Tiger
+*
+* Description:
+* This function handles whether the action exists for the
+*
+* Arguments:
+* ace self interact menu params
+*
+* Return:
+* None
+*
+* Example:
+* [] call potato_customGear_launchers_fnc_carlGAB_Cond;
+*//***************************************************************************/
+//IGNORE_PRIVATE_WARNING ["_player"];
+toLowerANSI secondaryWeapon _player in ["launch_mraws_green_f","launch_mraws_sand_f","launch_mraws_olive_f"]

--- a/addons/customGear/launchers/functions/fnc_carlGAB_DetonateLaser.sqf
+++ b/addons/customGear/launchers/functions/fnc_carlGAB_DetonateLaser.sqf
@@ -1,0 +1,56 @@
+#include "\z\potato\addons\customGear\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT customGear_launchers
+#define CONST_DT (1/60)
+#define CONST_G -9.80665
+#define CTRL_CA_IGUI_ELEMENTS_GROUP 170
+#define CTRL_CA_DISTANCE 198
+/***************************************************************************//*
+* Author: Lambda.Tiger
+*
+* Description:
+* This funciton will handle whether and when a carlG round should airburst
+*
+* Arguments:
+* _projectile - The projectile to airburst (OBJECT)
+*
+* Return:
+* None
+*
+* Example:
+* [_projectile] call potato_customGear_launchers_fnc_carlGAB_DetonateLaser;
+*//***************************************************************************/
+params [["_projectile", objNull]];
+if !(_projectile getShotInfo 5) exitWith {};
+// private _unit = _projectile getShotInfo 9; // 2.22 syntax
+private _unit = (getShotParents _projectile)#1;
+if (isNull _unit) then {_unit = (getShotParents _projectile)#0;};
+if (!(_unit getVariable [QGVAR(abCGRnd), false]) ||
+    {typeOf _projectile != QGVARMAIN(R_FFV448_he)} ||
+    {!(toLowerANSI secondaryWeapon _unit in ["launch_mraws_green_f","launch_mraws_sand_f","launch_mraws_olive_f"])}) exitWith {};
+private _distance = parseNumber ctrlText (((uiNamespace getVariable "RscUnitInfo") displayCtrl CTRL_CA_IGUI_ELEMENTS_GROUP) controlsGroupCtrl CTRL_CA_DISTANCE);
+if (_distance < 30) exitWith {};
+// TBD configurable offset
+_distance = _distance + (_unit getVariable [QGVAR(abOffset), 5]);
+private _friction = 0.05*-0.002; // Based on config'd val
+private _v = [350, 0]; // Based on config'd val
+private _r = 0;
+private _itr = 0;
+private _vMag = -1;
+private _lastV = [];
+private _dr = 0;
+while {_itr * CONST_DT < 4 && _r < _distance} do {
+    _lastV = _v;
+    _vMag = vectorMagnitude _lastV;
+    _v = [
+        (_lastV#0) + _friction * _vMag * (_lastV#0) * CONST_DT,
+        (_lastV#1) + (CONST_G + _friction * _vMag * (_lastV#1)) * CONST_DT
+    ];
+    _dr = (_lastV#0) * CONST_DT / 2;
+    _r = _r + (_v#0) * CONST_DT / 2 + _dr;
+    _itr = _itr + 1;
+};
+
+[{
+    triggerAmmo _this;
+}, _projectile, _itr * CONST_DT] call CBA_fnc_waitAndExecute;

--- a/addons/customGear/launchers/functions/fnc_carlGAB_DetonateLaser.sqf
+++ b/addons/customGear/launchers/functions/fnc_carlGAB_DetonateLaser.sqf
@@ -12,7 +12,7 @@
 * This funciton will handle whether and when a carlG round should airburst
 *
 * Arguments:
-* _projectile - The projectile to airburst (OBJECT)
+* fired EH parameters
 *
 * Return:
 * None
@@ -20,20 +20,17 @@
 * Example:
 * [_projectile] call potato_customGear_launchers_fnc_carlGAB_DetonateLaser;
 *//***************************************************************************/
-params [["_projectile", objNull]];
-if !(_projectile getShotInfo 5) exitWith {};
-// private _unit = _projectile getShotInfo 9; // 2.22 syntax
-private _unit = (getShotParents _projectile)#1;
-if (isNull _unit) then {_unit = (getShotParents _projectile)#0;};
-if (!(_unit getVariable [QGVAR(abCGRnd), false]) ||
-    {typeOf _projectile != QGVARMAIN(R_FFV448_he)} ||
-    {!(toLowerANSI secondaryWeapon _unit in ["launch_mraws_green_f","launch_mraws_sand_f","launch_mraws_olive_f"])}) exitWith {};
+params ["", "_weapon", "", "", "_ammo", "", "_projectile", "_unit"];
+if (!(_projectile getShotInfo 5) ||
+    {!(_unit getVariable [QGVAR(abCGRnd), false])} ||
+    {_ammo != QGVARMAIN(R_FFV448_he)} ||
+    {!(toLowerANSI _weapon in ["launch_mraws_green_f","launch_mraws_sand_f","launch_mraws_olive_f"])}) exitWith {};
 private _distance = parseNumber ctrlText (((uiNamespace getVariable "RscUnitInfo") displayCtrl CTRL_CA_IGUI_ELEMENTS_GROUP) controlsGroupCtrl CTRL_CA_DISTANCE);
 if (_distance < 30) exitWith {};
 // TBD configurable offset
 _distance = _distance + (_unit getVariable [QGVAR(abOffset), 5]);
-private _friction = 0.05*-0.002; // Based on config'd val
-private _v = [350, 0]; // Based on config'd val
+private _friction = 0.05*-0.002; // Based on config'd vals
+private _v = [350, 0]; // Based on config'd vals
 private _r = 0;
 private _itr = 0;
 private _vMag = -1;

--- a/addons/customGear/launchers/functions/fnc_carlGAB_OffDelta.sqf
+++ b/addons/customGear/launchers/functions/fnc_carlGAB_OffDelta.sqf
@@ -1,0 +1,28 @@
+#include "\z\potato\addons\customGear\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT customGear_launchers
+/***************************************************************************//*
+* Author: Lambda.Tiger
+*
+* Description:
+* This function handles increasing airburst offset from laser
+*
+* Arguments:
+* ace self interact menu params
+* 0: Increase the offset
+*
+* Return:
+* None
+*
+* Example:
+* [false] call potato_customGear_launchers_fnc_carlGAB_OffDelta;
+*//***************************************************************************/
+//IGNORE_PRIVATE_WARNING ["_player"];
+params [["_increase", false]];
+private _distance = _player getVariable [QGVAR(abOffset), 5];
+_distance = _distance + ([-5, 5] select _increase);
+if (abs _distance > 25) exitWith {
+    [format ["Maximum offset (%1m)", _distance - ([-5, 5] select _increase)], true, 5, 2] call ACEFUNC(common,displayText);
+};
+_player setVariable [QGVAR(abOffset), _distance];
+[format ["Offset to laser set to %1m", _distance], true, 5, 2] call ACEFUNC(common,displayText);

--- a/addons/customGear/launchers/functions/fnc_carlGAB_Toggle.sqf
+++ b/addons/customGear/launchers/functions/fnc_carlGAB_Toggle.sqf
@@ -1,0 +1,24 @@
+#include "\z\potato\addons\customGear\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT customGear_launchers
+/***************************************************************************//*
+* Author: Lambda.Tiger
+*
+* Description:
+* This function handles toggling airburst enable
+*
+* Arguments:
+* ace self interact menu params
+*
+* Return:
+* None
+*
+* Example:
+* [] call potato_customGear_launchers_fnc_carlGAB_Toggle;
+*//***************************************************************************/
+//IGNORE_PRIVATE_WARNING ["_player"];
+params [["_increase", false]];
+private _burst = _player getVariable [QGVAR(abCGRnd), false];
+_burst = !_burst;
+[format ["Airburst HE programming %1.", ["DISABLED", "ENABLED"] select _burst], true, 5, 2] call ACEFUNC(common,displayText);
+_player setVariable [QGVAR(abCGRnd), _burst];

--- a/addons/customGear/launchers/functions/fnc_carlGSmoke.sqf
+++ b/addons/customGear/launchers/functions/fnc_carlGSmoke.sqf
@@ -1,0 +1,39 @@
+#include "\z\potato\addons\customGear\script_component.hpp"
+#undef COMPONENT
+#define COMPONENT customGear_launchers
+/***************************************************************************//*
+* Author: Lambda.Tiger
+*
+* Description:
+* This funciton creates initial smnoke around the projectile while the
+* underlying smoke shell begins to bellow.
+*
+* Arguments:
+* _projectile - The projectile to create smoke around (OBJECT)
+*
+* Return:
+* None
+*
+* Example:
+* [_projectile] call potato_customGear_launchers_fnc_carlGSmoke;
+*//***************************************************************************/
+params [
+    ["_projectile", objNull]
+];
+TRACE_1("creatingSmoke",_this);
+if (isNull _projectile ) exitWith {
+    TRACE_1("Bad Init",_this);
+};
+private _shellPos = (ASLToAGL getPosASL _projectile) vectorAdd [0, 0, 1];
+private _smoke0 = createVehicleLocal ["#particlesource", _shellPos, [], 0, "CAN_COLLIDE"];
+_smoke0 setParticleRandom [1, [7, 7, 1], [2, 2, 0.1], 0, 0.5, [0, 0, 0, 0.1], 0, 0, 360];
+_smoke0 setParticleParams [
+	["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8, 0],
+	"", "Billboard", 1, 10, [0, 0, 0], [0 ,0, 0],
+	1, 0.87, 0.7, 0.1, [5, 9, 10],
+	[[0.75, 0.75, 0.75, 1], [0.75, 0.75, 0.75, 1], [0.5, 0.5, 0.5, 1], [0.5, 0.5, 0.5, 1], [0.25, 0.25, 0.25, 0.75], [0.1, 0.1, 0.1, 0]],
+	[1], 0.1, 0.1, "", "", _projectile
+];
+_smoke0 setDropInterval 0.005;
+triggerAmmo _projectile;
+[{deleteVehicle _this}, _smoke0, 0.05] call CBA_fnc_waitAndExecute;

--- a/addons/customGear/launchers/functions/fnc_carlGSmoke.sqf
+++ b/addons/customGear/launchers/functions/fnc_carlGSmoke.sqf
@@ -20,20 +20,25 @@
 params [
     ["_projectile", objNull]
 ];
-TRACE_1("creatingSmoke",_this);
+TRACE_1("attaching smoke EH",_this);
 if (isNull _projectile ) exitWith {
     TRACE_1("Bad Init",_this);
 };
-private _shellPos = (ASLToAGL getPosASL _projectile) vectorAdd [0, 0, 1];
-private _smoke0 = createVehicleLocal ["#particlesource", _shellPos, [], 0, "CAN_COLLIDE"];
-_smoke0 setParticleRandom [1, [7, 7, 1], [2, 2, 0.1], 0, 0.5, [0, 0, 0, 0.1], 0, 0, 360];
-_smoke0 setParticleParams [
-	["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8, 0],
-	"", "Billboard", 1, 10, [0, 0, 0], [0 ,0, 0],
-	1, 0.87, 0.7, 0.1, [5, 9, 10],
-	[[0.75, 0.75, 0.75, 1], [0.75, 0.75, 0.75, 1], [0.5, 0.5, 0.5, 1], [0.5, 0.5, 0.5, 1], [0.25, 0.25, 0.25, 0.75], [0.1, 0.1, 0.1, 0]],
-	[1], 0.1, 0.1, "", "", _projectile
-];
-_smoke0 setDropInterval 0.005;
-triggerAmmo _projectile;
-[{deleteVehicle _this}, _smoke0, 0.05] call CBA_fnc_waitAndExecute;
+_projectile addEventHandler ["Explode", {
+	params ["_projectile", "_posASL"];
+    private _posAGL = ASLToAGL _posASL;
+    private _shellPos = _posAGL vectorAdd [0, 0, 1];
+    private _smokeShell = createVehicle [QGVARMAIN(carlg_SmokeShell), _posAGL, [], 0, "CAN_COLLIDE"];
+    private _smoke0 = createVehicleLocal ["#particlesource", _shellPos, [], 0, "CAN_COLLIDE"];
+    _smoke0 setParticleRandom [1, [7, 7, 1], [2, 2, 0.1], 0, 0.5, [0, 0, 0, 0.1], 0, 0, 360];
+    _smoke0 setParticleParams [
+        ["\A3\data_f\ParticleEffects\Universal\Universal", 16, 12, 8, 0],
+        "", "Billboard", 1, 10, [0, 0, 0], [0 ,0, 0],
+        1, 0.87, 0.7, 0.1, [5, 9, 10],
+        [[0.75, 0.75, 0.75, 1], [0.75, 0.75, 0.75, 1], [0.5, 0.5, 0.5, 1], [0.5, 0.5, 0.5, 1], [0.25, 0.25, 0.25, 0.75], [0.1, 0.1, 0.1, 0]],
+        [1], 0.1, 0.1, "", "", _smokeShell
+    ];
+    _smoke0 setDropInterval 0.005;
+    triggerAmmo _smokeShell;
+    [{deleteVehicle _this}, _smoke0, 0.05] call CBA_fnc_waitAndExecute;
+}];


### PR DESCRIPTION
This PR:
- Adds a ASM 509 thermobaric round
- Adds n FFV 469C Smoke round
- Adds a FFV 448 HE/ Programmable Airburst Round
- Changes the base game magazine names to correlate to the rounds modeled.


## TODO

- [x] Fix smoke submunitions not deploying on ground impact