### PR TITLE
various - Backlog of Small Fixes

### DIFF
--- a/addons/adminMenu/functions/fnc_uihook_tabChange.sqf
+++ b/addons/adminMenu/functions/fnc_uihook_tabChange.sqf
@@ -206,8 +206,24 @@ case (7): {
             ["eng", "Logistics Engineer"],
             ["fac", ""],
             ["rifleman_02", ""],
+            ["rifleman_03", ""],
+            ["rifleman_04", ""],
             ["artl", "Artillery Leader"],
-            ["artg", "Artillery Gunner"]
+            ["artg", "Artillery Gunner"],
+            ["hmgg", "HMG Gunner"],
+            ["hmgag", "HMG Spotter/Ammo Bearer"],
+            ["hmgl", "HMG Lead"],
+            ["hatg", "HAT Gunner"],
+            ["hatag", "HAT Spotter/Ammo Bearer"],
+            ["hatl", "HAT Lead"],
+            ["sf_rifleman", "SF Rifle"],
+            ["sf_rifleman_02", "SF Rifle 2"],
+            ["sf_aar", "SF AAR"],
+            ["sf_ar", "SF AR"],
+            ["sf_lat", "SF RAT"],
+            ["sf_sl", "SF SL"],
+            ["sf_ftl", "SF FTL"],
+            ["sf_sm", "SF SM"]
         ];
         private _listGear = UI_TAB_FIX_UNIT_GEAR;
         lbClear _listGear;

--- a/addons/core/XEH_postInit.sqf
+++ b/addons/core/XEH_postInit.sqf
@@ -100,5 +100,9 @@ call FUNC(playerJipHint);
 if (isServer) then {
     private _list = allUnits select { !((_x getVariable ["acre_sys_radio_setup", ""]) isEqualType "") };
     { WARNING_2("Unit %1 (%2) has bad acre var",vehicleVarName _x,name _x); } forEach _list;
+    ["potato_serverLog", {
+        params ["_addon", "_message", ["_user", "??"]];
+        diag_log formatText ["[POTATO|%1] Logging [%2]: %3", _addon, _user, _message];
+    }] call CBA_fnc_addEventHandler;
 };
 if (hasInterface) then { player setVariable ["acre_sys_radio_setup", nil]; };

--- a/addons/core/script_mod.hpp
+++ b/addons/core/script_mod.hpp
@@ -2,7 +2,7 @@
 
 #define MAINPREFIX z
 #define PREFIX potato
-
+#define QCOMPONENT QUOTE(COMPONENT)
 #include "script_version.hpp"
 
 #define VERSION MAJOR.MINOR

--- a/addons/dui_goby/XEH_postInit.sqf
+++ b/addons/dui_goby/XEH_postInit.sqf
@@ -14,7 +14,7 @@ if (!hasInterface) exitWith {};
         if ((_setting != "diwako_dui_nametags_fontCustomInfo") && (_setting != "diwako_dui_nametags_customInfoShadow")) exitWith {};
         true call FUNC(updateUnit)  // update on dui-setting change for font and shadow
     }] call CBA_fnc_addEventHandler;
-    if (CBA_settings_client getVariable ["diwako_dui_compassRange", -1] < 0) then {
+    if (isNil {"diwako_dui_compassRange" call CBA_settings_fnc_get}) then {
         diwako_dui_compassRange = 50;
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/dui_goby/XEH_postInit.sqf
+++ b/addons/dui_goby/XEH_postInit.sqf
@@ -14,4 +14,7 @@ if (!hasInterface) exitWith {};
         if ((_setting != "diwako_dui_nametags_fontCustomInfo") && (_setting != "diwako_dui_nametags_customInfoShadow")) exitWith {};
         true call FUNC(updateUnit)  // update on dui-setting change for font and shadow
     }] call CBA_fnc_addEventHandler;
+    if (CBA_settings_client getVariable ["diwako_dui_compassRange", -1] < 0) then {
+        diwako_dui_compassRange = 50;
+    };
 }] call CBA_fnc_addEventHandler;

--- a/addons/forestry/XEH_postInit.sqf
+++ b/addons/forestry/XEH_postInit.sqf
@@ -11,15 +11,6 @@ if (hasInterface) then {
             call FUNC(doChop)
         }
     ] call CBA_fnc_addKeybind;
