### PR TITLE
launchers, miscFixes - Split Carl Gustaf Rounds Between Vanilla and CUP

### DIFF
--- a/addons/customGear/launchers/CfgAmmo.hpp
+++ b/addons/customGear/launchers/CfgAmmo.hpp
@@ -141,6 +141,9 @@ class CfgAmmo {
             };
         };
     };
+    class GVARMAIN(R_FFV448_he_cup): GVARMAIN(R_FFV448_he) {
+        thrust = 280;
+    };
     class GVARMAIN(R_ASM509_tb): R_MRAAWS_HE_F {
         ACEGVAR(frag,skip) = 1; // thermobaric, no real details
         ACEGVAR(frag,gurney_c) = 2745; // idk, PAX-42 or something
@@ -148,6 +151,9 @@ class CfgAmmo {
         indirectHit = 40;
         indirectHitRange = 8;
         model = "\A3\Weapons_F_Tank\Launchers\MRAWS\rocket_MRAWS_HEAT55_F.p3d";
+    };
+    class GVARMAIN(R_ASM509_tb_cup): GVARMAIN(R_ASM509_tb) {
+        thrust = 280;
     };
     class GVARMAIN(R_FFV469C_smoke): R_MRAAWS_HEAT_F {
         ACEGVAR(frag,skip) = 1;
@@ -165,6 +171,9 @@ class CfgAmmo {
                 init = QUOTE(_this call FUNC(carlGSmoke));
             };
         };
+    };
+    class GVARMAIN(R_FFV469C_smoke_cup): GVARMAIN(R_FFV469C_smoke) {
+        thrust = 280;
     };
     // Smoke submunition
     class SmokeShellArty;

--- a/addons/customGear/launchers/CfgMagazineWells.hpp
+++ b/addons/customGear/launchers/CfgMagazineWells.hpp
@@ -6,9 +6,9 @@ class CfgMagazineWells {
         ADDON[] = {QGVARMAIN(carlgustaf_FFV448_he),QGVARMAIN(carlgustaf_ASM509_tb),QGVARMAIN(carlgustaf_FFV469C_smoke)};
     };
     class potato_CUP_Carl_Gustaf {
-        ADDON[] = {QGVARMAIN(carlgustaf_FFV448_he),QGVARMAIN(carlgustaf_ASM509_tb),QGVARMAIN(carlgustaf_FFV469C_smoke)};
+        ADDON[] = {QGVARMAIN(carlgustaf_FFV448_he_cup),QGVARMAIN(carlgustaf_ASM509_tb_cup),QGVARMAIN(carlgustaf_FFV469C_smoke_cup)};
     };
     class CWR3_CARLGUSTAF {
-        ADDON[] = {QGVARMAIN(carlgustaf_FFV448_he),QGVARMAIN(carlgustaf_ASM509_tb),QGVARMAIN(carlgustaf_FFV469C_smoke)};
+        ADDON[] = {QGVARMAIN(carlgustaf_FFV448_he_cup),QGVARMAIN(carlgustaf_ASM509_tb_cup),QGVARMAIN(carlgustaf_FFV469C_smoke_cup)};
     };
 };

--- a/addons/customGear/launchers/CfgMagazineWells.hpp
+++ b/addons/customGear/launchers/CfgMagazineWells.hpp
@@ -5,4 +5,10 @@ class CfgMagazineWells {
     class CBA_Carl_Gustaf {
         ADDON[] = {QGVARMAIN(carlgustaf_FFV448_he),QGVARMAIN(carlgustaf_ASM509_tb),QGVARMAIN(carlgustaf_FFV469C_smoke)};
     };
+    class potato_CUP_Carl_Gustaf {
+        ADDON[] = {QGVARMAIN(carlgustaf_FFV448_he),QGVARMAIN(carlgustaf_ASM509_tb),QGVARMAIN(carlgustaf_FFV469C_smoke)};
+    };
+    class CWR3_CARLGUSTAF {
+        ADDON[] = {QGVARMAIN(carlgustaf_FFV448_he),QGVARMAIN(carlgustaf_ASM509_tb),QGVARMAIN(carlgustaf_FFV469C_smoke)};
+    };
 };

--- a/addons/customGear/launchers/CfgMagazines.hpp
+++ b/addons/customGear/launchers/CfgMagazines.hpp
@@ -128,28 +128,13 @@ class CfgMagazines {
         mass = 68.3;
     };
     // CUP Thrust changes
