### PR TITLE
mapMarkers - Add Map Marker Control System

### DIFF
--- a/addons/mapMarkers/$PBOPREFIX$
+++ b/addons/mapMarkers/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\potato\addons\mapMarkers

--- a/addons/mapMarkers/CfgEventHandlers.hpp
+++ b/addons/mapMarkers/CfgEventHandlers.hpp
@@ -1,0 +1,10 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+    };
+};

--- a/addons/mapMarkers/CfgEventHandlers.hpp
+++ b/addons/mapMarkers/CfgEventHandlers.hpp
@@ -1,3 +1,8 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
+    };
+};
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));

--- a/addons/mapMarkers/CfgVehicles.hpp
+++ b/addons/mapMarkers/CfgVehicles.hpp
@@ -1,0 +1,57 @@
+class CfgVehicles {
+    class Logic;
+    class Module_F: Logic {
+        class AttributesBase {
+            class Checkbox;
+            class Edit;
+        };
+    };
+    class GVAR(mapMarkers): Module_F {
+        author = QUOTE(PREFIX);
+        category = QEGVAR(core,util);
+        scope = 2;
+        displayName = "Modify Marker Sharing";
+        icon = "iconModule";
+        isGlobal = 2;
+        isTriggerActivated = 0;
+        function = QFUNC(module_shareMarkerInit);
+        class Attributes: AttributesBase {
+            class disableNetwork: Checkbox {
+                displayName = "Disable side markers";
+                defaultValue = "true";
+                property = QGVAR(disableNetwork);
+                tooltip = "Disable putting markers into global/side/vehicle channels.";
+            };
+            class enableShare: Checkbox {
+                displayName = "Enable Sharing";
+                defaultValue = "true";
+                property = QGVAR(enableShare);
+                tooltip = "Enable ACE actions to share map markers to those around them and specific players.";
+            };
+            class enableCopyFrom: Checkbox {
+                displayName = "Enable Copying";
+                defaultValue = "true";
+                property = QGVAR(enableCopyFrom);
+                tooltip = "Enable ACE action to share copy map markers from a specific unit.";
+            };
+            class enableCopyFromEnemy: Checkbox {
+                displayName = "Enable Cross Side Copying";
+                defaultValue = "false";
+                property = QGVAR(enableCopyFromEnemy);
+                tooltip = "Enable sharing between different sides (e.g., BluFor to OpFor).";
+            };
+            /*class enableCopyFromCorpse: Checkbox {
+                displayName = "[EXP] Enable Copying from Corpses";
+                defaultValue = "false";
+                tooltip = "[EXPERIMENTAL] Enable copying infor off of corpses.";
+            };*/
+            class shareRadius: Edit {
+                displayName = "Share Radius (m)";
+                defaultValue = "5";
+                property = QGVAR(shareRadius);
+                tooltip = "The radius in meters markers can be shared in. Max 15m.";
+                validate = "number";
+            };
+        };
+    };
+};

--- a/addons/mapMarkers/README.md
+++ b/addons/mapMarkers/README.md
@@ -1,0 +1,5 @@
+# Map Markers (mapMarkers)
+
+An addon that changes how player placed markers onto the map work.
+## Current Items
+- Marker sharing through ACE interact when enabled, limited marker sharing to side chat.

--- a/addons/mapMarkers/XEH_PREP.hpp
+++ b/addons/mapMarkers/XEH_PREP.hpp
@@ -1,0 +1,4 @@
+PREP(collectMarkers);
+PREP(module_shareMarkerInit);
+PREP(recieveMarks);
+PREP(sendMarks);

--- a/addons/mapMarkers/XEH_postInit.sqf
+++ b/addons/mapMarkers/XEH_postInit.sqf
@@ -1,0 +1,2 @@
+#include "script_component.hpp"
+if (!hasInterface) exitWith {};

--- a/addons/mapMarkers/XEH_preInit.sqf
+++ b/addons/mapMarkers/XEH_preInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+ADDON = true;

