### PR TITLE
spectate - Fix Improper Command Usage

### DIFF
--- a/addons/spectate/functions/fnc_setChannels.sqf
+++ b/addons/spectate/functions/fnc_setChannels.sqf
@@ -1,5 +1,5 @@
 /*
- * Author: AACO
+ * Author: AACO, Lambda.Tiger
  * Function used to set chat channels, allows global for admins (group cannot be turned off)
  *
  * Arguments:
@@ -33,6 +33,6 @@ private _disableMarkers = if (isNil QEGVAR(mapMarkers,disableNetwork)) then {
     [SIDE_CHANNEL_INDEX, COMMAND_CHANNEL_INDEX, VEHICLE_CHANNEL_INDEX, DIRECT_CHANNEL_INDEX]
 ] select (call CFUNC(isAuthorized)));
 
-if (channelEnabled SIDE_CHANNEL_INDEX) then {
+if ((channelEnabled SIDE_CHANNEL_INDEX)#2) then {
     setCurrentChannel SIDE_CHANNEL_INDEX;
 };

--- a/addons/spectate/functions/fnc_setChannels.sqf
+++ b/addons/spectate/functions/fnc_setChannels.sqf
@@ -26,7 +26,7 @@ private _disableMarkers = if (isNil QEGVAR(mapMarkers,disableNetwork)) then {
     if (_disableMarkers) then {
         _x enableChannel [_set, false, false, false];
     } else {
-        _x enableChannel [_set, false];
+        _x enableChannel _set;
     };
 } forEach ([
     [GLOBAL_CHANNEL_INDEX, SIDE_CHANNEL_INDEX, COMMAND_CHANNEL_INDEX, VEHICLE_CHANNEL_INDEX, DIRECT_CHANNEL_INDEX],


### PR DESCRIPTION
This PR fixes improper usage of `channelEnabled` in `fnc_setChannels` that breaks spectate.