-    class GVARMAIN(carlgustaf_FFV448_he_cup): MRAWS_HE_F {
+    class GVARMAIN(carlgustaf_FFV448_he_cup): GVARMAIN(carlgustaf_FFV448_he) {
         ammo = QGVARMAIN(R_FFV448_he_cup);
-        author = "Bourbon Warfare";
-        descriptionShort = "Type: FFV448 HE Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
-        displayName = "FFV448 (Programmable HE/AB) Round";
-        displayNameShort = "HE";
-        mass = 57.3;
     };
-    class GVARMAIN(carlgustaf_ASM509_tb_cup): MRAWS_HE_F {
+    class GVARMAIN(carlgustaf_ASM509_tb_cup): GVARMAIN(carlgustaf_ASM509_tb) {
         ammo = QGVARMAIN(R_ASM509_tb_cup);
-        author = "Bourbon Warfare";
-        descriptionShort = "Type: ASM-509 HE Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
-        displayName = "ASM-509 (Thermobaric) Round";
-        displayNameShort = "Thermobaric";
-        mass = 92.6;
     };
-    class GVARMAIN(carlgustaf_FFV469C_smoke_cup): MRAWS_HEAT55_F {
+    class GVARMAIN(carlgustaf_FFV469C_smoke_cup): GVARMAIN(carlgustaf_FFV469C_smoke) {
         ammo = QGVARMAIN(R_FFV469C_smoke_cup);
-        author = "Bourbon Warfare";
-        descriptionShort = "Type: FFV469C Smoke Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
-        displayName = "FFV469C (Smoke) Round";
-        displayNameShort = "Smoke";
-        mass = 68.3;
     };
 };

--- a/addons/customGear/launchers/CfgMagazines.hpp
+++ b/addons/customGear/launchers/CfgMagazines.hpp
@@ -127,4 +127,29 @@ class CfgMagazines {
         displayNameShort = "Smoke";
         mass = 68.3;
     };
+    // CUP Thrust changes
+    class GVARMAIN(carlgustaf_FFV448_he_cup): MRAWS_HE_F {
+        ammo = QGVARMAIN(R_FFV448_he_cup);
+        author = "Bourbon Warfare";
+        descriptionShort = "Type: FFV448 HE Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
+        displayName = "FFV448 (Programmable HE/AB) Round";
+        displayNameShort = "HE";
+        mass = 57.3;
+    };
+    class GVARMAIN(carlgustaf_ASM509_tb_cup): MRAWS_HE_F {
+        ammo = QGVARMAIN(R_ASM509_tb_cup);
+        author = "Bourbon Warfare";
+        descriptionShort = "Type: ASM-509 HE Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
+        displayName = "ASM-509 (Thermobaric) Round";
+        displayNameShort = "Thermobaric";
+        mass = 92.6;
+    };
+    class GVARMAIN(carlgustaf_FFV469C_smoke_cup): MRAWS_HEAT55_F {
+        ammo = QGVARMAIN(R_FFV469C_smoke_cup);
+        author = "Bourbon Warfare";
+        descriptionShort = "Type: FFV469C Smoke Rocket<br />Rounds: 1<br />Used in: Carl Gustaf, MAAWS";
+        displayName = "FFV469C (Smoke) Round";
+        displayNameShort = "Smoke";
+        mass = 68.3;
+    };
 };

--- a/addons/miscFixes/patchCUP/CfgAmmo.hpp
+++ b/addons/miscFixes/patchCUP/CfgAmmo.hpp
@@ -53,6 +53,10 @@ class CfgAmmo {
         indirectHit = 25;
         indirectHitRange = 3.5;
     };
+    // Carl Gustaf rounds too much thrus
+    class CUP_R_MEEWS_HEDP: RocketBase {
+        thrust = 0.1;
+    };
     // spg-9 and pg-15 round tracers
     class ShellBase;
     class CUP_Sh_PG9_AT: ShellBase {

--- a/addons/miscFixes/patchCUP/CfgAmmo.hpp
+++ b/addons/miscFixes/patchCUP/CfgAmmo.hpp
@@ -53,10 +53,6 @@ class CfgAmmo {
         indirectHit = 25;
         indirectHitRange = 3.5;
     };
-    // Carl Gustaf rounds too much thrus
-    class CUP_R_MEEWS_HEDP: RocketBase {
-        thrust = 0.1;
-    };
     // spg-9 and pg-15 round tracers
     class ShellBase;
     class CUP_Sh_PG9_AT: ShellBase {

--- a/addons/miscFixes/patchCUP/config.cpp
+++ b/addons/miscFixes/patchCUP/config.cpp
@@ -429,6 +429,9 @@ class CfgMagazineWells {
     class CBA_40mm_M203_6rnds {
         potato_magazineWell[] = { "potato_6Rnd_40mm_M433_HEDP" };
     };
+    class CBA_Carl_Gustaf {
+        CUP_mags[] = {};
+    };
 };
 
 class Mode_SemiAuto; // inheritance for sa61 accuracy fix
@@ -784,6 +787,10 @@ class CfgWeapons {
             };
         };
         class WeaponSlotsInfo;
+    };
+    class CUP_launch_MAAWS: Launcher_Base_F {
+        magazines[] = {"CUP_MAAWS_HEAT_M","CUP_MAAWS_HEDP_M"};
+        magazineWell[] = {"potato_CUP_Carl_Gustaf"};
     };
     class CUP_Vmlauncher_AT13_single_veh;
     class GVARMAIN(CUP_launch_M47_veh): CUP_Vmlauncher_AT13_single_veh {

--- a/addons/miscFixes/patchCWR/config.cpp
+++ b/addons/miscFixes/patchCWR/config.cpp
@@ -40,7 +40,10 @@ class CfgMagazineWells {
         cwr3_mags[] = {};
     };
     class CWR3_CARLGUSTAF {
-        cup_magazines[] = {}; // CWR3 expects a 0.1 second 280 thrust and CUP does not do that after changes we've made
+        cup_magazines[] = {"CUP_MAAWS_HEAT_M","CUP_MAAWS_HEDP_M"};
+    };
+    class potato_CUP_Carl_Gustaf {
+        cwr3_mags[] = {"cwr3_carlgustaf_hedp_m","cwr3_carlgustaf_heat_m"};
     };
 };
 

--- a/addons/miscFixes/patchCWR/config.cpp
+++ b/addons/miscFixes/patchCWR/config.cpp
@@ -21,13 +21,6 @@ class Extended_DisplayLoad_EventHandlers {
     };
 };
 