--- a/addons/mapMarkers/XEH_preStart.sqf
+++ b/addons/mapMarkers/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/mapMarkers/config.cpp
+++ b/addons/mapMarkers/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {QGVAR(mapMarkers)};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"potato_core"};
+        author = "Potato";
+        authorUrl = "https://github.com/BourbonWarfare/POTATO";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/mapMarkers/functions/fnc_collectMarkers.sqf
+++ b/addons/mapMarkers/functions/fnc_collectMarkers.sqf
@@ -1,0 +1,36 @@
+/*
+ * Author: Lambda.Tiger
+ * This function will take all user defined map markers and return either a
+ * hashmap or json string of them. It mainly focuses on two types of markers,
+ * 1) Icon markers, and 2) polyline / drawn markers. Each hashmap entry is
+ * key'd by the marker name and stores an array containing three or seven
+ * elements depending on marker type. The first entry is whether the marker
+ * is a polyline (BOOL), if it is, the next two entries are color and an
+ * array of polyline points. If it isn't, the array consists of (in order):
+ * marker color, position, direction, size, type, and text.
+ *
+ * Arguments:
+ * 0: Whether the output should be converted to JSON (BOOL, default false)
+ *
+ * Return:
+ * Either a hashmap of all user markers OR the hashmap toJSON'd
+ *
+ * Public: No
+ */
+params [["_jsonOutput", false, [false]]];
+private _marks = allMapMarkers select {_x select [0,15]  == "_USER_DEFINED #"};
+private _hashmap = createHashMap;
+{
+	if (markerShape _x == "POLYLINE") then {
+		_hashmap set [_x,[true, getMarkerColor _x, markerPolyline _x]];
+
+	} else {
+		_hashmap set [_x,[false, getMarkerColor _x, getMarkerPos _x, markerDir _x, getMarkerSize _x, getMarkerType _x, markerText _x]];
+	};
+} forEach _marks;
+
+if (_jsonOutput) then {
+    toJSON _hashmap
+} else {
+    _hashmap
+}