-
-/*
-    [["Potato", "Forestry"],
-        "potato_forestry_id_2", //replace with BW specific
-        ["Flatten Grass", "Commit nature abuse"],
-        "",
-        {call FUNC(doFlatten)}
-    ] call CBA_fnc_addKeybind;
-*/
 };
 
 // Server Event

--- a/addons/howTo/XEH_postInit.sqf
+++ b/addons/howTo/XEH_postInit.sqf
@@ -22,6 +22,8 @@ GVAR(howToUse) = createHashMapFromArray [  //IGNORE_PRIVATE_WARNING ["_player", 
 ,
 #include "guides\launcher_m136.inc.sqf"
 ,
+#include "guides\launcher_maawsMk4Mod1.inc.sqf"
+,
 #include "guides\launcher_rpg7-pgo.inc.sqf"
 ];
 GVAR(showAll) = false;

--- a/addons/howTo/guides/launcher_maawsMk4Mod1.inc.sqf
+++ b/addons/howTo/guides/launcher_maawsMk4Mod1.inc.sqf
@@ -1,0 +1,10 @@
+["MAAWS Mk4 Mod 1 Launcher", [{
+    (_units findIf {(toLowerANSI secondaryWeapon _x) in ["launch_mraws_green_f","launch_mraws_sand_f","launch_mraws_olive_f"]}) != -1
+}, {
+"Squad equiped with MAAWS Mk4 Mod 1<br/><br/>
+
+The launcher is equipped with a laser range finder, this laser range finder DOES NOT adjust ranging on the launcher, rather provides a range for the gunner to aim at using the optics built in ranging marks.<br/><br/>
+All rounds used in the launcher the same trajectory and therefore may use the same ranging marks. Special rounds including, Airburst HE rounds can be toggled from impact mode to airburst mode.<br/><br/>
+
+HE 448D rounds may be set to airburst by ACE self-interact. If the lased range is longer than 30m, the round is programmed to detonated in the air at the lased range. An additional offset may be set using the ACE self-interact to either increase or reduce the range to detonation by up to 25m."
+}]]