-class CfgAmmo {
-    class RocketBase;
-    class cwr3_r_carlgustaf_hedp: RocketBase {
-        thrust = 0.1;
-    };
-};
-
 class CfgMagazines {
     class cwr3_12rnd_mm1_m;
     class potato_12Rnd_40mm_M433_HEDP: cwr3_12rnd_mm1_m {
@@ -41,6 +34,16 @@ class CfgMagazines {
         tracersEvery = 1;
     };
 };
+
+class CfgMagazineWells {
+    class CBA_Carl_Gustaf { // Default parameter is thrust = 0.1, thrustTime = 0.1, CWR does not do this
+        cwr3_mags[] = {};
+    };
+    class CWR3_CARLGUSTAF {
+        cup_magazines[] = {}; // CWR3 expects a 0.1 second 280 thrust and CUP does not do that after changes we've made
+    };
+};
+
 
 class CfgWeapons {
     class Rifle_Base_F;

--- a/addons/miscFixes/patchCWR/config.cpp
+++ b/addons/miscFixes/patchCWR/config.cpp
@@ -21,6 +21,13 @@ class Extended_DisplayLoad_EventHandlers {
     };
 };
 
+class CfgAmmo {
+    class RocketBase;
+    class cwr3_r_carlgustaf_hedp: RocketBase {
+        thrust = 0.1;
+    };
+};
+
 class CfgMagazines {
     class cwr3_12rnd_mm1_m;
     class potato_12Rnd_40mm_M433_HEDP: cwr3_12rnd_mm1_m {


### PR DESCRIPTION
## Summary
This PR splits the magazine wells between Vanilla and CUP and their derivatives. 
## Motivation
CUP (and CWR3) and Vanilla (including GM) both use a momentary thrust on launch lasting 0.1 seconds, CUP's system uses a thrust of 280, while vanilla uses a thrust 0.1. The difference in thrusts creates a fairly large difference in impact location at range and also propagates to how the two families of optics are zeroed. Specifically, both versions and their derivatives need the thrust to be accurate for their respective optics to be accurate. 