--- a/addons/mapMarkers/functions/fnc_module_shareMarkerInit.sqf
+++ b/addons/mapMarkers/functions/fnc_module_shareMarkerInit.sqf
@@ -1,0 +1,79 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * This function is run by a module on init. It takes the configured
+ * radio parameters, adds relevant events and ACE actions, and configures
+ * local variables for marker sharing.
+ *
+ * Arguments:
+ * 0: The module being initialized
+ * 2: Whether the module is active
+ *
+ * Examples:
+ * Should be called by module init
+ *
+ * Public: No
+ */
+ TRACE_1("create diary entry from config",_this);
+params ["_logic", "", "_activated"];
+if (!_activated || !hasInterface) exitWith {
+    TRACE_3("leaving markerInit early",_logic,_activated,hasInterface);
+};
+
+private _disableNetwork = _logic getVariable [QUOTE(disableNetwork), true];
+private _enableShare = _logic getVariable [QUOTE(enableShare), true];
+private _enableCopyFrom = _logic getVariable [QUOTE(enableCopyFrom), true];
+private _enableCopyFromEnemy = _enableCopyFrom && (_logic getVariable [QUOTE(enableCopyFromEnemy), false]);
+//private _enableCopyFromCorpse = _enableCopyFrom && (_logic getVariable [QUOTE(enableCopyFromCorpse), false]);
+private _shareRadius = 15 min (_logic getVariable [QUOTE(shareRadius), 5]);
+
+[QGVAR(requestMarkers), {
+    [_this,  _thisArgs] call FUNC(sendMarks);
+    ["Somone copied your map markers.", true, 5] call ACEFUNC(common,displayText);
+}, _enableCopyFromEnemy] call CBA_fnc_addEventHandlerArgs;
+[QGVAR(recieveMarkers), {call FUNC(recieveMarks)}] call CBA_fnc_addEventHandler;
+
+if (_disableNetwork) then { // handle markers including spec reset of markers
+    GVAR(disableNetwork) = true;
+    [{!isNil QEGVAR(core,playerAuth)}, {
+        private _auth = [] call CFUNC(isAuthorized);
+        for "_i" from 0 to 4 do {
+            if !(_i == 3 || (_auth && _i == 0)) then {
+                _i enableChannel false;
+            };
+        };
+        setCurrentChannel 3;
+    }] call CBA_fnc_waitUntilAndExecute;
+};
+
+if (_enableShare) then {
+    //IGNORE_PRIVATE_WARNING["_target", "_player","_actionParams"];
+    private _action = [
+        QGVAR(shareMarks),
+        format ["Share Markers (%1m)", _shareRadius toFixed 0],
+        "\a3\ui_f\data\GUI\Rsc\RscDisplayArsenal\map_ca.paa", {
+        _actionParams params ["_shareRadius", "_shareAcrossSides"];
+        private _players = (getPosATL _player) nearEntities ["CAManBase", _shareRadius];
+        private _side = side _player;
+        _players = _players select {
+            isPlayer _x && {getNumber ((configOf _target) >> "isPlayableLogic") == 0}
+            && {_shareAcrossSides || side _x == _side}
+            && _x != _player};
+        if (_players isNotEqualTo []) then {
+            [format ["Sharing markers in a %1m radius.", _shareRadius], true, 5] call ACEFUNC(common,displayText);
+            [_players, _shareAcrossSides] call FUNC(sendMarks);
+        };
+    }, {true}, {}, [_shareRadius, _enableCopyFromEnemy]] call ACEFUNC(interact_menu,createAction);
+    ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action, true] call ACEFUNC(interact_menu,addActionToClass);
+};
+
+if (_enableCopyFrom) then { // handle copy from enemy (alive)
+    //IGNORE_PRIVATE_WARNING["_target", "_player","_actionParams"];
+    private _action = [
+        QGVAR(copyFromUnit), "Copy Map Markers",
+        "\a3\ui_f\data\GUI\Rsc\RscDisplayArsenal\map_ca.paa", {
+        [QGVAR(requestMarkers), [_player], _target] call CBA_fnc_targetEvent;
+    }, {side _target == side _player || _actionParams},
+    {}, _enableCopyFromEnemy] call ACEFUNC(interact_menu,createAction);
+    ["CAManBase", 0, ["ACE_MainActions"], _action, true] call ACEFUNC(interact_menu,addActionToClass);
+};

--- a/addons/mapMarkers/functions/fnc_module_shareMarkerInit.sqf
+++ b/addons/mapMarkers/functions/fnc_module_shareMarkerInit.sqf
@@ -63,7 +63,7 @@ if (_enableShare) then {
             [format ["Sharing markers in a %1m radius.", _shareRadius], true, 5] call ACEFUNC(common,displayText);
             [_players, _shareAcrossSides] call FUNC(sendMarks);
         };
-    }, {true}, {}, [_shareRadius, _enableCopyFromEnemy]] call ACEFUNC(interact_menu,createAction);
+    }, {_player getSlotItemName 608 != ""}, {}, [_shareRadius, _enableCopyFromEnemy]] call ACEFUNC(interact_menu,createAction);
     ["CAManBase", 1, ["ACE_SelfActions", "ACE_Equipment"], _action, true] call ACEFUNC(interact_menu,addActionToClass);
 };
 
@@ -73,7 +73,7 @@ if (_enableCopyFrom) then { // handle copy from enemy (alive)
         QGVAR(copyFromUnit), "Copy Map Markers",
         "\a3\ui_f\data\GUI\Rsc\RscDisplayArsenal\map_ca.paa", {
         [QGVAR(requestMarkers), [_player], _target] call CBA_fnc_targetEvent;
-    }, {side _target == side _player || _actionParams},
+    }, {isPlayer _target && alive _target && {side _target == side _player || _actionParams}},
     {}, _enableCopyFromEnemy] call ACEFUNC(interact_menu,createAction);
     ["CAManBase", 0, ["ACE_MainActions"], _action, true] call ACEFUNC(interact_menu,addActionToClass);
 };

--- a/addons/mapMarkers/functions/fnc_module_shareMarkerInit.sqf
+++ b/addons/mapMarkers/functions/fnc_module_shareMarkerInit.sqf
@@ -19,7 +19,10 @@ params ["_logic", "", "_activated"];
 if (!_activated || !hasInterface) exitWith {
     TRACE_3("leaving markerInit early",_logic,_activated,hasInterface);
 };
