### PR TITLE
missionTesting, missionMaking - Misc Changes

### DIFF
--- a/addons/missionMaking/functions/fnc_onMissionLoad.sqf
+++ b/addons/missionMaking/functions/fnc_onMissionLoad.sqf
@@ -2,41 +2,47 @@
 
 private _author = "Scenario" get3DENMissionAttribute "author";
 if (_author == "*** Insert author name here. ***") then {
-   set3DENMissionAttributes [["Scenario", "author", profileName]];
-   systemChat "New Mission";
-   systemChat format ["Assigning %1 as author", profileName];
+    set3DENMissionAttributes [["Scenario", "author", profileName]];
+    systemChat "New Mission";
+    systemChat format ["Assigning %1 as author", profileName];
 
    // Warn on old framework, this will only be checked on brand new missions because it is after the author check
-   private _fnc_daysSinceJesus = {
-      private _split = _this splitString "/";
-      if (_split#1 == "20") then { _split set [1, "12"]; }; // lol
-      (366 * parseNumber (_split param [0, ""])) + (31 * parseNumber (_split param [1, ""])) + (parseNumber (_split param [2, ""]));
-   };
-   private _missionBwmfVersion = getText (missionConfigFile >> "bwmfDate");
-   // EXPECTED_BWMF is defined in core/script_mod.hpp
-   INFO_2("Creating new mission on framework [Mission: %1 - Expected: %2]",_missionBwmfVersion,EXPECTED_BWMF);
+    private _fnc_daysSinceJesus = {
+        private _split = _this splitString "/";
+        if (_split#1 == "20") then { _split set [1, "12"]; }; // lol
+        (366 * parseNumber (_split param [0, ""])) + (31 * parseNumber (_split param [1, ""])) + (parseNumber (_split param [2, ""]));
+    };
+    // EXPECTED_BWMF is defined in core/script_mod.hpp
+    private _missionBwmfVersion = getText (missionConfigFile >> "bwmfDate");
+    INFO_2("Creating new mission on framework [Mission: %1 - Expected: %2]",_missionBwmfVersion,EXPECTED_BWMF);
     if (_missionBwmfVersion == "") exitWith {
         ERROR_WITH_TITLE("Problem Reading description.ext","");
     };
-   if ((EXPECTED_BWMF call _fnc_daysSinceJesus) > (_missionBwmfVersion call _fnc_daysSinceJesus)) then {
-      ERROR_WITH_TITLE("Old Framework","~~~~~~~~~~~~~~~~~~~~ Download a newer framework ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
-   };
+    if ((EXPECTED_BWMF call _fnc_daysSinceJesus) > (_missionBwmfVersion call _fnc_daysSinceJesus)) then {
+        ERROR_WITH_TITLE("Old Framework","~~~~~~~~~~~~~~~~~~~~ Download a newer framework ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+    };
 };
 
 private _current_uuid = QEGVAR(missiontesting,missionTestingInfo) get3DENMissionAttribute QGVAR(uuid);
-diag_log format["POTATO - loaded UUID: %1", _current_uuid];
-if (!(_current_uuid isEqualType "") || { _current_uuid isEqualTo "" }) then {
-   _current_uuid = call CBA_fnc_createUUID;
-   diag_log format["POTATO - setting mission uuid: %1", _current_uuid];
-   set3DENMissionAttributes [[QEGVAR(missiontesting,missionTestingInfo), QGVAR(uuid), _current_uuid]];
+TRACE_1("POTATO - loaded UUID",_current_uuid);
+if (!(_current_uuid isEqualType "") || { _current_uuid isEqualTo "" } || { _current_uuid isEqualTo "true" }) then {
+    _current_uuid = call CBA_fnc_createUUID;
+    diag_log format["POTATO - setting mission uuid: %1", _current_uuid];
+    set3DENMissionAttributes [[QEGVAR(missiontesting,missionTestingInfo), QGVAR(uuid), _current_uuid]];
+};
+
+private _missionType = QEGVAR(missiontesting,missionTestingInfo) get3DENMissionAttribute QEGVAR(missiontesting,missionType);
+TRACE_1("Potato - Mission type",_missionType);
+if (isNil "_missionType" || {!(_missionType isEqualType 0)} || {_missionType < -1}) then {
+    QEGVAR(missiontesting,missionTestingInfo) set3DENMissionAttribute [QEGVAR(missiontesting,missionType), 0];
 };
 
 all3DENEntities params ["_objects"];
 {
-   private _at = _x get3DENAttribute "acre_sys_radio_edenSetup";
-   if (!isNil "_at" && {_at isNotEqualTo [[]]}) then {
-      INFO_1("Removing acre attrib from object %1",_x);
-      systemChat "Cleaning up acre attrib - Make sure to save the mission after this";
-      _x clear3DENAttribute "acre_sys_radio_edenSetup";
-   };
+    private _at = _x get3DENAttribute "acre_sys_radio_edenSetup";
+    if (!isNil "_at" && {_at isNotEqualTo [[]]}) then {
+        INFO_1("Removing acre attrib from object %1",_x);
+        systemChat "Cleaning up acre attrib - Make sure to save the mission after this";
+        _x clear3DENAttribute "acre_sys_radio_edenSetup";
+    };
 } forEach _objects;

--- a/addons/missionTesting/CfgEden.hpp
+++ b/addons/missionTesting/CfgEden.hpp
@@ -51,6 +51,7 @@ class Cfg3DEN {
                                 class AFTER_HOURS {
                                     name = "After-Hours/Offnight";
                                     value = 0;
+                                    default = 1;
                                 };
                                 class COOP {
                                     name = "COOP";

--- a/addons/missionTesting/CfgEden.hpp
+++ b/addons/missionTesting/CfgEden.hpp
@@ -41,7 +41,7 @@ class Cfg3DEN {
                             displayName = "Mission Type:";
                             property = QGVAR(missionType);
                             control = QUOTE(combo);
-                            defaultValue = 0;
+                            defaultValue = -2607;
                             typeName = "NUMBER";
                             class Values {
                                 class INVALID {

--- a/addons/setVehicleAmmo/functions/fnc_attributeLoad.sqf
+++ b/addons/setVehicleAmmo/functions/fnc_attributeLoad.sqf
@@ -177,14 +177,15 @@ private _addWeaponSystem = {
         private _muzzles = getArray (configFile >> "CfgWeapons" >> _weapon >> "muzzles");
         private _weaponMagazines = compatibleMagazines _weapon;
 
-        ((GVAR(turretMagsArray) select _index) select 1) pushBack _weaponMagazines;
-
         {
             if (_x != "this") then {
                 _weaponMagazines append (getArray (configFile >> "CfgWeapons" >> _weapon >> _x >> "magazines"));
             };
             false
         } count _muzzles;
+
+        _weaponMagazines = _weaponMagazines arrayIntersect _weaponMagazines;
+        ((GVAR(turretMagsArray) select _index) select 1) pushBack _weaponMagazines;
 
         private _tvIndexWeapon = (_control controlsGroupCtrl 101) tvAdd [[_tvIndexTurret], _x];
         (_control controlsGroupCtrl 101) tvExpand [_tvIndexTurret, _tvIndexWeapon];


### PR DESCRIPTION
This PR:
- Attempts to fix POTATO vehicle customization options doubling up magazines
- Changes the config default for `potato_missionMaking_missionType` to allow adding the system's expected default mission type 
  - Also whitespace, sorry