### PR TITLE
miscFixes - PatchGM - Tank Shells Engage Air Targets

### DIFF
--- a/addons/miscFixes/patchGM/CfgAmmo.hpp
+++ b/addons/miscFixes/patchGM/CfgAmmo.hpp
@@ -104,13 +104,21 @@ class CfgAmmo {
     class gm_shell_artillery_Base: gm_shell_base {
         effectFly = "";
     };
-    class gm_shell_HE_Base: gm_shell_base {};
+    class gm_shell_AP_Base: gm_shell_base {
+        airlock = 1;
+    };
+    class gm_shell_HE_Base: gm_shell_base {
+        airlock = 1;
+    };
     class gm_shell_73mm_HE_og15v: gm_shell_HE_Base {
         model = "\a3\Weapons_F_Tank\Ammo\rocket_spg9.p3d";
+        airlock = 0;
         tracerStartTime = 0.001;
         tracerEndTime = 12;
     };
-    class gm_shell_HEAT_Base: gm_shell_HE_Base {};
+    class gm_shell_HEAT_Base: gm_shell_HE_Base {
+        airlock = 0;
+    };
     class gm_shell_73mm_HEAT_pg15v: gm_shell_HEAT_Base {
         model = "\a3\Weapons_F_Tank\Ammo\rocket_spg9.p3d";
         tracerStartTime = 0.001;

--- a/addons/miscFixes/patchGM/CfgMagazines.hpp
+++ b/addons/miscFixes/patchGM/CfgMagazines.hpp
@@ -34,4 +34,8 @@ class CfgMagazines {
         ammo = "gm_bullet_762x51mm_B_T_DM21_yellow";
         displayName = "7.62mm 120Rnd MG3 Ball-T DM21 Green Mag (Yellow)";
     };
+    class gm_vehicleMagazine_Base;
+    class gm_vehicleMagazine_cannon_Base: gm_vehicleMagazine_Base {
+        maxLeadSpeed = 30;
+    };
 };


### PR DESCRIPTION
This PR allows AI to use the GM shells (tank and otherwise) to engage air targets. Needs to be tested in game since GM magazines have high `maxLeadSpeed`s.