-
+if !(isNil QGVAR(disableNetwork)) exitWith {
+    ERROR_MSG_1("[%1] Attempt to initialize group teleport, only one module per mission",_logic);
+};
+GVAR(disableNetwork) = false;
 private _disableNetwork = _logic getVariable [QUOTE(disableNetwork), true];
 private _enableShare = _logic getVariable [QUOTE(enableShare), true];
 private _enableCopyFrom = _logic getVariable [QUOTE(enableCopyFrom), true];

--- a/addons/mapMarkers/functions/fnc_recieveMarks.sqf
+++ b/addons/mapMarkers/functions/fnc_recieveMarks.sqf
@@ -1,0 +1,40 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * This function is run by a module on init. It takes the configured
+ * radio parameters, adds relevant events and ACE actions, and configures
+ * local variables for marker sharing
+ *
+ * Arguments:
+ * 0: The module being initialized
+ * 2: Whether the module is active
+ *
+ * Examples:
+ * Should be called by module init
+ *
+ * Public: No
+ */
+params [["_jsonMarkers", "{}"]];
+private _markers = fromJSON _jsonMarkers;
+
+if (isNil {_markers} || {_markers isEqualTo createHashMap}) exitWith {
+    TRACE_1("Bad JSON sent",_jsonMarkers);
+};
+["Markers copied to map.", true, 5] call ACEFUNC(common,displayText);
+{
+    if (_y#0) then {
+        _y params ["", "_color", "_pts"];
+        private _marker = createMarkerLocal [_x, [_pts#0, _pts#1, 0]];
+        _x setMarkerShapeLocal "POLYLINE";
+        _x setMarkerColorLocal _color;
+        _x setMarkerPolylineLocal _pts;
+    } else {
+        _y params ["", "_color", "_pos", "_dir", "_size", "_type", "_text"];
+        private _marker = createMarkerLocal [_x, _pos];
+        _x setMarkerColorLocal _color;
+        _x setMarkerDirLocal _dir;
+        _x setMarkerSizeLocal _size;
+        _x setMarkerTypeLocal _type;
+        _x setMarkerTextLocal _text;
+    };
+} forEach _markers;

--- a/addons/mapMarkers/functions/fnc_recieveMarks.sqf
+++ b/addons/mapMarkers/functions/fnc_recieveMarks.sqf
@@ -20,6 +20,10 @@ private _markers = fromJSON _jsonMarkers;
 if (isNil {_markers} || {_markers isEqualTo createHashMap}) exitWith {
     TRACE_1("Bad JSON sent",_jsonMarkers);
 };
+if (ace_player getSlotItemName 608 == "") exitWith {
+    ["You tried to copy someone's markers but you don't have a map.", true, 5] call ACEFUNC(common,displayText);
+};
+
 ["Markers copied to map.", true, 5] call ACEFUNC(common,displayText);
 {
     if (_y#0) then {

--- a/addons/mapMarkers/functions/fnc_recieveMarks.sqf
+++ b/addons/mapMarkers/functions/fnc_recieveMarks.sqf
@@ -1,13 +1,11 @@
 #include "..\script_component.hpp"
 /*
  * Author: Lambda.Tiger
- * This function is run by a module on init. It takes the configured
- * radio parameters, adds relevant events and ACE actions, and configures
- * local variables for marker sharing
+ * This function takes in a JSON'd hashmap, converts it to a hashmap and
+ * then uses it to create a number of local markers.
  *
  * Arguments:
- * 0: The module being initialized
- * 2: Whether the module is active
+ * _jsonMarkers - A jsonified hashmap of markers ("STRING", default "{}")
  *
  * Examples:
  * Should be called by module init

--- a/addons/mapMarkers/functions/fnc_sendMarks.sqf
+++ b/addons/mapMarkers/functions/fnc_sendMarks.sqf
@@ -1,13 +1,15 @@
 #include "..\script_component.hpp"
 /*
  * Author: Lambda.Tiger
- * This function is run by a module on init. It takes the configured
- * radio parameters, adds relevant events and ACE actions, and configures
- * local variables for marker sharing
+ * This function handles sending markers to a request array of players.
+ * It takes an array of players and a boolean of whether to share across sides.
+ * It then filters by side from ace_player side if the boolean is true, and
+ * then collects map markers and sends a target event if there are markers to
+ * send.
  *
  * Arguments:
- * 0: The module being initialized
- * 2: Whether the module is active
+ * _targets - An array of units that markers should be shared with (ARRAY, default [])
+ * _allowOtherSides - Allow copying maps between different sides (BOOL, default false)
  *
  * Return:
  * None

--- a/addons/mapMarkers/functions/fnc_sendMarks.sqf
+++ b/addons/mapMarkers/functions/fnc_sendMarks.sqf
@@ -19,4 +19,7 @@ if !(_allowOtherSides) then {
     private _side = side ace_player;
     _targets = _targets select {side _x == _side};
 };
-[QGVAR(recieveMarkers), [true] call FUNC(collectMarkers), _targets] call CBA_fnc_targetEvent;
+private _marks = [true] call FUNC(collectMarkers);
+if (_marks != "{}") then {
+    [QGVAR(recieveMarkers), _marks, _targets] call CBA_fnc_targetEvent;
+};

--- a/addons/mapMarkers/functions/fnc_sendMarks.sqf
+++ b/addons/mapMarkers/functions/fnc_sendMarks.sqf
@@ -1,0 +1,22 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Lambda.Tiger
+ * This function is run by a module on init. It takes the configured
+ * radio parameters, adds relevant events and ACE actions, and configures
+ * local variables for marker sharing
+ *
+ * Arguments:
+ * 0: The module being initialized
+ * 2: Whether the module is active
+ *
+ * Return:
+ * None
+ *
+ * Public: No
+ */
+params [["_targets", []], ["_allowOtherSides", false, [false]]];
+if !(_allowOtherSides) then {
+    private _side = side ace_player;
+    _targets = _targets select {side _x == _side};
+};
+[QGVAR(recieveMarkers), [true] call FUNC(collectMarkers), _targets] call CBA_fnc_targetEvent;

--- a/addons/mapMarkers/script_component.hpp
+++ b/addons/mapMarkers/script_component.hpp
@@ -1,0 +1,8 @@
+#define COMPONENT mapMarkers
+#include "\z\potato\addons\core\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#include "\z\potato\addons\core\script_macros.hpp"

--- a/addons/spectate/functions/fnc_setChannels.sqf
+++ b/addons/spectate/functions/fnc_setChannels.sqf
@@ -17,8 +17,17 @@ TRACE_1("Params",_this);
 
 params [["_set", false, [false]]];
 
+private _disableMarkers = if (isNil QEGVAR(mapMarkers,disableNetwork)) then {
+    false
+} else {
+    EGVAR(mapMarkers,disableNetwork)
+};
 {
-    _x enableChannel _set;
+    if (_disableMarkers) then {
+        _x enableChannel [_set, false, false, false];
+    } else {
+        _x enableChannel [_set, false];
+    };
 } forEach ([
     [GLOBAL_CHANNEL_INDEX, SIDE_CHANNEL_INDEX, COMMAND_CHANNEL_INDEX, VEHICLE_CHANNEL_INDEX, DIRECT_CHANNEL_INDEX],
     [SIDE_CHANNEL_INDEX, COMMAND_CHANNEL_INDEX, VEHICLE_CHANNEL_INDEX, DIRECT_CHANNEL_INDEX]


### PR DESCRIPTION
This PR adds a module and system to restrict map markers to within a group. In addition, the module allows control to
- Disable map marker sharing (disable markers on non-group channels, except for authorized users)
- Enable/Disable sharing markers
- Enable/Disable copying markers from other people
- Enable/Disable copy from enemy
- The sharing radius

Future Plans include
- Allowing/tracking markers for taking off of dead bodies
- Zeus tools
- Live shared markers for briefing.