### PR TITLE
miscFixes - Air Targeting and PG-9 & PG-15 Model

### DIFF
--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -117,7 +117,6 @@ class CfgAmmo {
     };
 
     // Carl Gustaf time
-    class RocketBase;
     class R_MRAAWS_HEAT_F: RocketBase {
         class EventHandlers;
     };

--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -105,16 +105,14 @@ class CfgAmmo {
     };
 
     // Custom Anti-Air Capable RPG rounds
-    class CUP_R_PG7VL_AT;
-    class CUP_R_PG7VM_AT;
-    class CUP_R_PG7V_AT;
-    class potato_R_PG7VL_AA: CUP_R_PG7VL_AT {
+    class RocketBase;
+    class CUP_R_PG7VL_AT: RocketBase {
         airLock = 1;
     };
-    class potato_R_PG7VM_AA: CUP_R_PG7VM_AT {
+    class CUP_R_PG7VM_AT: RocketBase {
         airLock = 1;
     };
-    class potato_R_PG7V_AA: CUP_R_PG7V_AT {
+    class CUP_R_PG7V_AT: RocketBase {
         airLock = 1;
     };
 

--- a/addons/customGear/launchers/CfgMagazines.hpp
+++ b/addons/customGear/launchers/CfgMagazines.hpp
@@ -66,20 +66,27 @@ class CfgMagazines {
     };
 
     // Custom Anti-Air Capable RPG rounds
-    class CUP_PG7V_M;
-    class CUP_PG7VM_M;
-    class CUP_PG7VL_M;
-    class potato_PG7V_M: CUP_PG7V_M {
-        ammo = "potato_R_PG7V_AA";
+    class CA_LauncherMagazine;
+    class CUP_PG7V_M: CA_LauncherMagazine {
         maxLeadSpeed = 150;
+    };
+    class CUP_PG7VM_M: CA_LauncherMagazine {
+        maxLeadSpeed = 150;
+    };
+    class CUP_PG7VL_M: CA_LauncherMagazine {
+        maxLeadSpeed = 150;
+    };
+    class potato_PG7V_M: CUP_PG7V_M {
+        scope = 1;
+        scopeArsenal = 1;
     };
     class potato_PG7VM_M: CUP_PG7VM_M {
-        ammo = "potato_R_PG7V_AA";
-        maxLeadSpeed = 150;
+        scope = 1;
+        scopeArsenal = 1;
     };
     class potato_PG7VL_M: CUP_PG7VL_M {
-        ammo = "potato_R_PG7V_AA";
-        maxLeadSpeed = 150;
+        scope = 1;
+        scopeArsenal = 1;
     };
 
     // Carl Gustaf time

--- a/addons/customGear/launchers/CfgMagazines.hpp
+++ b/addons/customGear/launchers/CfgMagazines.hpp
@@ -90,7 +90,6 @@ class CfgMagazines {
     };
 
     // Carl Gustaf time
-    class CA_LauncherMagazine;
     class MRAWS_HEAT_F: CA_LauncherMagazine {
         descriptionShort = "Type: FFV751 Tandem HEAT Rocket<br />Rounds: 1<br />Used in: MAAWS";
         displayName = "FFV751 (Tandem HEAT) Round";

--- a/addons/miscFixes/CfgAmmo.hpp
+++ b/addons/miscFixes/CfgAmmo.hpp
@@ -1,9 +1,17 @@
 class CfgAmmo {
-    
+
     // Fix smoke bounce (downside is gl smokes lose some sound effects)
     class SmokeShell;
     class G_40mm_Smoke: SmokeShell {
         simulation = "shotSmoke";
         deflectionSlowDown = 0.2;
+    };
+    // Tank shells engage air targets
+    class ShellBase;
+    class Sh_120mm_APFSDS: ShellBase {
+        airLock = 1;
+    };
+    class Sh_120mm_HE: ShellBase {
+        airLock = 1;
     };
 };

--- a/addons/miscFixes/patchCUP/CfgAmmo.hpp
+++ b/addons/miscFixes/patchCUP/CfgAmmo.hpp
@@ -58,6 +58,5 @@ class CfgAmmo {
     class CUP_Sh_PG9_AT: ShellBase {
         tracerStartTime = 0.001;
         tracerEndTime = 12;
-        airLock = 1;
     };
 };

--- a/addons/miscFixes/patchCUP/CfgAmmo.hpp
+++ b/addons/miscFixes/patchCUP/CfgAmmo.hpp
@@ -53,4 +53,11 @@ class CfgAmmo {
         indirectHit = 25;
         indirectHitRange = 3.5;
     };
+    // spg-9 and pg-15 round tracers
+    class ShellBase;
+    class CUP_Sh_PG9_AT: ShellBase {
+        tracerStartTime = 0.001;
+        tracerEndTime = 12;
+        airLock = 1;
+    };
 };

--- a/addons/miscFixes/patchGM/CfgAmmo.hpp
+++ b/addons/miscFixes/patchGM/CfgAmmo.hpp
@@ -104,6 +104,18 @@ class CfgAmmo {
     class gm_shell_artillery_Base: gm_shell_base {
         effectFly = "";
     };
+    class gm_shell_HE_Base: gm_shell_base {};
+    class gm_shell_73mm_HE_og15v: gm_shell_HE_Base {
+        model = "\a3\Weapons_F_Tank\Ammo\rocket_spg9.p3d";
+        tracerStartTime = 0.001;
+        tracerEndTime = 12;
+    };
+    class gm_shell_HEAT_Base: gm_shell_HE_Base {};
+    class gm_shell_73mm_HEAT_pg15v: gm_shell_HEAT_Base {
+        model = "\a3\Weapons_F_Tank\Ammo\rocket_spg9.p3d";
+        tracerStartTime = 0.001;
+        tracerEndTime = 12;
+    };
 
     // what if there were colors
     class gm_bullet_762x51mm_B_T_DM21;


### PR DESCRIPTION
This PR:

- Hides the potato PG7 rounds and removes ammo
- Changes CUP PG7 rounds to allow AI usage against helicopters
- Add tracers to CUP and GM PG-9 and PG-15 rounds to make it clear.
- Changed tank rounds  to now engage slower air targets