--- a/addons/missionTesting/XEH_postInit.sqf
+++ b/addons/missionTesting/XEH_postInit.sqf
@@ -38,6 +38,7 @@ GVAR(MissionTestingChecklistMaster) = [
     ,["COOP CHECKLIST",
         [
             ["Talk to the Zeus/mission-maker about their intent.",D_CHECK,MISSION_TYPE_APPLIES_COOP]
+            ,["Make sure there is resupply for loadouts (medical, AT, rifles, etc.) or another gameplay element in place.",D_CHECK,MISSION_TYPE_APPLIES_COOP]
             ,["Make sure the humans can kill whatever Zeus intends to spawn in.",D_CHECK,MISSION_TYPE_APPLIES_COOP]
             ,["Make sure that no heavy scripts are killing server FPS/CPS",D_CHECK,MISSION_TYPE_APPLIES_COOP]
             ,["Talk about the objectives and make a call on if they are doable within the time frame of 75-80 minutes assuming ideal player conditions. Essentially is it likely that we will have all objectives completed or nearing completion around the 90 minute mark (including Safe Start).",D_CHECK,MISSION_TYPE_APPLIES_COOP]

--- a/addons/respawn/functions/fnc_ui_handleAdminLoad.sqf
+++ b/addons/respawn/functions/fnc_ui_handleAdminLoad.sqf
@@ -46,19 +46,20 @@ _ctrlNoMarkerFrame ctrlSetText "No Markers";
 
 _ctrlNoMarkerCheckBox ctrlSetPosition [0.69 * safeZoneW + safeZoneX, 0.23 * safeZoneH + safeZoneY, 0.02 * safeZoneW, 4/3 * 0.02 * safeZoneW];
 _ctrlNoMarkerCheckBox ctrlCommit 0;
-_ctrlNoMarkerCheckBox ctrlSetTooltip "Secret Respawn";
+_ctrlNoMarkerCheckBox ctrlSetTooltip "Secret Reinforce";
 _ctrlNoMarkerCheckBox cbSetChecked (missionNamespace getVariable [QGVAR(noMarkers), false]);
 _ctrlNoMarkerCheckBox ctrlAddEventHandler ["CheckedChanged", {
     params ["", "_checked"];
     _checked = [false, true] select _checked;
     missionNamespace setVariable [QGVAR(noMarkers), _checked, true];
-    systemChat format ["Respawn No-Markers: %1", _checked];
+    systemChat format ["Reinforce No-Markers: %1", _checked];
+    ["potato_serverLog", [QCOMPONENT, format ["%1 reinforce markers", ["Enabling", "Disabling"] select _checked], profileName]] call CBA_fnc_serverEvent;
 }];
 
 
 // validate user
 if (!([] call EFUNC(core,isAuthorized)) && !(ZEUS_ENABLED && !((getPlayerUID player) in BLACK_LIST_UIDS) && (true isEqualTo (profileNamespace getVariable [EULA_CHECK, false])))) exitWith {
-    WARNING("Not authorized for respawn");
+    WARNING("Not authorized for Reinforce");
     [] call FUNC(closeAdminRespawn);
 };
 

--- a/addons/respawn/functions/fnc_ui_handleAdminLoad.sqf
+++ b/addons/respawn/functions/fnc_ui_handleAdminLoad.sqf
@@ -77,7 +77,7 @@ private _allFactions = createHashMap;
 } forEach allUnits;
 
 {
-    (GVAR(factionsToInfo) get _x) params ["_displayName", "", "_factionClassname"];
+    _y params ["_displayName", "", "_factionClassname"];
     private _count = _allFactions getOrDefault [_factionClassname, 0];
     if (_count > 0) then { _displayName = _displayName + format [" [%1]", _count]; };
 
@@ -86,7 +86,7 @@ private _allFactions = createHashMap;
         lbSetPicture [ADMIN_FACTION_COMBO_IDC, _index, getText (configFile >> "CfgFactionClasses" >> _factionClassname >> "icon")];
     };
     lbSetData [ADMIN_FACTION_COMBO_IDC, _index, _x];
-} forEach (keys GVAR(factionsToInfo));
+} forEach GVAR(factionsToInfo);
 
 private _factionIndex = if (isNil QGVAR(lastFactionIndex)) then {
     0

--- a/addons/spectate/functions/fnc_setChannels.sqf
+++ b/addons/spectate/functions/fnc_setChannels.sqf
@@ -18,8 +18,12 @@ TRACE_1("Params",_this);
 params [["_set", false, [false]]];
 
 {
-    _x enableChannel _set;
+    _x enableChannel [_set, false, _set, _set];
 } forEach ([
     [GLOBAL_CHANNEL_INDEX, SIDE_CHANNEL_INDEX, COMMAND_CHANNEL_INDEX, VEHICLE_CHANNEL_INDEX, DIRECT_CHANNEL_INDEX],
     [SIDE_CHANNEL_INDEX, COMMAND_CHANNEL_INDEX, VEHICLE_CHANNEL_INDEX, DIRECT_CHANNEL_INDEX]
 ] select (call CFUNC(isAuthorized)));
+
+if (channelEnabled SIDE_CHANNEL_INDEX) then {
+    setCurrentChannel SIDE_CHANNEL_INDEX;
+};

--- a/addons/spectate/functions/fnc_setChannels.sqf
+++ b/addons/spectate/functions/fnc_setChannels.sqf
@@ -18,7 +18,7 @@ TRACE_1("Params",_this);
 params [["_set", false, [false]]];
 
 {
-    _x enableChannel [_set, false, _set, _set];
+    _x enableChannel _set;
 } forEach ([
     [GLOBAL_CHANNEL_INDEX, SIDE_CHANNEL_INDEX, COMMAND_CHANNEL_INDEX, VEHICLE_CHANNEL_INDEX, DIRECT_CHANNEL_INDEX],
     [SIDE_CHANNEL_INDEX, COMMAND_CHANNEL_INDEX, VEHICLE_CHANNEL_INDEX, DIRECT_CHANNEL_INDEX]


### PR DESCRIPTION
This PR:
- Adds more reset gear types to the admin menu
- Adds a server logging event called `potato_serverLog`
- `QCOMPONENT` macro that us `QUOTE(COMPONENT)` to `core/script_mod.hpp`
- Cleaned unused commented setting from forestry
- Added howTo for MAAWS Mk4 Mod 1 Launcher
- Added MM checklist item for Coop resupply
- Server logging for reinforce menu marker toggle
- Hashmap access/iteration optimization
- Set text/marker channel to `side` if available